### PR TITLE
Fix dm6300 get tempurature

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -26,32 +26,32 @@ build_unflags =
 build_flags =
   -DDM5680
 
-[env:vtx_freestyle]
+[env:hdzero_freestyle]
 extends = DM5680
 build_flags =
   ${DM5680.build_flags}
-  -DVTX_L
+  -DHDZERO_FREESTYLE
 
-[env:vtx_whoop_lite]
+[env:hdzero_whoop_lite]
 extends = DM5680
 build_flags =
   ${DM5680.build_flags}
-  -DVTX_WL
+  -DHDZERO_WHOOP_LITE
 
-[env:vtx_whoop]
+[env:hdzero_whoop]
 extends = DM5680
 build_flags =
   ${DM5680.build_flags}
-  -DVTX_W
+  -DHDZERO_WHOOP
 
-[env:vtx_race_v1]
+[env:hdzero_race_v1]
 extends = DM5680
 build_flags =
   ${DM5680.build_flags}
-  -DVTX_R_V1
+  -DHDZERO_RACE_V1
 
-[env:vtx_race_v2]
+[env:hdzero_race_v2]
 extends = DM5680
 build_flags =
   ${DM5680.build_flags}
-  -DVTX_R_V2
+  -DHDZERO_RACE_V2

--- a/src/common.h
+++ b/src/common.h
@@ -11,36 +11,36 @@
 #define VERSION 0x41
 #define BETA 0x04
 
-//#define VTX_W
-//#define VTX_WL
-//#define VTX_R_V1
-//#define VTX_R_V2
-//#define VTX_L
+//#define HDZERO_WHOOP
+//#define HDZERO_WHOOP_LITE
+//#define HDZERO_RACE_V1
+//#define HDZERO_RACE_V2
+//#define HDZERO_FREESTYLE
 
-#if defined VTX_W
+#if defined HDZERO_WHOOP
 #define VTX_ID          0x54
-#elif defined VTX_WL
+#elif defined HDZERO_WHOOP_LITE
 #define VTX_ID          0x55
-#elif defined VTX_R_V1
+#elif defined HDZERO_RACE_V1
 #define VTX_ID          0x56
-#elif defined VTX_R_V2
+#elif defined HDZERO_RACE_V2
 #define VTX_ID          0x57
-#elif defined VTX_L
+#elif defined HDZERO_FREESTYLE
 #define VTX_ID          0x58
 #else
 #define VTX_ID          0x00
 #endif
 
-#if defined VTX_W
-#define VTX_NAME    "         WHOOP"
-#elif defined VTX_WL
-#define VTX_NAME    "    WHOOP LITE"
-#elif defined VTX_R_V1
-#define VTX_NAME    "       RACE V1"
-#elif defined VTX_R_V2
-#define VTX_NAME    "       RACE V2"
-#elif defined VTX_L
-#define VTX_NAME    "     FREESTYLE"
+#if defined HDZERO_WHOOP
+#define VTX_NAME    "     HDZ WHOOP"
+#elif defined HDZERO_WHOOP_LITE
+#define VTX_NAME    "HDZ WHOOP LITE"
+#elif defined HDZERO_RACE_V1
+#define VTX_NAME    "   HDZ RACE V1"
+#elif defined HDZERO_RACE_V2
+#define VTX_NAME    "   HDZ RACE V2"
+#elif defined HDZERO_FREESTYLE
+#define VTX_NAME    " HDZ FREESTYLE"
 #else
 #define VTX_NAME    "              "
 #endif
@@ -76,11 +76,11 @@
 #define USE_MSP
 #endif
 
-#ifndef VTX_W
+#ifndef HDZERO_WHOOP
 #define USE_SMARTAUDIO
 #endif
 
-#if defined(VTX_L) || defined(VTX_WL)
+#if defined(HDZERO_FREESTYLE) || defined(HDZERO_WHOOP_LITE)
 #define USE_TEMPERATURE_SENSOR
 #endif
 
@@ -108,7 +108,7 @@
 #define SDA             P0_1
 #define CAM_SCL         P0_0
 #define CAM_SDA         P0_1
