### PR TITLE
add toolchain macros to enable cross compiler compatibility 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/.vscode
+/batch
+/src/Listings
+/src/dm5680_fw_tx.uvgui.*
+/src/*.BAT

--- a/src/common.h
+++ b/src/common.h
@@ -1,7 +1,10 @@
 #ifndef _COMMON_H_
 #define _COMMON_H_
+
 #include <stdint.h>
 #include <string.h>
+
+#include "toolchain.h"
 #include "sfr_def.h"
 #include "sfr_ext.h"
 
@@ -13,16 +16,6 @@
 //#define VTX_R
 
 // system
-#define KEILC
-#define C51_XDAT xdata
-#define C51_IDAT idata
-#define C51_CODE code
-#define C51_ROM  code
-#define C51_BIT  bit
-#define CODE_P
-#define PDATA_P
-#define IDATA_P
-#define DATA_P
 #define assert(c)
 #define dbg_pt(a)   DBG_PIN0 = a
 

--- a/src/hardware.c
+++ b/src/hardware.c
@@ -199,7 +199,7 @@ void CFG_Back()
 
 void GetVtxParameter()
 {
-    unsigned char code *ptr = 0xFFE8;
+    unsigned char CODE_SEG *ptr = 0xFFE8;
     uint8_t i, j;
     uint8_t tab[FREQ_MAX+1][POWER_MAX+1];
     uint8_t flash_vld = 1;

--- a/src/isr.c
+++ b/src/isr.c
@@ -14,7 +14,7 @@ uint8_t temp_tflg = 0;
 uint8_t timer_4hz = 0;
 uint8_t timer_8hz = 0;
 uint8_t timer_16hz = 0;
-uint16_t idata timer_ms10x = 0;
+IDATA_SEG uint16_t timer_ms10x = 0;
 uint16_t seconds = 0;
 uint8_t RS0_ERR = 0;
 

--- a/src/isr.c
+++ b/src/isr.c
@@ -4,8 +4,8 @@
 #include "isr.h"
 #include "uart.h"
 
-bit int0_req = 0;
-bit int1_req = 0;
+BIT_TYPE int0_req = 0;
+BIT_TYPE int1_req = 0;
 uint8_t btn1_tflg = 0;
 uint8_t pwr_sflg = 0;    //power autoswitch flag
 uint8_t pwr_tflg = 0;

--- a/src/isr.c
+++ b/src/isr.c
@@ -66,7 +66,7 @@ void CPU_init(void)
     
 }
 
-void Timer0_isr(void) interrupt 1
+void Timer0_isr(void) INTERRUPT(1)
 {
     TH0 = 138;
 
@@ -84,22 +84,22 @@ void Timer0_isr(void) interrupt 1
     timer_ms10x++;
 }
 
-void Timer1_isr(void) interrupt 3 
+void Timer1_isr(void) INTERRUPT(3)
 {
 }		 
 
 
-void Ext0_isr(void) interrupt 0
+void Ext0_isr(void) INTERRUPT(0)
 {
 	int0_req = 1;
 }
 
-void Ext1_isr(void) interrupt 2
+void Ext1_isr(void) INTERRUPT(2)
 {
 	int1_req = 1;
 }
 
-void UART0_isr() interrupt 4
+void UART0_isr() INTERRUPT(4)
 {
 	if( RI ) {			//RX int
 		RI = 0;
@@ -114,7 +114,7 @@ void UART0_isr() interrupt 4
 	}
 }
 
-void UART1_isr() interrupt 6
+void UART1_isr() INTERRUPT(6)
 {
     
 	if( RI1 ) {			//RX int

--- a/src/isr.h
+++ b/src/isr.h
@@ -7,7 +7,7 @@ extern uint8_t pwr_tflg;
 extern uint8_t cfg_tflg;
 extern uint8_t temp_tflg;
 extern uint16_t  seconds;
-extern uint16_t idata timer_ms10x;
+extern IDATA_SEG uint16_t timer_ms10x;
 extern uint8_t timer_4hz;
 extern uint8_t timer_8hz;
 extern uint8_t timer_16hz;

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -21,8 +21,8 @@ XDATA_SEG uint8_t 			argc  = 0;		// command line cnt
 XDATA_SEG uint8_t 			last_argc = 0;
 
 XDATA_SEG uint8_t 			comment=0;
-bit			    echo  = 1;
-bit                verbose = 1;
+BIT_TYPE			    echo  = 1;
+BIT_TYPE                verbose = 1;
 
 
 #ifdef _DEBUG_MODE

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -14,15 +14,15 @@
 ///////////////////////////////////////////////
 // Global variables for this module only.
 // DO NOT TRY to use it outside the scope
-C51_XDAT uint8_t 			incnt = 0;		// in char count
-C51_XDAT uint8_t 			monstr[MAX_CMD_LEN];		// buffer for input string
-C51_XDAT uint8_t C51_XDAT   *argv[7];		// command line arguments
-C51_XDAT uint8_t 			argc  = 0;		// command line cnt
-C51_XDAT uint8_t 			last_argc = 0;
+XDATA_SEG uint8_t 			incnt = 0;		// in char count
+XDATA_SEG uint8_t 			monstr[MAX_CMD_LEN];		// buffer for input string
+XDATA_SEG uint8_t    *argv[7];		// command line arguments
+XDATA_SEG uint8_t 			argc  = 0;		// command line cnt
+XDATA_SEG uint8_t 			last_argc = 0;
 
-C51_XDAT uint8_t 			comment=0;
-		 bit			    echo  = 1;
-         bit                verbose = 1;
+XDATA_SEG uint8_t 			comment=0;
+bit			    echo  = 1;
+bit                verbose = 1;
 
 
 #ifdef _DEBUG_MODE

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -11,5 +11,5 @@ void MonWrite(uint8_t mode);
 void MonRead(uint8_t mode);
 void chg_vtx(void);
 extern XDATA_SEG uint8_t   *argv[7];	
-extern bit verbose;
+extern BIT_TYPE verbose;
 #endif //_MONITOR_H_

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -10,6 +10,6 @@ void Monitor(void);
 void MonWrite(uint8_t mode);
 void MonRead(uint8_t mode);
 void chg_vtx(void);
-extern C51_XDAT uint8_t C51_XDAT   *argv[7];	
+extern XDATA_SEG uint8_t   *argv[7];	
 extern bit verbose;
 #endif //_MONITOR_H_

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -38,8 +38,8 @@ uint8_t dptxbuf[256];
 uint8_t dptx_rptr,dptx_wptr;
 
 uint8_t fc_lock = 0;
-//bit[0] msp_displayport
-//bit[1] VTX_serial
+//BIT_TYPE[0] msp_displayport
+//BIT_TYPE[1] VTX_serial
 uint8_t disp_mode;  //DISPLAY_OSD | DISPLAY_CMS;
 uint8_t osd_ready;
 

--- a/src/print.c
+++ b/src/print.c
@@ -11,8 +11,8 @@ void DoPrint(const char *fmt, va_list ap )
 	char  ch;
 	char  i;
 	long  value;
-	bit   fl_zero;
-	bit   fl_num;
+	BIT_TYPE   fl_zero;
+	BIT_TYPE   fl_num;
 	uint8_t  fl_len;
 	uint8_t  cnt;
   char *ptr;

--- a/src/print.c
+++ b/src/print.c
@@ -6,7 +6,7 @@ uint16_t global_cnt;
 uint16_t global_value;
 
 #ifdef _DEBUG_MODE
-void DoPrint( const char CODE_P *fmt, va_list ap )
+void DoPrint(const char *fmt, va_list ap )
 {
 	char  ch;
 	char  i;
@@ -154,7 +154,7 @@ void DoPrint( const char CODE_P *fmt, va_list ap )
 #endif
 
 
-void Printf( const char CODE_P *fmt, ... )
+void Printf(const char *fmt, ... )
 {
 #ifdef _DEBUG_MODE
 	va_list ap;

--- a/src/print.h
+++ b/src/print.h
@@ -3,8 +3,8 @@
 
 #include <stdarg.h>
 
-//void DoPrint( const char CODE_P *fmt, va_list ap );
-void Printf( const char CODE_P *fmt, ... );
+//void DoPrint(const char *fmt, va_list ap );
+void Printf(const char *fmt, ...);
 
 //void Puts( char *ptr );
 

--- a/src/sfr_def.h
+++ b/src/sfr_def.h
@@ -70,99 +70,99 @@ SFR_DEF(EIP,       0xF8);
 // Bit define
 
 /*  P0  */
