### PR TITLE
enable compilation on sdcc

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+TabWidth: 2
+IndentWidth: 2
+UseTab: Never
+ColumnLimit: 0
+NamespaceIndentation: All
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+BreakConstructorInitializers: BeforeComma
+IndentPPDirectives: None

--- a/script/pre_script.py
+++ b/script/pre_script.py
@@ -1,6 +1,7 @@
 Import("env")
 
-SDCC_OPTS = ["--model-large", "--opt-code-speed"]
+SDCC_OPTS = ["--model-large", "--opt-code-speed", "--peep-return",
+             "--fomit-frame-pointer", "--allow-unsafe-read"]
 
 env.Append(
     CFLAGS=SDCC_OPTS,

--- a/src/camera.c
+++ b/src/camera.c
@@ -161,7 +161,7 @@ void Runcam_SetBrightness(uint8_t val)
 
 void Runcam_SetSharpness(uint8_t val)
 {
-    uint32_t d;
+    uint32_t d = 0;
 
     camCfg_Cur.sharpness = val;
 
@@ -701,57 +701,59 @@ void SaveCamCfg_Menu(void)
     }
 }
 
-void SetCamCfg(cameraConfig_t cfg, uint8_t INIT)
+void SetCamCfg(cameraConfig_t *cfg, uint8_t INIT)
 {
     uint8_t i,j;
 
+    if(cfg == 0)
+        return;
     if(cameraID == 0)
         return;
     if(INIT)
     {
-        Runcam_SetBrightness(cfg.brightness);
-        Runcam_SetSharpness(cfg.sharpness);
-        Runcam_SetSaturation(cfg.saturation);
-        Runcam_SetContrast(cfg.contrast);
-        Runcam_SetHVFlip(cfg.hvFlip);
-        Runcam_SetNightMode(cfg.nightMode);
-        Runcam_SetWB(cfg.wbRed, cfg.wbBlue, cfg.wbMode);
+        Runcam_SetBrightness(cfg->brightness);
+        Runcam_SetSharpness(cfg->sharpness);
+        Runcam_SetSaturation(cfg->saturation);
+        Runcam_SetContrast(cfg->contrast);
+        Runcam_SetHVFlip(cfg->hvFlip);
+        Runcam_SetNightMode(cfg->nightMode);
+        Runcam_SetWB(cfg->wbRed, cfg->wbBlue, cfg->wbMode);
     }
     else
     {
-        if(camCfg_Cur.brightness != cfg.brightness)
-            Runcam_SetBrightness(cfg.brightness);
+        if(camCfg_Cur.brightness != cfg->brightness)
+            Runcam_SetBrightness(cfg->brightness);
 
-        if(camCfg_Cur.sharpness != cfg.sharpness)
-            Runcam_SetSharpness(cfg.sharpness);
+        if(camCfg_Cur.sharpness != cfg->sharpness)
+            Runcam_SetSharpness(cfg->sharpness);
 
-        if(camCfg_Cur.saturation != cfg.saturation)
-            Runcam_SetSaturation(cfg.saturation);
+        if(camCfg_Cur.saturation != cfg->saturation)
+            Runcam_SetSaturation(cfg->saturation);
 
-        if(camCfg_Cur.contrast != cfg.contrast)
-            Runcam_SetContrast(cfg.contrast);
+        if(camCfg_Cur.contrast != cfg->contrast)
+            Runcam_SetContrast(cfg->contrast);
 
-        if(camCfg_Cur.hvFlip != cfg.hvFlip)
-            Runcam_SetHVFlip(cfg.hvFlip);
+        if(camCfg_Cur.hvFlip != cfg->hvFlip)
+            Runcam_SetHVFlip(cfg->hvFlip);
 
-        if(camCfg_Cur.nightMode != cfg.nightMode)
-            Runcam_SetNightMode(cfg.nightMode);
+        if(camCfg_Cur.nightMode != cfg->nightMode)
+            Runcam_SetNightMode(cfg->nightMode);
 
         j = 0;
-        if(camCfg_Cur.wbMode != cfg.wbMode)
+        if(camCfg_Cur.wbMode != cfg->wbMode)
             j = 1;
         else
         {
             for(i=0;i<WBMODE_MAX;i++)
             {
-                if(camCfg_Cur.wbRed[i] != cfg.wbRed[i])
+                if(camCfg_Cur.wbRed[i] != cfg->wbRed[i])
                     j |= 1;
-                if(camCfg_Cur.wbBlue[i] != cfg.wbBlue[i])
+                if(camCfg_Cur.wbBlue[i] != cfg->wbBlue[i])
                     j |= 1;
             }
         }
         if(j==1)
-            Runcam_SetWB(cfg.wbRed, cfg.wbBlue, cfg.wbMode);
+            Runcam_SetWB(cfg->wbRed, cfg->wbBlue, cfg->wbMode);
 
     }
     #ifdef _DEBUG_MODE
@@ -766,7 +768,7 @@ void CameraInit()
 
     GetCamCfg_EEP();
     GetCamCfg(1);
-    SetCamCfg(camCfg, 1);
+    SetCamCfg(&camCfg, 1);
 }
 
 #if(0)