-#ifdef VTX_L
+#ifdef HDZERO_FREESTYLE
 #define PA_EN           P0_2
 #else
 #define LED_1           P0_2

--- a/src/dm6300.c
+++ b/src/dm6300.c
@@ -21,6 +21,7 @@ uint32_t init6300_fnum[FREQ_MAX_EXT+1] = {0};
 uint32_t dcoc_ih = 0x075F0000;
 uint32_t dcoc_qh = 0x075F0000;
 
+uint8_t dm6300_init_done = 0;
 #ifdef HDZERO_FREESTYLE
 uint8_t table_power[FREQ_MAX_EXT+1][POWER_MAX+1] = {
     {0x70, 0x68, 0x5c, 0x60},         
@@ -233,18 +234,21 @@ void DM6300_InitAUXADC()
     SPI_Write(0x6, 0xFF0, 0x00000018);
     SPI_Write(0x3, 0x2A0, 0xC05B55FE);
     SPI_Write(0x6, 0xFF0, 0x00000019);
+    WAIT(1);
     SPI_Read (0x3, 0x17C, &dat);
     dat1 = ((int32_t)dat) >> 20;
     
     SPI_Write(0x6, 0xFF0, 0x00000018);
     SPI_Write(0x3, 0x2A0, 0x305B55FE);
     SPI_Write(0x6, 0xFF0, 0x00000019);
+    WAIT(1);
     SPI_Read (0x3, 0x17C, &dat);
     dat2 = ((int32_t)dat) >> 20;
     
     SPI_Write(0x6, 0xFF0, 0x00000018);
     SPI_Write(0x3, 0x2A0, 0xA05B51FE);
     SPI_Write(0x6, 0xFF0, 0x00000019);
+    WAIT(1);
     SPI_Read (0x3, 0x17C, &dat);
     dat3 = ((int32_t)dat) >> 20;
     
@@ -259,6 +263,7 @@ void DM6300_AUXADC_Calib()
     WriteReg(0, 0x8F, 0x01);
     DM6300_InitAUXADC();
     WriteReg(0, 0x8F, 0x11);
+    dm6300_init_done = 1;
 }
 /*void DM6300_CalibRF()
 {

--- a/src/dm6300.c
+++ b/src/dm6300.c
@@ -21,7 +21,7 @@ uint32_t init6300_fnum[FREQ_MAX_EXT+1] = {0};
 uint32_t dcoc_ih = 0x075F0000;
 uint32_t dcoc_qh = 0x075F0000;
 
-#ifdef VTX_L
+#ifdef HDZERO_FREESTYLE
 uint8_t table_power[FREQ_MAX_EXT+1][POWER_MAX+1] = {
     {0x70, 0x68, 0x5c, 0x60},         
     {0x70, 0x68, 0x5c, 0x60},         
@@ -144,7 +144,7 @@ void DM6300_SetChannel(uint8_t ch)
 
 void DM6300_SetPower(uint8_t pwr, uint8_t freq, uint8_t offset)
 {
-	#ifdef VTX_L
+	#ifdef HDZERO_FREESTYLE
     uint16_t a_tab[4] = {0x204, 0x11F, 0x21F, 0x31F};  
     #else
     uint16_t a_tab[2] = {0x21F, 0x41F};

--- a/src/dm6300.h
+++ b/src/dm6300.h
@@ -33,4 +33,5 @@ extern uint8_t table_power[FREQ_MAX_EXT+1][POWER_MAX+1];
 
 extern uint32_t dcoc_ih,dcoc_qh;
 
+extern uint8_t dm6300_init_done;
 #endif /* __DM6300_H_ */

--- a/src/dm6300.h
+++ b/src/dm6300.h
@@ -3,7 +3,7 @@
 
 #include "common.h"
 
-#ifdef VTX_L
+#ifdef HDZERO_FREESTYLE
 	#define PIT_POWER 0x18  //2dbm
 #else
 	#define PIT_POWER 0x26