-sbit P0_7     = P0^7;
-sbit P0_6     = P0^6;
-sbit P0_5     = P0^5;
-sbit P0_4     = P0^4;
-sbit P0_3     = P0^3;
-sbit P0_2     = P0^2;
-sbit P0_1     = P0^1;
-sbit P0_0     = P0^0;
+SBIT_DEF(P0_7,     P0^7);
+SBIT_DEF(P0_6,     P0^6);
+SBIT_DEF(P0_5,     P0^5);
+SBIT_DEF(P0_4,     P0^4);
+SBIT_DEF(P0_3,     P0^3);
+SBIT_DEF(P0_2,     P0^2);
+SBIT_DEF(P0_1,     P0^1);
+SBIT_DEF(P0_0,     P0^0);
 
 /*  P1  */
-sbit P1_7     = P1^7;
-sbit P1_6     = P1^6;
-sbit P1_5     = P1^5;
-sbit P1_4     = P1^4;
-sbit P1_3     = P1^3;
-sbit P1_2     = P1^2;
-sbit P1_1     = P1^1;
-sbit P1_0     = P1^0;
+SBIT_DEF(P1_7,     P1^7);
+SBIT_DEF(P1_6,     P1^6);
+SBIT_DEF(P1_5,     P1^5);
+SBIT_DEF(P1_4,     P1^4);
+SBIT_DEF(P1_3,     P1^3);
+SBIT_DEF(P1_2,     P1^2);
+SBIT_DEF(P1_1,     P1^1);
+SBIT_DEF(P1_0,     P1^0);
 
 /*  P2  */