@@ -870,7 +872,7 @@ uint8_t camStatusUpdate(uint8_t op)
                     camProfile = camProfile_Menu;
                     GetCamCfg(0);
                     GetCamCfg_Menu(0);
-                    SetCamCfg(camCfg_Menu, 0);
+                    SetCamCfg(&camCfg_Menu, 0);
                 }
             }
             else if(op == BTN_RIGHT)
@@ -885,7 +887,7 @@ uint8_t camStatusUpdate(uint8_t op)
                         camProfile = camProfile_Menu;
                         GetCamCfg(0);
                         GetCamCfg_Menu(0);
-                        SetCamCfg(camCfg_Menu, 0);
+                        SetCamCfg(&camCfg_Menu, 0);
                     }
                 }
                 else// if(cameraID == RUNCAM_MICRO_V2)
@@ -897,7 +899,7 @@ uint8_t camStatusUpdate(uint8_t op)
                         camProfile = camProfile_Menu;
                         GetCamCfg(0);
                         GetCamCfg_Menu(0);
-                        SetCamCfg(camCfg_Menu, 0);
+                        SetCamCfg(&camCfg_Menu, 0);
                     }
                 }
             }
@@ -1411,7 +1413,7 @@ uint8_t camStatusUpdate(uint8_t op)
                         }
                     }
                 }
-                SetCamCfg(camCfg_Menu, 0);
+                SetCamCfg(&camCfg_Menu, 0);
             }
         break;
             
@@ -1428,7 +1430,7 @@ uint8_t camStatusUpdate(uint8_t op)
                 camMenuStatus = CAM_STATUS_IDLE;
                 msp_tx_cnt = 0;
                 ret = 1;
-                SetCamCfg(camCfg, 0);
+                SetCamCfg(&camCfg, 0);
             }
         break;
 

--- a/src/camera.c
+++ b/src/camera.c
@@ -1,3 +1,6 @@
+#pragma save
+#pragma stackauto
+
 #include "camera.h"
 #include "i2c_device.h"
 #include "global.h"
@@ -1718,3 +1721,4 @@ void camMenuStringUpdate(uint8_t status)
 
     camMenuDrawBracket();
 }
+#pragma restore

--- a/src/global.c
+++ b/src/global.c
@@ -107,10 +107,3 @@ void uint8ToString(uint8_t dec, uint8_t* Str)
             Str[1] = ' ';
     }
 }
-
-void memcopy(uint8_t* dst, uint8_t* src, uint32_t len)
-{
-    uint32_t i;
-    for(i=0;i<len;i++)
-        dst[i] = src[i];
-}

--- a/src/global.h
+++ b/src/global.h
@@ -24,6 +24,4 @@ void uint8ToString(uint8_t dec, uint8_t* Str);
 
 void WAIT(uint32_t ms);
 
-void memcopy(uint8_t* dst, uint8_t* src, uint32_t len);
-
 #endif //_GLOBAL_H_

--- a/src/hardware.c
+++ b/src/hardware.c
@@ -3,7 +3,7 @@
 #include "global.h"
 #include "uart.h"
 #include "print.h"
-#include "Monitor.h"
+#include "monitor.h"
 #include "isr.h"
 #include "hardware.h"
 #include "i2c.h"

--- a/src/isr.c
+++ b/src/isr.c
@@ -4,8 +4,6 @@
 #include "isr.h"
 #include "uart.h"
 