--- a/src/hardware.c
+++ b/src/hardware.c
@@ -459,6 +459,9 @@ void TempDetect()
     static uint8_t init = 1;
     int16_t temp_new;
     
+    if(!dm6300_init_done)
+        return;
+
     if(temp_tflg){
         temp_tflg = 0;
         

--- a/src/hardware.c
+++ b/src/hardware.c
@@ -18,23 +18,22 @@
 uint8_t KEYBOARD_ON = 0; //avoid conflict between keyboard and cam_control
 uint8_t EE_VALID = 0;
 
-#ifdef VTX_L
+#ifdef HDZERO_FREESTYLE
 uint8_t powerLock = 1;
 #endif
 /**********************************
 //
 //  POWER MODE
 //
-//    VTX_L
+//    HDZERO_FREESTYLE
 //    0------------25mW   (14dBm)
 //    1------------200mW  (23dBm)
 //    2------------500mW  (27dBm)
 //    3------------1000mW (30dBm)
 
-//    VTX_R, VTX_W
+//    HDZERO_RACE, HDZERO_WHOOP
 //    0------------25mW (14dBm)
 //    1------------200mW(23dBm)
-//    2------------500mW(27dBm)
 **********************************/
 uint8_t RF_POWER = 0;
 uint8_t RF_FREQ = 0;
@@ -296,7 +295,7 @@ void GetVtxParameter() {
         #endif
         #endif
 
-        #ifdef VTX_L
+        #ifdef HDZERO_FREESTYLE
         //powerLock
         powerLock = 0x01 & I2C_Read8_Wait(10, ADDR_EEPROM, EEP_ADDR_POWER_LOCK);
         #endif
@@ -358,7 +357,7 @@ void Init_6300RF(uint8_t freq, uint8_t pwr)
     DM6300_Init(freq, RF_BW);
     DM6300_SetChannel(freq);
 #ifndef VIDEO_PAT
-#ifdef VTX_L
+#ifdef HDZERO_FREESTYLE
     if((pwr == 3) && (!g_IS_ARMED))
         pwr_lmt_done = 0;
     else 
@@ -396,7 +395,7 @@ void Init_HW()
     Init_6300RF(RF_FREQ, RF_POWER);
     DM6300_AUXADC_Calib();
 #else
-    #ifdef VTX_L
+    #ifdef HDZERO_FREESTYLE
         LED_TC3587_Init();
     #endif
 //--------- eeprom --------------------
@@ -518,7 +517,7 @@ void PowerAutoSwitch()
     else if(temp < 80) pwr_offset = 20;
     else               pwr_offset = 20;
 
-    #ifdef VTX_WL
+    #ifdef HDZERO_WHOOP_LITE
     pwr_offset >>= 1;
     #endif
 
@@ -659,7 +658,7 @@ void HeatProtect()
                             debugf("\r\nHeat Protect.");
                             #endif
                             heat_protect = 1;
-                            #ifdef VTX_L
+                            #ifdef HDZERO_FREESTYLE
                             WriteReg(0, 0x8F, 0x00);
                             msp_set_vtx_config(POWER_MAX+1, 0);
                             #else
@@ -712,7 +711,7 @@ void PwrLMT()
                     pwr_tflg = 0;
                     pwr_lmt_sec++;
                     
-                    #ifdef VTX_L
+                    #ifdef HDZERO_FREESTYLE
                     //test: power plus every sec 
                     if(pwr_lmt_sec >= 3){
                         if(RF_POWER == 3){
@@ -788,7 +787,7 @@ void PwrLMT()
                         pwr_tflg = 0;
                         pwr_lmt_sec++;
                         
-                        #ifdef VTX_L
+                        #ifdef HDZERO_FREESTYLE
                         //test: power plus every sec 
                         if(pwr_lmt_sec >= 3){
                             if(RF_POWER == 3){
@@ -808,7 +807,7 @@ void PwrLMT()
                                 SPI_Write(0x3, 0x330, 0x31F); // analog offset 1W
                             }
                         }
-                        #endif//VTX_L
+                        #endif//HDZERO_FREESTYLE
                             
                         #ifdef _DEBUG_MODE
                         debugf("\r\npwr_lmt_sec %x", (uint16_t)pwr_lmt_sec);
@@ -961,7 +960,7 @@ void Imp_RF_Param()
     if(LP_MODE && !g_IS_ARMED)
         return;
 #ifndef VIDEO_PAT
-#ifdef VTX_L
+#ifdef HDZERO_FREESTYLE
     if(RF_POWER == 3 && !g_IS_ARMED)
         pwr_lmt_done = 0;
     else
@@ -1042,7 +1041,7 @@ void Button1_SP()
             
             if(RF_POWER >= POWER_MAX) RF_POWER = 0;
             else RF_POWER++;
-            #ifdef VTX_L
+            #ifdef HDZERO_FREESTYLE
             if(powerLock)
                 RF_POWER &= 0x01;
             #endif
@@ -1055,7 +1054,7 @@ void Button1_SP()
                 cur_pwr = 0;
             }else{
             #ifndef VIDEO_PAT
-            #ifdef VTX_L
+            #ifdef HDZERO_FREESTYLE
                 if(RF_POWER == 3 && !g_IS_ARMED)
                     pwr_lmt_done = 0;
                 else

--- a/src/hardware.h
+++ b/src/hardware.h
@@ -62,13 +62,13 @@ typedef enum{
 
 #define FREQ_MAX        7
 #define FREQ_MAX_EXT    9
-#if defined VTX_L
+#if defined HDZERO_FREESTYLE
     #define POWER_MAX   3
 #else
     #define POWER_MAX   1
 #endif
 
-#ifdef VTX_L
+#ifdef HDZERO_FREESTYLE
     #define LED_BLUE_ON     I2C_Write16(ADDR_TC3587, 0x0014, 0x0000)
     #define LED_BLUE_OFF    I2C_Write16(ADDR_TC3587, 0x0014, 0x8000)
 #else
@@ -94,7 +94,7 @@ void Set_720P60(uint8_t page);
 void Set_720P30(uint8_t page, uint8_t is_43);
 
 void Flicker_LED(uint8_t n);
-#ifdef VTX_L
+#ifdef HDZERO_FREESTYLE
 extern uint8_t powerLock;
 #endif
 extern uint8_t RF_FREQ;

--- a/src/i2c_device.c
+++ b/src/i2c_device.c
@@ -54,7 +54,7 @@ void Init_MAX7315(uint32_t val)
 
 /////////////////////////////////////////////////////////////////
 // TC3587
-#ifdef VTX_L
+#ifdef HDZERO_FREESTYLE
 void LED_TC3587_Init()
 {
     I2C_Write16(ADDR_TC3587, 0x0002, 0x0001);

--- a/src/i2c_device.h
+++ b/src/i2c_device.h
@@ -14,7 +14,7 @@
 
 
 void Init_MAX7315(uint32_t val);
-#ifdef VTX_L
+#ifdef HDZERO_FREESTYLE
 void LED_TC3587_Init();
 #endif
 void Init_TC3587();

--- a/src/mcu.c
+++ b/src/mcu.c
@@ -16,7 +16,6 @@
 #include "lifetime.h"
 
 uint8_t UNUSED = 0;
-uint8_t rf_init_done = 0;
 
 void timer_task();
 void RF_Delay_Init();
@@ -193,7 +192,7 @@ void RF_Delay_Init()
     }
     
     //init_rf
-    if(rf_init_done == 0) {
+    if(!dm6300_init_done) {
 
         if(seconds < WAIT_SA_CONFIG)
             return;
@@ -246,6 +245,5 @@ void RF_Delay_Init()
             
             DM6300_AUXADC_Calib();
         }
-        rf_init_done = 1;
     }
 }

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -853,6 +853,7 @@ void parseMspVtx_V2(uint16_t cmd_u16)
             #endif
             if(nxt_pwr == POWER_MAX+1) {
                 WriteReg(0, 0x8F, 0x10);
+                dm6300_init_done = 0;
                 cur_pwr = POWER_MAX + 2;
                 vtx_pit_save = PIT_0MW;
                 temp_err = 1;
@@ -884,6 +885,7 @@ void parseMspVtx_V2(uint16_t cmd_u16)
             if(cur_pwr != POWER_MAX + 2)
             {
                 WriteReg(0, 0x8F, 0x10);
+                dm6300_init_done = 0;
                 cur_pwr = POWER_MAX + 2;
                 vtx_pit_save = PIT_0MW;
                 temp_err = 1;
@@ -893,7 +895,7 @@ void parseMspVtx_V2(uint16_t cmd_u16)
             if(PIT_MODE)
                 RF_POWER = POWER_MAX + 1;
             
-            if(rf_init_done)
+            if(!dm6300_init_done)
             {
                 if(cur_pwr != RF_POWER)
                 {
@@ -1121,6 +1123,7 @@ void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throt
                 }else{
                     msp_set_vtx_config(POWER_MAX+1, 0); //enter 0mW for SA
                     WriteReg(0, 0x8F, 0x10);
+                    dm6300_init_done = 0;
                     cur_pwr = POWER_MAX + 2;
                     temp_err = 1;
                 }
@@ -1586,6 +1589,7 @@ void set_vtx_param()
                 if(vtx_pit_save == PIT_0MW)
                 {
                     WriteReg(0, 0x8F, 0x10);
+                    dm6300_init_done = 0;
                     //SPI_Write(0x6, 0xFF0, 0x00000018);
                     //SPI_Write(0x3, 0xd00, 0x00000000);
                     #ifdef _DEBUG_MODE

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -678,7 +678,7 @@ void msp_set_vtx_config(uint8_t power, uint8_t save)
     CMS_tx(0x00);       crc ^= 0x00;            //freq_l
     CMS_tx(0x06);       crc ^= 0x06;            //band number
     CMS_tx(0x08);       crc ^= 0x08;            //channel number
-    #ifdef VTX_L
+    #ifdef HDZERO_FREESTYLE
     if(powerLock){
         CMS_tx(3);
         crc ^= (3);      //power number
@@ -845,7 +845,7 @@ void parseMspVtx_V2(uint16_t cmd_u16)
             cur_pwr = POWER_MAX+1;
         }else{
             #ifndef VIDEO_PAT
-            #ifdef VTX_L
+            #ifdef HDZERO_FREESTYLE
             if((RF_POWER == 3) && (!g_IS_ARMED))
                 pwr_lmt_done = 0;
             else
@@ -898,7 +898,7 @@ void parseMspVtx_V2(uint16_t cmd_u16)
                 if(cur_pwr != RF_POWER)
                 {
                     #ifndef VIDEO_PAT
-                    #ifdef VTX_L
+                    #ifdef HDZERO_FREESTYLE
                     if((RF_POWER == 3) && (!g_IS_ARMED))
                         pwr_lmt_done = 0;
                     else 
@@ -1204,7 +1204,7 @@ void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throt
                             else if(VirtualBtn == BTN_RIGHT){
                                 if(SA_lock == 0){
                                     vtx_power++;
-                                    #ifdef VTX_L
+                                    #ifdef HDZERO_FREESTYLE
                                     if(powerLock)
                                         vtx_power &= 0x01;
                                     #endif
@@ -1214,7 +1214,7 @@ void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throt
                             }else if(VirtualBtn == BTN_LEFT){
                                 if(SA_lock==0){
                                     vtx_power--;
-                                    #ifdef VTX_L
+                                    #ifdef HDZERO_FREESTYLE
                                     if(powerLock)
                                         vtx_power &= 0x01;
                                     #endif
@@ -1634,7 +1634,7 @@ void set_vtx_param()
             debugf("\n\rExit PIT or LP");
             #endif
         #ifndef VIDEO_PAT
-        #ifdef VTX_L
+        #ifdef HDZERO_FREESTYLE
             if(RF_POWER == 3 && !g_IS_ARMED)
                 pwr_lmt_done = 0;
             else
@@ -1717,7 +1717,7 @@ void InitVtxTable() {
     power_table[0] = bf_vtx_power_table[0];
     power_table[1] = bf_vtx_power_table[1];
 
-#if defined VTX_L
+#if defined HDZERO_FREESTYLE
     if (!powerLock) {
         // if we dont have power lock, enable 500mw and 1W
         power_table[2] = bf_vtx_power_500mW;

--- a/src/msp_displayport.h
+++ b/src/msp_displayport.h
@@ -162,5 +162,4 @@ extern uint8_t msp_tx_cnt;
 extern uint8_t resolution;
 extern uint8_t first_arm;
 extern uint8_t mspVtxLock;
-extern uint8_t rf_init_done;
 #endif /* __MSP_DISPLAYPORT_H_ */

--- a/src/smartaudio_protocol.c
+++ b/src/smartaudio_protocol.c
@@ -206,6 +206,7 @@ void SA_Update(uint8_t cmd)
                     debugf("\n\rEnter 0mW");
                     #endif
                     WriteReg(0, 0x8F, 0x10); // reset RF_chip
+                    dm6300_init_done = 0;
                     temp_err = 1;
                 }
             }else if(SA_dbm_last == 0) { // Exit 0mW
@@ -351,6 +352,7 @@ void SA_Update(uint8_t cmd)
                     debugf("\n\rSA:Enter 0mW");
                     #endif
                     WriteReg(0, 0x8F, 0x10); // reset RF_chip
+                    dm6300_init_done = 0;
                     temp_err = 1;
                 }else{
                     DM6300_SetPower(POWER_MAX+1, RF_FREQ, 0);
@@ -367,6 +369,7 @@ void SA_Update(uint8_t cmd)
                     debugf("\n\rSA:Enter 0mW");
                     #endif
                     WriteReg(0, 0x8F, 0x10); // reset RF_chip
+                    dm6300_init_done = 0;
                     temp_err = 1;
                 }else{
             		#ifndef VIDEO_PAT

--- a/src/smartaudio_protocol.c
+++ b/src/smartaudio_protocol.c
@@ -99,7 +99,7 @@ void SA_Response(uint8_t cmd)
         tbuf[7] = freq_new_h;           // cur_freq_h
         tbuf[8] = freq_new_l;           // cur_freq_l
         tbuf[9] = SA_dbm;               // power dbm
-        #ifdef VTX_L
+        #ifdef HDZERO_FREESTYLE
         if(powerLock){
             tbuf[10] = 1 + 1;       // amount of power level
             for(i=0;i<=1;i++)
@@ -227,7 +227,7 @@ void SA_Update(uint8_t cmd)
                 }
             }else{
                 cur_pwr = dbm_to_pwr(SA_dbm);
-                #ifdef VTX_L
+                #ifdef HDZERO_FREESTYLE
                 if(powerLock)
                     cur_pwr &= 0x01;
                 #endif
@@ -236,7 +236,7 @@ void SA_Update(uint8_t cmd)
                     pwr_init = cur_pwr;
                 else{
             		#ifndef VIDEO_PAT
-            		#ifdef VTX_L
+            		#ifdef HDZERO_FREESTYLE
                     if((RF_POWER == 3) && (!g_IS_ARMED))
                         pwr_lmt_done = 0;
                     else
@@ -370,7 +370,7 @@ void SA_Update(uint8_t cmd)
                     temp_err = 1;
                 }else{
             		#ifndef VIDEO_PAT
-            		#ifdef VTX_L
+            		#ifdef HDZERO_FREESTYLE
                     if((RF_POWER == 3) && (!g_IS_ARMED)){
                         pwr_lmt_done = 0;
                         cur_pwr = 3;


### PR DESCRIPTION
The bug will cause the VTX to eventually fail to output the expected RF power, the actual RF power will be 2~3dBm lower, and the temperature compensation function will be lost.
Temperature Compensation: When the VTX heats up, the VTX increases the RF output power to counteract thermal decay within a certain temperature range.