-sbit P2_7     = P2^7;
-sbit P2_6     = P2^6;
-sbit P2_5     = P2^5;
-sbit P2_4     = P2^4;
-sbit P2_3     = P2^3;
-sbit P2_2     = P2^2;
-sbit P2_1     = P2^1;
-sbit P2_0     = P2^0;
+SBIT_DEF(P2_7,     P2^7);
+SBIT_DEF(P2_6,     P2^6);
+SBIT_DEF(P2_5,     P2^5);
+SBIT_DEF(P2_4,     P2^4);
+SBIT_DEF(P2_3,     P2^3);
+SBIT_DEF(P2_2,     P2^2);
+SBIT_DEF(P2_1,     P2^1);
+SBIT_DEF(P2_0,     P2^0);
 
 /*  P3  */
-sbit P3_7     = P3^7;
-sbit P3_6     = P3^6;
-sbit P3_5     = P3^5;
-sbit P3_4     = P3^4;
-sbit P3_3     = P3^3;
-sbit P3_2     = P3^2;
-sbit P3_1     = P3^1;
-sbit P3_0     = P3^0;
+SBIT_DEF(P3_7,     P3^7);
+SBIT_DEF(P3_6,     P3^6);
+SBIT_DEF(P3_5,     P3^5);
+SBIT_DEF(P3_4,     P3^4);
+SBIT_DEF(P3_3,     P3^3);
+SBIT_DEF(P3_2,     P3^2);
+SBIT_DEF(P3_1,     P3^1);
+SBIT_DEF(P3_0,     P3^0);
 
 /*  TCON  */
-sbit TF1      = TCON^7;
-sbit TR1      = TCON^6;
-sbit TF0      = TCON^5;
-sbit TR0      = TCON^4;
-sbit IE1      = TCON^3;
-sbit IT1      = TCON^2;
-sbit IE0      = TCON^1;
-sbit IT0      = TCON^0;
+SBIT_DEF(TF1,      TCON^7);
+SBIT_DEF(TR1,      TCON^6);
+SBIT_DEF(TF0,      TCON^5);
+SBIT_DEF(TR0,      TCON^4);
+SBIT_DEF(IE1,      TCON^3);
+SBIT_DEF(IT1,      TCON^2);
+SBIT_DEF(IE0,      TCON^1);
+SBIT_DEF(IT0,      TCON^0);
 
 /*  IE  */