-BIT_TYPE int0_req = 0;
-BIT_TYPE int1_req = 0;
 uint8_t btn1_tflg = 0;
 uint8_t pwr_sflg = 0;    //power autoswitch flag
 uint8_t pwr_tflg = 0;
@@ -64,67 +62,4 @@ void CPU_init(void)
                     // [0]   enable INT0   interupt   0
     IP    = 0x10;   // UART0=higher priority, Timer 0 = low
     
-}
-
-void Timer0_isr(void) INTERRUPT(1)
-{
-    TH0 = 138;
-
-    #ifdef USE_SMARTAUDIO
-    if(SA_config) {
-        if(suart_tx_en) {
-            //TH0 = 139;
-            suart_txint();
-        }
-        else
-            suart_rxint();
-    }
-    #endif
-    
-    timer_ms10x++;
-}
-
-void Timer1_isr(void) INTERRUPT(3)
-{
-}		 
-
-
-void Ext0_isr(void) INTERRUPT(0)
-{
-	int0_req = 1;
-}
-
-void Ext1_isr(void) INTERRUPT(2)
-{
-	int1_req = 1;
-}
-
-void UART0_isr() INTERRUPT(4)
-{
-	if( RI ) {			//RX int
-		RI = 0;
-		RS_buf[RS_in++] = SBUF0;
-		if( RS_in>=BUF_MAX ) RS_in = 0;
-        if(RS_in == RS_out) RS0_ERR = 1;
-	}
-
-	if( TI ) {			//TX int
-		TI = 0;
-		RS_Xbusy=0;
-	}
-}
-
-void UART1_isr() INTERRUPT(6)
-{
-    
-	if( RI1 ) {			//RX int
-		RI1 = 0;
-		RS_buf1[RS_in1++] = SBUF1;
-		if( RS_in1>=BUF_MAX ) RS_in1 = 0;
-	}
-
-	if( TI1 ) {			//TX int
-		TI1 = 0;
-		RS_Xbusy1=0;
-	}
 }

--- a/src/mcu.c
+++ b/src/mcu.c
@@ -3,7 +3,7 @@
 #include "global.h"
 #include "uart.h"
 #include "print.h"
-#include "Monitor.h"
+#include "monitor.h"
 #include "sfr_ext.h"
 #include "hardware.h"
 #include "i2c_device.h"

--- a/src/mcu.c
+++ b/src/mcu.c
@@ -22,6 +22,72 @@ void timer_task();
 void SA_Delay_init();
 #endif
 