-sbit EA       = IE^7;
-sbit ES1      = IE^6;
-sbit ET2      = IE^5;
-sbit ES0      = IE^4;
-sbit ET1      = IE^3;
-sbit EX1      = IE^2;
-sbit ET0      = IE^1;
-sbit EX0      = IE^0;
+SBIT_DEF(EA,       IE^7);
+SBIT_DEF(ES1,      IE^6);
+SBIT_DEF(ET2,      IE^5);
+SBIT_DEF(ES0,      IE^4);
+SBIT_DEF(ET1,      IE^3);
+SBIT_DEF(EX1,      IE^2);
+SBIT_DEF(ET0,      IE^1);
+SBIT_DEF(EX0,      IE^0);
 
 /*  IP  */
-sbit PS1      = IP^6;
-sbit PT2      = IP^5;
-sbit PS0      = IP^4;
-sbit PT1      = IP^3;
-sbit PX1      = IP^2;
-sbit PT0      = IP^1;
-sbit PX0      = IP^0;
+SBIT_DEF(PS1,      IP^6);
+SBIT_DEF(PT2,      IP^5);
+SBIT_DEF(PS0,      IP^4);
+SBIT_DEF(PT1,      IP^3);
+SBIT_DEF(PX1,      IP^2);
+SBIT_DEF(PT0,      IP^1);
+SBIT_DEF(PX0,      IP^0);
 
 /*  SCON0  */
-sbit SM0      = SCON0^7;
-sbit SM1      = SCON0^6;
-sbit SM2      = SCON0^5;
-sbit REN      = SCON0^4;
-sbit TB8      = SCON0^3;
-sbit RB8      = SCON0^2;
-sbit TI       = SCON0^1;
-sbit RI       = SCON0^0;
+SBIT_DEF(SM0,      SCON0^7);
+SBIT_DEF(SM1,      SCON0^6);
+SBIT_DEF(SM2,      SCON0^5);
+SBIT_DEF(REN,      SCON0^4);
+SBIT_DEF(TB8,      SCON0^3);
+SBIT_DEF(RB8,      SCON0^2);
+SBIT_DEF(TI,       SCON0^1);
+SBIT_DEF(RI,       SCON0^0);
 
 /*  SCON1  */
-sbit SM10     = SCON1^7;
-sbit SM11     = SCON1^6;
-sbit SM12     = SCON1^5;
-sbit REN1     = SCON1^4;
-sbit TB18     = SCON1^3;
-sbit RB18     = SCON1^2;
-sbit TI1      = SCON1^1;
-sbit RI1      = SCON1^0;
+SBIT_DEF(SM10,     SCON1^7);
+SBIT_DEF(SM11,     SCON1^6);
+SBIT_DEF(SM12,     SCON1^5);
+SBIT_DEF(REN1,     SCON1^4);
+SBIT_DEF(TB18,     SCON1^3);
+SBIT_DEF(RB18,     SCON1^2);
+SBIT_DEF(TI1,      SCON1^1);
+SBIT_DEF(RI1,      SCON1^0);
 
 /*  EIF  */
-//sbit INT6F    = EIF^4;
-//sbit INT5F    = EIF^3;
-//sbit INT4F    = EIF^2;
-//sbit INT3F    = EIF^1;
-//sbit INT2F    = EIF^0;
+//SBIT_DEF(INT6F,    EIF^4);
+//SBIT_DEF(INT5F,    EIF^3);
+//SBIT_DEF(INT4F,    EIF^2);
+//SBIT_DEF(INT3F,    EIF^1);
+//SBIT_DEF(INT2F,    EIF^0);
 
 #endif

--- a/src/sfr_def.h
+++ b/src/sfr_def.h
@@ -1,68 +1,70 @@
 #ifndef __SFR_DEF_H_
 #define __SFR_DEF_H_
 
+#include "toolchain.h"
+
 ////////////////////////////////////////////////////////////////////////////////
 // SFR
 
-sfr P0        = 0x80;   /* Port 0                    */
-sfr SP        = 0x81;   /* Stack Pointer             */
-sfr DPL0      = 0x82;   /* Data Pointer 0 Low byte   */
-sfr DPH0      = 0x83;   /* Data Pointer 0 High byte  */
-sfr DPL1      = 0x84;   /* Data Pointer 1 Low byte   */
-sfr DPH1      = 0x85;   /* Data Pointer 1 High byte  */
-sfr DPS       = 0x86;
-sfr PCON      = 0x87;   /* Power Configuration       */
+SFR_DEF(P0,        0x80);   /* Port 0                    */
+SFR_DEF(SP,        0x81);   /* Stack Pointer             */
+SFR_DEF(DPL0,      0x82);   /* Data Pointer 0 Low byte   */
+SFR_DEF(DPH0,      0x83);   /* Data Pointer 0 High byte  */
+SFR_DEF(DPL1,      0x84);   /* Data Pointer 1 Low byte   */
+SFR_DEF(DPH1,      0x85);   /* Data Pointer 1 High byte  */
+SFR_DEF(DPS,       0x86);
+SFR_DEF(PCON,      0x87);   /* Power Configuration       */
 
-sfr TCON      = 0x88;   /* Timer 0,1 Configuration   */
-sfr TMOD      = 0x89;   /* Timer 0,1 Mode            */
-sfr TL0       = 0x8A;   /* Timer 0 Low byte counter  */
-sfr TL1       = 0x8B;   /* Timer 1 Low byte counter  */
-sfr TH0       = 0x8C;   /* Timer 0 High byte counter */
-sfr TH1       = 0x8D;   /* Timer 1 High byte counter */
-sfr CKCON     = 0x8E;   /* XDATA Wait States         */
+SFR_DEF(TCON,      0x88);   /* Timer 0,1 Configuration   */
+SFR_DEF(TMOD,      0x89);   /* Timer 0,1 Mode            */
+SFR_DEF(TL0,       0x8A);   /* Timer 0 Low byte counter  */
+SFR_DEF(TL1,       0x8B);   /* Timer 1 Low byte counter  */
+SFR_DEF(TH0,       0x8C);   /* Timer 0 High byte counter */
+SFR_DEF(TH1,       0x8D);   /* Timer 1 High byte counter */
+SFR_DEF(CKCON,     0x8E);   /* XDATA Wait States         */
 
-sfr P1        = 0x90;   /* Port 1                    */
-sfr EIF       = 0x91;
-sfr WTST      = 0x92;   /* Program Wait States       */
-sfr DPX0      = 0x93;   /* Data Page Pointer 0       */
-sfr DPX1      = 0x95;   /* Data Page Pointer 1       */
+SFR_DEF(P1,        0x90);   /* Port 1                    */
+SFR_DEF(EIF,       0x91);
+SFR_DEF(WTST,      0x92);   /* Program Wait States       */
+SFR_DEF(DPX0,      0x93);   /* Data Page Pointer 0       */
+SFR_DEF(DPX1,      0x95);   /* Data Page Pointer 1       */
 
-sfr SCON0     = 0x98;   /* Serial 0 Configuration    */
-sfr SBUF0     = 0x99;   /* Serial 0 I/O Buffer       */
+SFR_DEF(SCON0,     0x98);   /* Serial 0 Configuration    */
+SFR_DEF(SBUF0,     0x99);   /* Serial 0 I/O Buffer       */
 
-sfr P2        = 0xA0;   /* Port 2                    */
+SFR_DEF(P2,        0xA0);   /* Port 2                    */
 
-sfr IE        = 0xA8;   /* Interrupt Enable          */
+SFR_DEF(IE,        0xA8);   /* Interrupt Enable          */
 
-sfr P3        = 0xB0;   /* Port 3                    */
+SFR_DEF(P3,        0xB0);   /* Port 3                    */
 
-sfr IP        = 0xB8;
+SFR_DEF(IP,        0xB8);
 