+BIT_TYPE int0_req = 0;
+BIT_TYPE int1_req = 0;
+
+void Timer0_isr(void) INTERRUPT(1)
+{
+    TH0 = 138;
+
+    #ifdef USE_SMARTAUDIO
+    if(SA_config) {
+        if(suart_tx_en) {
+            //TH0 = 139;
+            suart_txint();
+        }
+        else
+            suart_rxint();
+    }
+    #endif
+    
+    timer_ms10x++;
+}
+
+void Timer1_isr(void) INTERRUPT(3)
+{
+}		 
+
+
+void Ext0_isr(void) INTERRUPT(0)
+{
+	int0_req = 1;
+}
+
+void Ext1_isr(void) INTERRUPT(2)
+{
+	int1_req = 1;
+}
+
+void UART0_isr() INTERRUPT(4)
+{
+	if( RI ) {			//RX int
+		RI = 0;
+		RS_buf[RS_in++] = SBUF0;
+		if( RS_in>=BUF_MAX ) RS_in = 0;
+        if(RS_in == RS_out) RS0_ERR = 1;
+	}
+
+	if( TI ) {			//TX int
+		TI = 0;
+		RS_Xbusy=0;
+	}
+}
+
+void UART1_isr() INTERRUPT(6)
+{
+    
+	if( RI1 ) {			//RX int
+		RI1 = 0;
+		RS_buf1[RS_in1++] = SBUF1;
+		if( RS_in1>=BUF_MAX ) RS_in1 = 0;
+	}
+
+	if( TI1 ) {			//TX int
+		TI1 = 0;
+		RS_Xbusy1=0;
+	}
+}
+
 void main(void)
 {
     // init

--- a/src/sfr_def.h
+++ b/src/sfr_def.h
@@ -3,166 +3,176 @@
 
 #include "toolchain.h"
 
+#define REG_P0 0x80
+#define REG_P1 0x90
+#define REG_P2 0xA0
+#define REG_P3 0xB0
+#define REG_TCON 0x88
+#define REG_IE 0xA8
+#define REG_IP 0xB8
+#define REG_SCON0 0x98
+#define REG_SCON1 0xC0
+
 ////////////////////////////////////////////////////////////////////////////////
 // SFR
 
-SFR_DEF(P0,        0x80);   /* Port 0                    */
-SFR_DEF(SP,        0x81);   /* Stack Pointer             */
-SFR_DEF(DPL0,      0x82);   /* Data Pointer 0 Low byte   */
-SFR_DEF(DPH0,      0x83);   /* Data Pointer 0 High byte  */
-SFR_DEF(DPL1,      0x84);   /* Data Pointer 1 Low byte   */
-SFR_DEF(DPH1,      0x85);   /* Data Pointer 1 High byte  */
-SFR_DEF(DPS,       0x86);
-SFR_DEF(PCON,      0x87);   /* Power Configuration       */
+SFR_DEF(P0, REG_P0); /* Port 0                    */
+SFR_DEF(SP, 0x81);   /* Stack Pointer             */
+SFR_DEF(DPL0, 0x82); /* Data Pointer 0 Low byte   */
+SFR_DEF(DPH0, 0x83); /* Data Pointer 0 High byte  */
+SFR_DEF(DPL1, 0x84); /* Data Pointer 1 Low byte   */
+SFR_DEF(DPH1, 0x85); /* Data Pointer 1 High byte  */
+SFR_DEF(DPS, 0x86);
+SFR_DEF(PCON, 0x87); /* Power Configuration       */
 
-SFR_DEF(TCON,      0x88);   /* Timer 0,1 Configuration   */
-SFR_DEF(TMOD,      0x89);   /* Timer 0,1 Mode            */
-SFR_DEF(TL0,       0x8A);   /* Timer 0 Low byte counter  */
-SFR_DEF(TL1,       0x8B);   /* Timer 1 Low byte counter  */
-SFR_DEF(TH0,       0x8C);   /* Timer 0 High byte counter */
-SFR_DEF(TH1,       0x8D);   /* Timer 1 High byte counter */
-SFR_DEF(CKCON,     0x8E);   /* XDATA Wait States         */
+SFR_DEF(TCON, REG_TCON); /* Timer 0,1 Configuration   */
+SFR_DEF(TMOD, 0x89);     /* Timer 0,1 Mode            */
+SFR_DEF(TL0, 0x8A);      /* Timer 0 Low byte counter  */
+SFR_DEF(TL1, 0x8B);      /* Timer 1 Low byte counter  */
+SFR_DEF(TH0, 0x8C);      /* Timer 0 High byte counter */
+SFR_DEF(TH1, 0x8D);      /* Timer 1 High byte counter */
+SFR_DEF(CKCON, 0x8E);    /* XDATA Wait States         */
 
-SFR_DEF(P1,        0x90);   /* Port 1                    */
-SFR_DEF(EIF,       0x91);
-SFR_DEF(WTST,      0x92);   /* Program Wait States       */
-SFR_DEF(DPX0,      0x93);   /* Data Page Pointer 0       */
-SFR_DEF(DPX1,      0x95);   /* Data Page Pointer 1       */
+SFR_DEF(P1, REG_P1); /* Port 1                    */
+SFR_DEF(EIF, 0x91);
+SFR_DEF(WTST, 0x92); /* Program Wait States       */
+SFR_DEF(DPX0, 0x93); /* Data Page Pointer 0       */
+SFR_DEF(DPX1, 0x95); /* Data Page Pointer 1       */
 
-SFR_DEF(SCON0,     0x98);   /* Serial 0 Configuration    */
-SFR_DEF(SBUF0,     0x99);   /* Serial 0 I/O Buffer       */
+SFR_DEF(SCON0, REG_SCON0); /* Serial 0 Configuration    */
+SFR_DEF(SBUF0, 0x99);      /* Serial 0 I/O Buffer       */
 
-SFR_DEF(P2,        0xA0);   /* Port 2                    */
+SFR_DEF(P2, REG_P2); /* Port 2                    */
 
-SFR_DEF(IE,        0xA8);   /* Interrupt Enable          */
+SFR_DEF(IE, REG_IE); /* Interrupt Enable          */
 
-SFR_DEF(P3,        0xB0);   /* Port 3                    */
+SFR_DEF(P3, REG_P3); /* Port 3                    */
 
-SFR_DEF(IP,        0xB8);
+SFR_DEF(IP, REG_IP);
 
-SFR_DEF(SCON1,     0xC0);   /* Serial 1 Configuration    */
-SFR_DEF(SBUF1,     0xC1);   /* Serial 1 I/O Buffer       */
+SFR_DEF(SCON1, REG_SCON1); /* Serial 1 Configuration    */
+SFR_DEF(SBUF1, 0xC1);      /* Serial 1 I/O Buffer       */
 
-SFR_DEF(T2CON,     0xC8);
-SFR_DEF(T2IF,      0xC9);
-SFR_DEF(RLDL,      0xCA);
-SFR_DEF(RLDH,      0xCB);
-SFR_DEF(TL2,       0xCC);
-SFR_DEF(TH2,       0xCD);
-SFR_DEF(CCEN,      0xCE);
+SFR_DEF(T2CON, 0xC8);
+SFR_DEF(T2IF, 0xC9);
+SFR_DEF(RLDL, 0xCA);
+SFR_DEF(RLDH, 0xCB);
+SFR_DEF(TL2, 0xCC);
+SFR_DEF(TH2, 0xCD);
+SFR_DEF(CCEN, 0xCE);
 
-SFR_DEF(PSW,       0xD0);   /* Program Status Word       */
+SFR_DEF(PSW, 0xD0); /* Program Status Word       */
 
-SFR_DEF(WDCON,     0xD8);
+SFR_DEF(WDCON, 0xD8);
 
-SFR_DEF(ACC,       0xE0);   /* Accumulator               */
+SFR_DEF(ACC, 0xE0); /* Accumulator               */
 
-SFR_DEF(EIE,       0xE8);   /* External Interrupt Enable */
-SFR_DEF(STATUS,    0xE9);   /* Status register           */
-SFR_DEF(MXAX,      0xEA);   /* MOVX @Ri High address     */
-SFR_DEF(TA,        0xEB);
+SFR_DEF(EIE, 0xE8);    /* External Interrupt Enable */
+SFR_DEF(STATUS, 0xE9); /* Status register           */
+SFR_DEF(MXAX, 0xEA);   /* MOVX @Ri High address     */
+SFR_DEF(TA, 0xEB);
 
-SFR_DEF(B,         0xF0);   /* B Working register        */
+SFR_DEF(B, 0xF0); /* B Working register        */
 
-SFR_DEF(EIP,       0xF8);
+SFR_DEF(EIP, 0xF8);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Bit define
 
 /*  P0  */
-SBIT_DEF(P0_7,     P0^7);
-SBIT_DEF(P0_6,     P0^6);
-SBIT_DEF(P0_5,     P0^5);
-SBIT_DEF(P0_4,     P0^4);
-SBIT_DEF(P0_3,     P0^3);
-SBIT_DEF(P0_2,     P0^2);
-SBIT_DEF(P0_1,     P0^1);
-SBIT_DEF(P0_0,     P0^0);
+SBIT_DEF(P0_7, REG_P0 ^ 7);
+SBIT_DEF(P0_6, REG_P0 ^ 6);
+SBIT_DEF(P0_5, REG_P0 ^ 5);
+SBIT_DEF(P0_4, REG_P0 ^ 4);
+SBIT_DEF(P0_3, REG_P0 ^ 3);
+SBIT_DEF(P0_2, REG_P0 ^ 2);
+SBIT_DEF(P0_1, REG_P0 ^ 1);
+SBIT_DEF(P0_0, REG_P0 ^ 0);
 
 /*  P1  */
-SBIT_DEF(P1_7,     P1^7);
-SBIT_DEF(P1_6,     P1^6);
-SBIT_DEF(P1_5,     P1^5);
-SBIT_DEF(P1_4,     P1^4);
-SBIT_DEF(P1_3,     P1^3);
-SBIT_DEF(P1_2,     P1^2);
-SBIT_DEF(P1_1,     P1^1);
-SBIT_DEF(P1_0,     P1^0);
+SBIT_DEF(P1_7, REG_P1 ^ 7);
+SBIT_DEF(P1_6, REG_P1 ^ 6);
+SBIT_DEF(P1_5, REG_P1 ^ 5);
+SBIT_DEF(P1_4, REG_P1 ^ 4);
+SBIT_DEF(P1_3, REG_P1 ^ 3);
+SBIT_DEF(P1_2, REG_P1 ^ 2);
+SBIT_DEF(P1_1, REG_P1 ^ 1);
+SBIT_DEF(P1_0, REG_P1 ^ 0);
 
 /*  P2  */
-SBIT_DEF(P2_7,     P2^7);
-SBIT_DEF(P2_6,     P2^6);
-SBIT_DEF(P2_5,     P2^5);
-SBIT_DEF(P2_4,     P2^4);
-SBIT_DEF(P2_3,     P2^3);
-SBIT_DEF(P2_2,     P2^2);
-SBIT_DEF(P2_1,     P2^1);
-SBIT_DEF(P2_0,     P2^0);
+SBIT_DEF(P2_7, REG_P2 ^ 7);
+SBIT_DEF(P2_6, REG_P2 ^ 6);
+SBIT_DEF(P2_5, REG_P2 ^ 5);
+SBIT_DEF(P2_4, REG_P2 ^ 4);
+SBIT_DEF(P2_3, REG_P2 ^ 3);
+SBIT_DEF(P2_2, REG_P2 ^ 2);
+SBIT_DEF(P2_1, REG_P2 ^ 1);
+SBIT_DEF(P2_0, REG_P2 ^ 0);
 
 /*  P3  */
-SBIT_DEF(P3_7,     P3^7);
-SBIT_DEF(P3_6,     P3^6);
-SBIT_DEF(P3_5,     P3^5);
-SBIT_DEF(P3_4,     P3^4);
-SBIT_DEF(P3_3,     P3^3);
-SBIT_DEF(P3_2,     P3^2);
-SBIT_DEF(P3_1,     P3^1);
-SBIT_DEF(P3_0,     P3^0);
+SBIT_DEF(P3_7, REG_P3 ^ 7);
+SBIT_DEF(P3_6, REG_P3 ^ 6);
+SBIT_DEF(P3_5, REG_P3 ^ 5);
+SBIT_DEF(P3_4, REG_P3 ^ 4);
+SBIT_DEF(P3_3, REG_P3 ^ 3);
+SBIT_DEF(P3_2, REG_P3 ^ 2);
+SBIT_DEF(P3_1, REG_P3 ^ 1);
+SBIT_DEF(P3_0, REG_P3 ^ 0);
 
 /*  TCON  */
-SBIT_DEF(TF1,      TCON^7);
-SBIT_DEF(TR1,      TCON^6);
-SBIT_DEF(TF0,      TCON^5);
-SBIT_DEF(TR0,      TCON^4);
-SBIT_DEF(IE1,      TCON^3);
-SBIT_DEF(IT1,      TCON^2);
-SBIT_DEF(IE0,      TCON^1);
-SBIT_DEF(IT0,      TCON^0);
+SBIT_DEF(TF1, REG_TCON ^ 7);
+SBIT_DEF(TR1, REG_TCON ^ 6);
+SBIT_DEF(TF0, REG_TCON ^ 5);
+SBIT_DEF(TR0, REG_TCON ^ 4);
+SBIT_DEF(IE1, REG_TCON ^ 3);
+SBIT_DEF(IT1, REG_TCON ^ 2);
+SBIT_DEF(IE0, REG_TCON ^ 1);
+SBIT_DEF(IT0, REG_TCON ^ 0);
 
 /*  IE  */
-SBIT_DEF(EA,       IE^7);
-SBIT_DEF(ES1,      IE^6);
-SBIT_DEF(ET2,      IE^5);
-SBIT_DEF(ES0,      IE^4);
-SBIT_DEF(ET1,      IE^3);
-SBIT_DEF(EX1,      IE^2);
-SBIT_DEF(ET0,      IE^1);
-SBIT_DEF(EX0,      IE^0);
+SBIT_DEF(EA, REG_IE ^ 7);
+SBIT_DEF(ES1, REG_IE ^ 6);
+SBIT_DEF(ET2, REG_IE ^ 5);
+SBIT_DEF(ES0, REG_IE ^ 4);
+SBIT_DEF(ET1, REG_IE ^ 3);
+SBIT_DEF(EX1, REG_IE ^ 2);
+SBIT_DEF(ET0, REG_IE ^ 1);
+SBIT_DEF(EX0, REG_IE ^ 0);
 
 /*  IP  */
-SBIT_DEF(PS1,      IP^6);
-SBIT_DEF(PT2,      IP^5);
-SBIT_DEF(PS0,      IP^4);
-SBIT_DEF(PT1,      IP^3);
-SBIT_DEF(PX1,      IP^2);
-SBIT_DEF(PT0,      IP^1);
-SBIT_DEF(PX0,      IP^0);
+SBIT_DEF(PS1, REG_IP ^ 6);
+SBIT_DEF(PT2, REG_IP ^ 5);
+SBIT_DEF(PS0, REG_IP ^ 4);
+SBIT_DEF(PT1, REG_IP ^ 3);
+SBIT_DEF(PX1, REG_IP ^ 2);
+SBIT_DEF(PT0, REG_IP ^ 1);
+SBIT_DEF(PX0, REG_IP ^ 0);
 
 /*  SCON0  */
-SBIT_DEF(SM0,      SCON0^7);
-SBIT_DEF(SM1,      SCON0^6);
-SBIT_DEF(SM2,      SCON0^5);
-SBIT_DEF(REN,      SCON0^4);
-SBIT_DEF(TB8,      SCON0^3);
-SBIT_DEF(RB8,      SCON0^2);
-SBIT_DEF(TI,       SCON0^1);
-SBIT_DEF(RI,       SCON0^0);
+SBIT_DEF(SM0, REG_SCON0 ^ 7);
+SBIT_DEF(SM1, REG_SCON0 ^ 6);
+SBIT_DEF(SM2, REG_SCON0 ^ 5);
+SBIT_DEF(REN, REG_SCON0 ^ 4);
+SBIT_DEF(TB8, REG_SCON0 ^ 3);
+SBIT_DEF(RB8, REG_SCON0 ^ 2);
+SBIT_DEF(TI, REG_SCON0 ^ 1);
+SBIT_DEF(RI, REG_SCON0 ^ 0);
 
 /*  SCON1  */
-SBIT_DEF(SM10,     SCON1^7);
-SBIT_DEF(SM11,     SCON1^6);
-SBIT_DEF(SM12,     SCON1^5);
-SBIT_DEF(REN1,     SCON1^4);
-SBIT_DEF(TB18,     SCON1^3);
-SBIT_DEF(RB18,     SCON1^2);
-SBIT_DEF(TI1,      SCON1^1);
-SBIT_DEF(RI1,      SCON1^0);
+SBIT_DEF(SM10, REG_SCON1 ^ 7);
+SBIT_DEF(SM11, REG_SCON1 ^ 6);
+SBIT_DEF(SM12, REG_SCON1 ^ 5);
+SBIT_DEF(REN1, REG_SCON1 ^ 4);
+SBIT_DEF(TB18, REG_SCON1 ^ 3);
+SBIT_DEF(RB18, REG_SCON1 ^ 2);
+SBIT_DEF(TI1, REG_SCON1 ^ 1);
+SBIT_DEF(RI1, REG_SCON1 ^ 0);
 
 /*  EIF  */
-//SBIT_DEF(INT6F,    EIF^4);
-//SBIT_DEF(INT5F,    EIF^3);
-//SBIT_DEF(INT4F,    EIF^2);
-//SBIT_DEF(INT3F,    EIF^1);
-//SBIT_DEF(INT2F,    EIF^0);
+// SBIT_DEF(INT6F,    EIF^4);
+// SBIT_DEF(INT5F,    EIF^3);
+// SBIT_DEF(INT4F,    EIF^2);
+// SBIT_DEF(INT3F,    EIF^1);
+// SBIT_DEF(INT2F,    EIF^0);
 
 #endif

--- a/src/smartaudio_protocol.c
+++ b/src/smartaudio_protocol.c
@@ -3,7 +3,7 @@
 #include "global.h"
 #include "uart.h"
 #include "print.h"
-#include "Monitor.h"
+#include "monitor.h"
 #include "sfr_ext.h"
 #include "hardware.h"
 #include "i2c_device.h"


### PR DESCRIPTION
builds on #8

this PR includes the minimal amount of changes to enable compilation on sdcc 
_with `INIT_VTX_TABLE` disabled_, it does not fit into flash with that enabled _yet_

it is however not yet operational.

most of the commits were originally authored by @saidinesh5 and have been refined by @pjpei and myself

compilation and correct operation on Keil was verified by myself. 