-sfr SCON1     = 0xC0;   /* Serial 1 Configuration    */
-sfr SBUF1     = 0xC1;   /* Serial 1 I/O Buffer       */
+SFR_DEF(SCON1,     0xC0);   /* Serial 1 Configuration    */
+SFR_DEF(SBUF1,     0xC1);   /* Serial 1 I/O Buffer       */
 
-sfr T2CON     = 0xC8;
-sfr T2IF      = 0xC9;
-sfr RLDL      = 0xCA;
-sfr RLDH      = 0xCB;
-sfr TL2       = 0xCC;
-sfr TH2       = 0xCD;
-sfr CCEN      = 0xCE;
+SFR_DEF(T2CON,     0xC8);
+SFR_DEF(T2IF,      0xC9);
+SFR_DEF(RLDL,      0xCA);
+SFR_DEF(RLDH,      0xCB);
+SFR_DEF(TL2,       0xCC);
+SFR_DEF(TH2,       0xCD);
+SFR_DEF(CCEN,      0xCE);
 
-sfr PSW       = 0xD0;   /* Program Status Word       */
+SFR_DEF(PSW,       0xD0);   /* Program Status Word       */
 
-sfr WDCON     = 0xD8;
+SFR_DEF(WDCON,     0xD8);
 
-sfr ACC       = 0xE0;   /* Accumulator               */
+SFR_DEF(ACC,       0xE0);   /* Accumulator               */
 
-sfr EIE       = 0xE8;   /* External Interrupt Enable */
-sfr STATUS    = 0xE9;   /* Status register           */
-sfr MXAX      = 0xEA;   /* MOVX @Ri High address     */
-sfr TA        = 0xEB;
+SFR_DEF(EIE,       0xE8);   /* External Interrupt Enable */
+SFR_DEF(STATUS,    0xE9);   /* Status register           */
+SFR_DEF(MXAX,      0xEA);   /* MOVX @Ri High address     */
+SFR_DEF(TA,        0xEB);
 
-sfr B         = 0xF0;   /* B Working register        */
+SFR_DEF(B,         0xF0);   /* B Working register        */
 
-sfr EIP       = 0xF8;
+SFR_DEF(EIP,       0xF8);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Bit define

--- a/src/sfr_ext.h
+++ b/src/sfr_ext.h
@@ -1,12 +1,14 @@
 #ifndef __SFR_EXT_H_
 #define __SFR_EXT_H_
 
-sfr SFR_CMD     = 0xB9;
-sfr SFR_DATA    = 0xBA;
-sfr SFR_ADDRL   = 0xBB;
-sfr SFR_ADDRH   = 0xBC;
-sfr SFR_BUSY    = 0xBD;
-sfr DBG_PIN0    = 0xFB;
+#include "toolchain.h"
+
+SFR_DEF(SFR_CMD,     0xB9);
+SFR_DEF(SFR_DATA,    0xBA);
+SFR_DEF(SFR_ADDRL,   0xBB);
+SFR_DEF(SFR_ADDRH,   0xBC);
+SFR_DEF(SFR_BUSY,    0xBD);
+SFR_DEF(DBG_PIN0,    0xFB);
 
 void WriteReg(uint8_t page, uint8_t addr, uint8_t dat);
 uint8_t ReadReg(uint8_t page, uint8_t addr);

--- a/src/toolchain.h
+++ b/src/toolchain.h
@@ -6,6 +6,8 @@
 #define IDATA_SEG __idata
 #define XDATA_SEG __xdata
 
+#define BIT_TYPE __bit
+
 #define SFR_DEF(name, loc) __sfr __at(loc) name
 #define SBIT_DEF(name, loc) __sbit __at(loc) name
 
@@ -13,6 +15,8 @@
 
 #define IDATA_SEG idata
 #define XDATA_SEG xdata
+
+#define BIT_TYPE bit
 
 #define SFR_DEF(name, loc) sfr name = loc
 #define SBIT_DEF(name, loc) sbit name = loc

--- a/src/toolchain.h
+++ b/src/toolchain.h
@@ -7,6 +7,7 @@
 #define XDATA_SEG __xdata
 
 #define SFR_DEF(name, loc) __sfr __at(loc) name
+#define SBIT_DEF(name, loc) __sbit __at(loc) name
 
 #else // Keil
 
@@ -14,6 +15,7 @@
 #define XDATA_SEG xdata
 
 #define SFR_DEF(name, loc) sfr name = loc
+#define SBIT_DEF(name, loc) sbit name = loc
 
 #endif
 

--- a/src/toolchain.h
+++ b/src/toolchain.h
@@ -1,0 +1,14 @@
+#ifndef __TOOLCHAIN__H_
+#define __TOOLCHAIN__H_
+
+#ifdef SDCC
+
+#define XDATA_SEG __xdata
+
+#else // Keil
+
+#define XDATA_SEG xdata
+
+#endif
+
+#endif

--- a/src/toolchain.h
+++ b/src/toolchain.h
@@ -5,6 +5,7 @@
 
 #define IDATA_SEG __idata
 #define XDATA_SEG __xdata
+#define CODE_SEG __code
 
 #define BIT_TYPE __bit
 
@@ -17,6 +18,7 @@
 
 #define IDATA_SEG idata
 #define XDATA_SEG xdata
+#define CODE_SEG code
 
 #define BIT_TYPE bit
 

--- a/src/toolchain.h
+++ b/src/toolchain.h
@@ -11,6 +11,8 @@
 #define SFR_DEF(name, loc) __sfr __at(loc) name
 #define SBIT_DEF(name, loc) __sbit __at(loc) name
 
+#define INTERRUPT(num) __interrupt(num)
+
 #else // Keil
 
 #define IDATA_SEG idata
@@ -20,6 +22,8 @@
 
 #define SFR_DEF(name, loc) sfr name = loc
 #define SBIT_DEF(name, loc) sbit name = loc
+
+#define INTERRUPT(num) interrupt num
 
 #endif
 

--- a/src/toolchain.h
+++ b/src/toolchain.h
@@ -3,10 +3,12 @@
 
 #ifdef SDCC
 
+#define IDATA_SEG __idata
 #define XDATA_SEG __xdata
 
 #else // Keil
 
+#define IDATA_SEG idata
 #define XDATA_SEG xdata
 
 #endif

--- a/src/toolchain.h
+++ b/src/toolchain.h
@@ -6,10 +6,14 @@
 #define IDATA_SEG __idata
 #define XDATA_SEG __xdata
 
+#define SFR_DEF(name, loc) __sfr __at(loc) name
+
 #else // Keil
 
 #define IDATA_SEG idata
 #define XDATA_SEG xdata
+
+#define SFR_DEF(name, loc) sfr name = loc
 
 #endif
 

--- a/src/uart.c
+++ b/src/uart.c
@@ -6,19 +6,19 @@
 XDATA_SEG uint8_t RS_buf[BUF_MAX];
 #ifdef EXTEND_BUF
 XDATA_SEG uint16_t RS_in=0, RS_out=0;
-         bit     RS_Xbusy=0;
+         BIT_TYPE     RS_Xbusy=0;
 #else
 XDATA_SEG uint8_t RS_in=0, RS_out=0;
-         bit     RS_Xbusy=0;
+         BIT_TYPE     RS_Xbusy=0;
 #endif
 
 XDATA_SEG uint8_t RS_buf1[BUF1_MAX];
 #ifdef EXTEND_BUF1
 XDATA_SEG uint16_t RS_in1=0, RS_out1=0;
-         bit     RS_Xbusy1=0;
+         BIT_TYPE     RS_Xbusy1=0;
 #else
 XDATA_SEG uint8_t RS_in1=0, RS_out1=0;
-         bit     RS_Xbusy1=0;
+         BIT_TYPE     RS_Xbusy1=0;
 #endif
 				 
 

--- a/src/uart.c
+++ b/src/uart.c
@@ -3,21 +3,21 @@
 #include "print.h"
 #include "smartaudio_protocol.h"
 
-C51_XDAT uint8_t RS_buf[BUF_MAX];
+XDATA_SEG uint8_t RS_buf[BUF_MAX];
 #ifdef EXTEND_BUF
-C51_XDAT uint16_t RS_in=0, RS_out=0;
+XDATA_SEG uint16_t RS_in=0, RS_out=0;
          bit     RS_Xbusy=0;
 #else
-C51_XDAT uint8_t RS_in=0, RS_out=0;
+XDATA_SEG uint8_t RS_in=0, RS_out=0;
          bit     RS_Xbusy=0;
 #endif
 
-C51_XDAT uint8_t RS_buf1[BUF1_MAX];
+XDATA_SEG uint8_t RS_buf1[BUF1_MAX];
 #ifdef EXTEND_BUF1
-C51_XDAT uint16_t RS_in1=0, RS_out1=0;
+XDATA_SEG uint16_t RS_in1=0, RS_out1=0;
          bit     RS_Xbusy1=0;
 #else
-C51_XDAT uint8_t RS_in1=0, RS_out1=0;
+XDATA_SEG uint8_t RS_in1=0, RS_out1=0;
          bit     RS_Xbusy1=0;
 #endif
 				 
@@ -91,8 +91,8 @@ uint8_t RS_rx1_len(void)
 ////////////////////////////////////////////////////////////////////////////
 //SUART TX
 #ifdef USE_SMARTAUDIO
-C51_XDAT uint8_t SUART_rbuf[SUART_BUF_MAX];
-C51_XDAT uint8_t SUART_rin=0, SUART_rout=0,SUART_rERR=0;
+XDATA_SEG uint8_t SUART_rbuf[SUART_BUF_MAX];
+XDATA_SEG uint8_t SUART_rin=0, SUART_rout=0,SUART_rERR=0;
 
 void suart_rxint()  //ISR
 {

--- a/src/uart.h
+++ b/src/uart.h
@@ -42,19 +42,19 @@ uint8_t RS_rx1_len(void);
 uint8_t RS_rx1(void);
 
 extern bit RS_Xbusy;
-extern C51_XDAT uint8_t RS_buf[BUF_MAX];
+extern XDATA_SEG uint8_t RS_buf[BUF_MAX];
 #ifdef EXTEND_BUF
-extern C51_XDAT uint16_t RS_in, RS_out;
+extern XDATA_SEG uint16_t RS_in, RS_out;
 #else
-extern C51_XDAT uint8_t RS_in, RS_out;
+extern XDATA_SEG uint8_t RS_in, RS_out;
 #endif
 
 extern bit RS_Xbusy1;
-extern C51_XDAT uint8_t RS_buf1[BUF1_MAX];
+extern XDATA_SEG uint8_t RS_buf1[BUF1_MAX];
 #ifdef EXTEND_BUF1
-extern C51_XDAT uint16_t RS_in1, RS_out1;
+extern XDATA_SEG uint16_t RS_in1, RS_out1;
 #else
-extern C51_XDAT uint8_t RS_in1, RS_out1;
+extern XDATA_SEG uint8_t RS_in1, RS_out1;
 #endif
 
 #ifdef USE_SMARTAUDIO

--- a/src/uart.h
+++ b/src/uart.h
@@ -41,7 +41,7 @@ uint8_t RS_rx1_len(void);
 
 uint8_t RS_rx1(void);
 
-extern bit RS_Xbusy;
+extern BIT_TYPE RS_Xbusy;
 extern XDATA_SEG uint8_t RS_buf[BUF_MAX];
 #ifdef EXTEND_BUF
 extern XDATA_SEG uint16_t RS_in, RS_out;
@@ -49,7 +49,7 @@ extern XDATA_SEG uint16_t RS_in, RS_out;
 extern XDATA_SEG uint8_t RS_in, RS_out;
 #endif
 
-extern bit RS_Xbusy1;
+extern BIT_TYPE RS_Xbusy1;
 extern XDATA_SEG uint8_t RS_buf1[BUF1_MAX];
 #ifdef EXTEND_BUF1
 extern XDATA_SEG uint16_t RS_in1, RS_out1;


### PR DESCRIPTION
builds on #4 
adds macros for the different compiler intrinsics in use, to enable compilation with compilers other than Keil.
compilation with keil was validated. effective code stays the same.