### PR TITLE
Format code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,3 +6,4 @@ NamespaceIndentation: All
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 BreakConstructorInitializers: BeforeComma
 IndentPPDirectives: None
+AlignConsecutiveMacros: AcrossComments

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": true,
+}

--- a/src/camera.c
+++ b/src/camera.c
@@ -1,13 +1,12 @@
-
-
 #include "camera.h"
-#include "i2c_device.h"
+
 #include "global.h"
-#include "i2c.h"
-#include "print.h"
-#include "msp_displayport.h"
-#include "isr.h"
 #include "hardware.h"
+#include "i2c.h"
+#include "i2c_device.h"
+#include "isr.h"
+#include "msp_displayport.h"
+#include "print.h"
 
 uint8_t cameraID = 0;
 RuncamV2Profile_e camProfile_EEP;
@@ -21,27 +20,26 @@ cameraConfig_t camCfg_EEP[CAM_PROFILE_NUM];
 // {brightness, sharpness, saturation, contrast, hvFlip, nightMode, wbMode,
 //  wbRed[0], wbRed[1], wbRed[2], wbRed[3],
 //  wbBlue[0], wbBlue[1], wbBlue[2], wbBlue[3],}
-const uint8_t camParameterInit[CAM_PROFILE_NUM][15] = 
-{
-    //Micro V1
+const uint8_t camParameterInit[CAM_PROFILE_NUM][15] = {
+    // Micro V1
     {0x80, 0x01, 0x03, 0x01, 0x00, 0x01, 0x00,
-    0xC7, 0xC7, 0xC7, 0xC7,
-    0xCA, 0xCA, 0xCA, 0xCA},
-    
-    //Micro V2
+     0xC7, 0xC7, 0xC7, 0xC7,
+     0xCA, 0xCA, 0xCA, 0xCA},
+
+    // Micro V2
     {0x80, 0x01, 0x05, 0x01, 0x00, 0x01, 0x00,
-    0xC7, 0xC7, 0xC7, 0xC7,
-    0xCA, 0xCA, 0xCA, 0xCA,},
-    
-    //Nano V2
+     0xC7, 0xC7, 0xC7, 0xC7,
+     0xCA, 0xCA, 0xCA, 0xCA},
+
+    // Nano V2
     {0x80, 0x02, 0x05, 0x01, 0x00, 0x01, 0x00,
-    0xC7, 0xC7, 0xC7, 0xC7,
-    0xCA, 0xCA, 0xCA, 0xCA,},
-    
-    //Nano Lite
+     0xC7, 0xC7, 0xC7, 0xC7,
+     0xCA, 0xCA, 0xCA, 0xCA},
+
+    // Nano Lite
     {0x80, 0x02, 0x05, 0x02, 0x00, 0x01, 0x00,
-    0xC7, 0xC7, 0xC7, 0xC7,
-    0xCA, 0xCA, 0xCA, 0xCA,},
+     0xC7, 0xC7, 0xC7, 0xC7,
+     0xCA, 0xCA, 0xCA, 0xCA},
 };
 
 uint8_t CAM_MODE = CAM_720P60;
@@ -52,8 +50,7 @@ uint8_t bw_changed = 0;
 void camMenuStringUpdate(uint8_t status);
 void camMenuSetVdoRatioInit();
 
-uint8_t CamDetect()
-{
+uint8_t CamDetect() {
     int fps = CAM_720P60;
     uint8_t cycles = 4;
     uint8_t loss = 0;
@@ -93,27 +90,26 @@ uint8_t CamDetect()
         cycles--;
     }
 
-    if(cycles == 0){
+    if (cycles == 0) {
         fps = CAM_720P60_NEW;
         Set_720P60(IS_RX);
         I2C_Write16(ADDR_TC3587, 0x0058, 0x00e0);
-        if(!RUNCAM_Write(RUNCAM_MICRO_V1,0x50, 0x0452484E))
+        if (!RUNCAM_Write(RUNCAM_MICRO_V1, 0x50, 0x0452484E))
             cameraID = RUNCAM_MICRO_V1;
-        else if(!RUNCAM_Write(RUNCAM_MICRO_V2,0x50, 0x0452484E))
+        else if (!RUNCAM_Write(RUNCAM_MICRO_V2, 0x50, 0x0452484E))
             cameraID = RUNCAM_MICRO_V2;
         else
             cameraID = 0;
-        
-        #ifdef _DEBUG_MODE
+
+#ifdef _DEBUG_MODE
         debugf("\r\ncameraID: %x", (uint16_t)cameraID);
-        #endif
+#endif
     }
 
     return fps;
 }
 
-void Cam_Button_INIT()
-{
+void Cam_Button_INIT() {
     WriteReg(0, 0x17, 0xC0);
     WriteReg(0, 0x16, 0x00);
     WriteReg(0, 0x15, 0x02);
@@ -122,177 +118,170 @@ void Cam_Button_INIT()
 
 /////////////////////////////////////////////////////////////////
 // runcam config
-void Runcam_SetBrightness(uint8_t val)
-{
+void Runcam_SetBrightness(uint8_t val) {
     uint32_t d = 0x04004800;
     uint32_t val_32;
 
     camCfg_Cur.brightness = val;
 
-    if(cameraID == RUNCAM_MICRO_V1)
+    if (cameraID == RUNCAM_MICRO_V1)
         d = 0x0452484e;
-    else if(cameraID == RUNCAM_MICRO_V2)
+    else if (cameraID == RUNCAM_MICRO_V2)
         d = 0x04504850;
-    
+
     val_32 = (uint32_t)val;
-    
-    //indoor
+
+    // indoor
     d += val_32;
     d -= CAM_BRIGHTNESS_INITIAL;
-    
-    //outdoor
+
+    // outdoor
     d += (val_32 << 16);
     d -= ((uint32_t)CAM_BRIGHTNESS_INITIAL << 16);
-    
+
     RUNCAM_Write(cameraID, 0x50, d);
-    #ifdef _DEBUG_CAMERA
+#ifdef _DEBUG_CAMERA
     debugf("\r\nRUNCAM brightness:0x%02x", (uint16_t)val);
-    #endif
+#endif
 }
 
-void Runcam_SetSharpness(uint8_t val)
-{
+void Runcam_SetSharpness(uint8_t val) {
     uint32_t d = 0;
 
     camCfg_Cur.sharpness = val;
 
-    if(cameraID == RUNCAM_MICRO_V1)
+    if (cameraID == RUNCAM_MICRO_V1)
         d = 0x03FF0100;
-    else if(cameraID == RUNCAM_MICRO_V2)
+    else if (cameraID == RUNCAM_MICRO_V2)
         d = 0x03FF0000;
-    
-    if(val == 2){
+
+    if (val == 2) {
         RUNCAM_Write(cameraID, 0x0003C4, 0x03FF0000);
         RUNCAM_Write(cameraID, 0x0003CC, 0x28303840);
         RUNCAM_Write(cameraID, 0x0003D8, 0x28303840);
-    }else if(val == 1){
+    } else if (val == 1) {
         RUNCAM_Write(cameraID, 0x0003C4, 0x03FF0000);
         RUNCAM_Write(cameraID, 0x0003CC, 0x14181C20);
         RUNCAM_Write(cameraID, 0x0003D8, 0x14181C20);
-    }else if(val == 0){
-        RUNCAM_Write(cameraID, 0x0003C4, d         );
+    } else if (val == 0) {
+        RUNCAM_Write(cameraID, 0x0003C4, d);
         RUNCAM_Write(cameraID, 0x0003CC, 0x0A0C0E10);
         RUNCAM_Write(cameraID, 0x0003D8, 0x0A0C0E10);
     }
-    #ifdef _DEBUG_CAMERA
+#ifdef _DEBUG_CAMERA
     debugf("\r\nRUNCAM sharpness:0x%02x", (uint16_t)val);
-    #endif
+#endif
 }
 
-uint8_t Runcam_SetSaturation(uint8_t val)
-{
+uint8_t Runcam_SetSaturation(uint8_t val) {
     uint8_t ret = 1;
     uint32_t d = 0x20242626;
-    
 
     camCfg_Cur.saturation = val;
 
-    //initial
-    if(cameraID == RUNCAM_MICRO_V1)
+    // initial
+    if (cameraID == RUNCAM_MICRO_V1)
         d = 0x20242626;
-    else if(cameraID == RUNCAM_MICRO_V2)
+    else if (cameraID == RUNCAM_MICRO_V2)
         d = 0x24282c30;
-    
-    if(val == 0)
+
+    if (val == 0)
         d = 0x00000000;
-    else if(val == 1)
+    else if (val == 1)
         d -= 0x18181414;
-    else if(val == 2)
+    else if (val == 2)
         d -= 0x14141010;
-    else if(val == 3)
+    else if (val == 3)
         d -= 0x0c0c0808;
-    else if(val == 4)//low
+    else if (val == 4) // low
         d -= 0x08080404;
-    else if(val == 5)//normal
+    else if (val == 5) // normal
         ;
-    else if(val == 6) //high
+    else if (val == 6) // high
         d += 0x04041418;
-    #ifdef _DEBUG_CAMERA
+#ifdef _DEBUG_CAMERA
     debugf("\r\nRUNCAM saturation:%02x", (uint16_t)val);
-    #endif
-    
+#endif
+
     ret = RUNCAM_Write(cameraID, 0x0003A4, d);
     return ret;
 }
 
-void Runcam_SetContrast(uint8_t val)
-{
+void Runcam_SetContrast(uint8_t val) {
     uint32_t d = 0x46484A4C;
-    
-     camCfg_Cur.contrast = val;
 
-    if(cameraID == RUNCAM_MICRO_V1)
+    camCfg_Cur.contrast = val;
+
+    if (cameraID == RUNCAM_MICRO_V1)
         d = 0x46484A4C;
-    else if(cameraID == RUNCAM_MICRO_V2)
+    else if (cameraID == RUNCAM_MICRO_V2)
         d = 0x36383a3c;
-    
-    if(val==0)//low
+
+    if (val == 0) // low
         d -= 0x06040404;
-    else if(val == 1)//normal
+    else if (val == 1) // normal
         ;
-    else if(val == 2) //high
+    else if (val == 2) // high
         d += 0x04040404;
-    
+
     RUNCAM_Write(cameraID, 0x00038C, d);
-    #ifdef _DEBUG_CAMERA
+#ifdef _DEBUG_CAMERA
     debugf("\r\nRUNCAM contrast:%02x", (uint16_t)val);
-    #endif
+#endif
 }
 
-void Runcam_SetVdoRatio(uint8_t ratio)
-{
-/*
-    0: 720p60 4:3 default
-    1: 720p60 16:9 crop
-    2: 720p30 16:9 full
-*/
-    if(cameraID != RUNCAM_MICRO_V2)
+void Runcam_SetVdoRatio(uint8_t ratio) {
+    /*
+        0: 720p60 4:3 default
+        1: 720p60 16:9 crop
+        2: 720p30 16:9 full
+    */
+    if (cameraID != RUNCAM_MICRO_V2)
         return;
-    if(ratio == 0)
+    if (ratio == 0)
         RUNCAM_Write(cameraID, 0x000008, 0x0008910B);
-    else if(ratio == 1)
+    else if (ratio == 1)
         RUNCAM_Write(cameraID, 0x000008, 0x00089102);
-    else if(ratio == 2)
+    else if (ratio == 2)
         RUNCAM_Write(cameraID, 0x000008, 0x00089110);
 
-    //save
+    // save
     RUNCAM_Write(cameraID, 0x000694, 0x00000310);
     RUNCAM_Write(cameraID, 0x000694, 0x00000311);
-    #ifdef _DEBUG_CAMERA
+#ifdef _DEBUG_CAMERA
     debugf("\r\nRUNCAM VdoRatio:%02x", (uint16_t)ratio);
-    #endif
+#endif
 }
 
-#if(0)
-uint8_t Runcam_GetVdoFormat(uint8_t cameraID)
-{
-/*
-    0: 720p60 16:9
-    0: 720p60 4:3
-    1: 720p30 16:9
-    1: 720p30 4:3
-*/
+#if (0)
+uint8_t Runcam_GetVdoFormat(uint8_t cameraID) {
+    /*
+        0: 720p60 16:9
+        0: 720p60 4:3
+        1: 720p30 16:9
+        1: 720p30 4:3
+    */
     uint32_t val;
     uint8_t ret = 2;
-    
-    if(cameraID != RUNCAM_MICRO_V2)
+
+    if (cameraID != RUNCAM_MICRO_V2)
         return ret;
-    
-    while(ret == 2){
+
+    while (ret == 2) {
         val = RUNCAM_Read(cameraID, 0x000008);
-        if(val == 0x00089102){              //720p60  16:9
+        if (val == 0x00089102) { // 720p60  16:9
             ret = 0;
             cam_4_3 = 0;
-        }else if(val == 0x0008910B){        //720p60  4:3
+        } else if (val == 0x0008910B) { // 720p60  4:3
             ret = 0;
             cam_4_3 = 1;
-        }else if(val == 0x00089104){        //720p30 16:9
+        } else if (val == 0x00089104) { // 720p30 16:9
             ret = 1;
             cam_4_3 = 0;
-        }else if(val == 0x00089109){        //720p60 4:3
+        } else if (val == 0x00089109) { // 720p60 4:3
             ret = 1;
             cam_4_3 = 1;
-        }else{
+        } else {
             ret = 2;
             cam_4_3 = 0;
         }
@@ -302,85 +291,81 @@ uint8_t Runcam_GetVdoFormat(uint8_t cameraID)
         LED_BLUE_ON;
         led_status = ON;
     }
-    
-    #ifdef _DEBUG_CAMERA
+
+#ifdef _DEBUG_CAMERA
     debugf("\r\nVdoFormat:%02x, 4_3:%02x", (uint16_t)ret, (uint16_t)cam_4_3);
-    #endif
+#endif
     return ret;
 }
 #endif
 
-void Runcam_SetHVFlip(uint8_t val)
-{
-    if(cameraID != RUNCAM_MICRO_V2)
+void Runcam_SetHVFlip(uint8_t val) {
+    if (cameraID != RUNCAM_MICRO_V2)
         return;
-    
+
     camCfg_Cur.hvFlip = val;
 
-    if(val == 0)
+    if (val == 0)
         RUNCAM_Write(cameraID, 0x000040, 0x0022ffa9);
-    else if(val==1)
+    else if (val == 1)
         RUNCAM_Write(cameraID, 0x000040, 0x002effa9);
 }
 
-void Runcam_SetNightMode(uint8_t val)
-{
-/*
-    0: night mode off
-    1: night mode on
-*/
-    if(cameraID != RUNCAM_MICRO_V2)
+void Runcam_SetNightMode(uint8_t val) {
+    /*
+        0: night mode off
+        1: night mode on
+    */
+    if (cameraID != RUNCAM_MICRO_V2)
         return;
 
     camCfg_Cur.nightMode = val;
 
-    if(val == 1){  //Max gain on
+    if (val == 1) { // Max gain on
         RUNCAM_Write(cameraID, 0x000070, 0x10000040);
-        //RUNCAM_Write(cameraID, 0x000070, 0x04000040);
+        // RUNCAM_Write(cameraID, 0x000070, 0x04000040);
         RUNCAM_Write(cameraID, 0x000718, 0x28002700);
         RUNCAM_Write(cameraID, 0x00071c, 0x29002800);
         RUNCAM_Write(cameraID, 0x000720, 0x29002900);
-    }else if(val == 0){ //Max gain off
+    } else if (val == 0) { // Max gain off
         RUNCAM_Write(cameraID, 0x000070, 0x10000040);
-        //RUNCAM_Write(cameraID, 0x000070, 0x04000040);
+        // RUNCAM_Write(cameraID, 0x000070, 0x04000040);
         RUNCAM_Write(cameraID, 0x000718, 0x30002900);
         RUNCAM_Write(cameraID, 0x00071c, 0x32003100);
         RUNCAM_Write(cameraID, 0x000720, 0x34003300);
     }
-    
-    //save
+
+    // save
     RUNCAM_Write(cameraID, 0x000694, 0x00000310);
     RUNCAM_Write(cameraID, 0x000694, 0x00000311);
-    #ifdef _DEBUG_CAMERA
+#ifdef _DEBUG_CAMERA
     debugf("\r\nRUNCAM NightMode:%02x", (uint16_t)val);
-    #endif
+#endif
 }
 
-void Runcam_SetWB(uint8_t* wbRed, uint8_t* wbBlue, uint8_t wbMode)
-{
-    uint32_t wbRed_u32  = 0x02000000;
+void Runcam_SetWB(uint8_t *wbRed, uint8_t *wbBlue, uint8_t wbMode) {
+    uint32_t wbRed_u32 = 0x02000000;
     uint32_t wbBlue_u32 = 0x00000000;
     uint8_t i;
-    
+
     camCfg_Cur.wbMode = wbMode;
-    for(i=0;i<WBMODE_MAX;i++)
-    {
+    for (i = 0; i < WBMODE_MAX; i++) {
         camCfg_Cur.wbRed[i] = wbRed[i];
         camCfg_Cur.wbBlue[i] = wbBlue[i];
     }
 
-    if(wbMode){
-        wbRed_u32 += ((uint32_t)wbRed[wbMode-1] << 2);
-        wbBlue_u32 += ((uint32_t)wbBlue[wbMode-1] << 2);
-        wbRed_u32 ++;
-        wbBlue_u32 ++;
+    if (wbMode) {
+        wbRed_u32 += ((uint32_t)wbRed[wbMode - 1] << 2);
+        wbBlue_u32 += ((uint32_t)wbBlue[wbMode - 1] << 2);
+        wbRed_u32++;
+        wbBlue_u32++;
     }
 
-    if(wbMode){//MWB
+    if (wbMode) { // MWB
         RUNCAM_Write(cameraID, 0x0001b8, 0x020b007b);
         RUNCAM_Write(cameraID, 0x000204, wbRed_u32);
         RUNCAM_Write(cameraID, 0x000208, wbBlue_u32);
-    }else{//AWB
+    } else { // AWB
         RUNCAM_Write(cameraID, 0x0001b8, 0x020b0079);
     }
 }
@@ -400,7 +385,7 @@ void camera_check_and_save_parameters() {
     if (cameraID == 0)
         return;
 
-    if (camProfile_EEP >= Profile_Max) 
+    if (camProfile_EEP >= Profile_Max)
         camProfile_EEP = Profile_MicroV2;
 
     for (i = 0; i < CAM_PROFILE_NUM; i++) {
@@ -477,20 +462,19 @@ void GetCamCfg_EEP(void) {
 
     camera_check_and_save_parameters();
 }
-void GetCamCfg(uint8_t USE_EEP_PROFILE)
-{
+void GetCamCfg(uint8_t USE_EEP_PROFILE) {
     uint8_t i;
     uint8_t index = 0;
 
-    if(cameraID == 0)
+    if (cameraID == 0)
         return;
 
-    if(USE_EEP_PROFILE)
+    if (USE_EEP_PROFILE)
         camProfile = camProfile_EEP;
 
-    if(cameraID == RUNCAM_MICRO_V1)
+    if (cameraID == RUNCAM_MICRO_V1)
         index = 0;
-    else if(cameraID == RUNCAM_MICRO_V2)
+    else if (cameraID == RUNCAM_MICRO_V2)
         index = camProfile + 1;
 
     camCfg.brightness = camCfg_EEP[index].brightness;
@@ -500,13 +484,12 @@ void GetCamCfg(uint8_t USE_EEP_PROFILE)
     camCfg.hvFlip = camCfg_EEP[index].hvFlip;
     camCfg.nightMode = camCfg_EEP[index].nightMode;
     camCfg.wbMode = camCfg_EEP[index].wbMode;
-    for(i=0;i<WBMODE_MAX;i++)
-    {
+    for (i = 0; i < WBMODE_MAX; i++) {
         camCfg.wbRed[i] = camCfg_EEP[index].wbRed[i];
         camCfg.wbBlue[i] = camCfg_EEP[index].wbBlue[i];
     }
 
-    #ifdef _DEBUG_CAMERA
+#ifdef _DEBUG_CAMERA
     debugf("\r\nGetCamCfg->camProfile: 0x%02x", (uint16_t)camProfile);
     debugf("\r\nGetCamCfg->index:      0x%02x", (uint16_t)index);
     debugf("\r\nGetCamCfg->brightness: 0x%02x", (uint16_t)camCfg.brightness);
@@ -516,17 +499,16 @@ void GetCamCfg(uint8_t USE_EEP_PROFILE)
     debugf("\r\nGetCamCfg->hvFlip:     0x%02x", (uint16_t)camCfg.hvFlip);
     debugf("\r\nGetCamCfg->nightMode:  0x%02x", (uint16_t)camCfg.nightMode);
     debugf("\r\nGetCamCfg->wbMode:     0x%02x", (uint16_t)camCfg.wbMode);
-    #endif
+#endif
 }
 
-void GetCamCfg_Menu(uint8_t INIT_PROFILE)
-{
+void GetCamCfg_Menu(uint8_t INIT_PROFILE) {
     uint8_t i;
 
-    if(cameraID == 0)
+    if (cameraID == 0)
         return;
 
-    if(INIT_PROFILE)
+    if (INIT_PROFILE)
         camProfile_Menu = camProfile;
 
     camCfg_Menu.brightness = camCfg.brightness;
@@ -536,23 +518,20 @@ void GetCamCfg_Menu(uint8_t INIT_PROFILE)
     camCfg_Menu.hvFlip = camCfg.hvFlip;
     camCfg_Menu.nightMode = camCfg.nightMode;
     camCfg_Menu.wbMode = camCfg.wbMode;
-    for(i=0;i<WBMODE_MAX;i++)
-    {
+    for (i = 0; i < WBMODE_MAX; i++) {
         camCfg_Menu.wbRed[i] = camCfg.wbRed[i];
         camCfg_Menu.wbBlue[i] = camCfg.wbBlue[i];
     }
 }
 
-void SaveCamCfg_Menu(void)
-{
+void SaveCamCfg_Menu(void) {
     uint8_t i;
     uint8_t index = 0;
 
-    if(cameraID == 0)
+    if (cameraID == 0)
         return;
 
-    if(cameraID == RUNCAM_MICRO_V2)
-    {
+    if (cameraID == RUNCAM_MICRO_V2) {
         camProfile = camProfile_Menu;
         index = 1 + camProfile;
     }
@@ -563,8 +542,7 @@ void SaveCamCfg_Menu(void)
     camCfg.hvFlip = camCfg_Menu.hvFlip;
     camCfg.nightMode = camCfg_Menu.nightMode;
     camCfg.wbMode = camCfg_Menu.wbMode;
-    for(i=0;i<WBMODE_MAX;i++)
-    {
+    for (i = 0; i < WBMODE_MAX; i++) {
         camCfg.wbRed[i] = camCfg_Menu.wbRed[i];
         camCfg.wbBlue[i] = camCfg_Menu.wbBlue[i];
     }
@@ -577,15 +555,14 @@ void SaveCamCfg_Menu(void)
     camCfg_EEP[index].hvFlip = camCfg.hvFlip;
     camCfg_EEP[index].nightMode = camCfg.nightMode;
     camCfg_EEP[index].wbMode = camCfg.wbMode;
-    for(i=0;i<WBMODE_MAX;i++)
-    {
+    for (i = 0; i < WBMODE_MAX; i++) {
         camCfg_EEP[index].wbRed[i] = camCfg.wbRed[i];
         camCfg_EEP[index].wbBlue[i] = camCfg.wbBlue[i];
     }
 
     camera_check_and_save_parameters();
 
-    #ifdef _DEBUG_CAMERA
+#ifdef _DEBUG_CAMERA
     debugf("\r\nSaveCamCfg->camProfile: 0x%02x", (uint16_t)camProfile_EEP);
     debugf("\r\nSaveCamCfg->index:      0x%02x", (uint16_t)index);
     debugf("\r\nSaveCamCfg->brightness: 0x%02x", (uint16_t)camCfg_EEP[index].brightness);
@@ -595,20 +572,18 @@ void SaveCamCfg_Menu(void)
     debugf("\r\nSaveCamCfg->hvFlip:     0x%02x", (uint16_t)camCfg_EEP[index].hvFlip);
     debugf("\r\nSaveCamCfg->nightMode:  0x%02x", (uint16_t)camCfg_EEP[index].nightMode);
     debugf("\r\nSaveCamCfg->wbMode:     0x%02x", (uint16_t)camCfg_EEP[index].wbMode);
-    #endif
+#endif
 }
 
-void SetCamCfg(cameraConfig_t *cfg, uint8_t INIT)
-{
-    uint8_t i,j;
+void SetCamCfg(cameraConfig_t *cfg, uint8_t INIT) {
+    uint8_t i, j;
 
-    if(cfg == 0)
+    if (cfg == 0)
         return;
-    if(cameraID == 0)
+    if (cameraID == 0)
         return;
 
-    if(INIT)
-    {
+    if (INIT) {
         Runcam_SetBrightness(cfg->brightness);
         Runcam_SetSharpness(cfg->sharpness);
         Runcam_SetSaturation(cfg->saturation);
@@ -616,51 +591,45 @@ void SetCamCfg(cameraConfig_t *cfg, uint8_t INIT)
         Runcam_SetHVFlip(cfg->hvFlip);
         Runcam_SetNightMode(cfg->nightMode);
         Runcam_SetWB(cfg->wbRed, cfg->wbBlue, cfg->wbMode);
-    }
-    else
-    {
-        if(camCfg_Cur.brightness != cfg->brightness)
+    } else {
+        if (camCfg_Cur.brightness != cfg->brightness)
             Runcam_SetBrightness(cfg->brightness);
 
-        if(camCfg_Cur.sharpness != cfg->sharpness)
+        if (camCfg_Cur.sharpness != cfg->sharpness)
             Runcam_SetSharpness(cfg->sharpness);
 
-        if(camCfg_Cur.saturation != cfg->saturation)
+        if (camCfg_Cur.saturation != cfg->saturation)
             Runcam_SetSaturation(cfg->saturation);
 
-        if(camCfg_Cur.contrast != cfg->contrast)
+        if (camCfg_Cur.contrast != cfg->contrast)
             Runcam_SetContrast(cfg->contrast);
 
-        if(camCfg_Cur.hvFlip != cfg->hvFlip)
+        if (camCfg_Cur.hvFlip != cfg->hvFlip)
             Runcam_SetHVFlip(cfg->hvFlip);
 
-        if(camCfg_Cur.nightMode != cfg->nightMode)
+        if (camCfg_Cur.nightMode != cfg->nightMode)
             Runcam_SetNightMode(cfg->nightMode);
 
         j = 0;
-        if(camCfg_Cur.wbMode != cfg->wbMode)
+        if (camCfg_Cur.wbMode != cfg->wbMode)
             j = 1;
-        else
-        {
-            for(i=0;i<WBMODE_MAX;i++)
-            {
-                if(camCfg_Cur.wbRed[i] != cfg->wbRed[i])
+        else {
+            for (i = 0; i < WBMODE_MAX; i++) {
+                if (camCfg_Cur.wbRed[i] != cfg->wbRed[i])
                     j |= 1;
-                if(camCfg_Cur.wbBlue[i] != cfg->wbBlue[i])
+                if (camCfg_Cur.wbBlue[i] != cfg->wbBlue[i])
                     j |= 1;
             }
         }
-        if(j==1)
+        if (j == 1)
             Runcam_SetWB(cfg->wbRed, cfg->wbBlue, cfg->wbMode);
-
     }
-    #ifdef _DEBUG_MODE
-        debugf("\r\nSet camera parameter done!");
-    #endif
+#ifdef _DEBUG_MODE
+    debugf("\r\nSet camera parameter done!");
+#endif
 }
 
-void CameraInit()
-{
+void CameraInit() {
     CAM_MODE = CamDetect();
     Cam_Button_INIT();
 
@@ -669,577 +638,514 @@ void CameraInit()
     SetCamCfg(&camCfg, 1);
 }
 
-void Cam_Button_ENTER() { WriteReg(0, 0x14, 0x32);}
-void Cam_Button_RIGHT() { WriteReg(0, 0x14, 0x58);}
-void Cam_Button_DOWN()  { WriteReg(0, 0x14, 0x64);}
-void Cam_Button_LEFT()  { WriteReg(0, 0x14, 0x3F);}
-void Cam_Button_UP()    { WriteReg(0, 0x14, 0x4B);}
-void Cam_Button_MID()   { WriteReg(0, 0x14, 0x00);}
+void Cam_Button_ENTER() { WriteReg(0, 0x14, 0x32); }
+void Cam_Button_RIGHT() { WriteReg(0, 0x14, 0x58); }
+void Cam_Button_DOWN() { WriteReg(0, 0x14, 0x64); }
+void Cam_Button_LEFT() { WriteReg(0, 0x14, 0x3F); }
+void Cam_Button_UP() { WriteReg(0, 0x14, 0x4B); }
+void Cam_Button_MID() { WriteReg(0, 0x14, 0x00); }
 
 #ifdef USE_MSP
-uint8_t camStatusUpdate(uint8_t op)
-{
+uint8_t camStatusUpdate(uint8_t op) {
     uint8_t ret = 0;
     uint8_t i;
     static uint8_t step = 1;
     static uint8_t cnt;
     static uint8_t last_op = BTN_RIGHT;
 
-    if(op >= BTN_INVALID)
+    if (op >= BTN_INVALID)
         return ret;
 
-    if(cameraID == 0)
-    {
-        switch(op)
-        {
-            case BTN_UP:    Cam_Button_UP();    break;
-            case BTN_DOWN:  Cam_Button_DOWN();  break;
-            case BTN_LEFT:  Cam_Button_LEFT();  break;
-            case BTN_RIGHT: Cam_Button_RIGHT(); break;
-            case BTN_ENTER: Cam_Button_ENTER(); break;
-            case BTN_MID:   Cam_Button_MID();   break;
-            default: break;
-        }//switch(op)
+    if (cameraID == 0) {
+        switch (op) {
+        case BTN_UP:
+            Cam_Button_UP();
+            break;
+        case BTN_DOWN:
+            Cam_Button_DOWN();
+            break;
+        case BTN_LEFT:
+            Cam_Button_LEFT();
+            break;
+        case BTN_RIGHT:
+            Cam_Button_RIGHT();
+            break;
+        case BTN_ENTER:
+            Cam_Button_ENTER();
+            break;
+        case BTN_MID:
+            Cam_Button_MID();
+            break;
+        default:
+            break;
+        } // switch(op)
 
         return ret;
     }
 
-    switch(camMenuStatus)
-    {
-        case CAM_STATUS_IDLE:
-            if (op == BTN_MID)
-            {
-                GetCamCfg_Menu(1);
-                cnt = 0;
-                if(cameraID == RUNCAM_MICRO_V1)
-                    camMenuStatus = CAM_STATUS_BRIGHTNESS;
-                else
-                    camMenuStatus = CAM_STATUS_PROFILE;
-            }
-        break;
-
-        case CAM_STATUS_PROFILE:
-            if(last_op != BTN_MID)
-                break;
-
-            if (op == BTN_UP)
-                camMenuStatus = CAM_STATUS_SAVE_EXIT;
-            else if (op == BTN_DOWN)
+    switch (camMenuStatus) {
+    case CAM_STATUS_IDLE:
+        if (op == BTN_MID) {
+            GetCamCfg_Menu(1);
+            cnt = 0;
+            if (cameraID == RUNCAM_MICRO_V1)
                 camMenuStatus = CAM_STATUS_BRIGHTNESS;
-            else if (op == BTN_LEFT)
-            {
-                camProfile_Menu --;
-                if(camProfile_Menu  >= Profile_Max)
-                    camProfile_Menu = Profile_Max - 1;
-        
-                camProfile = camProfile_Menu;
-                GetCamCfg(0);
-                GetCamCfg_Menu(0);
-                SetCamCfg(&camCfg_Menu, 0);
-            }
-            else if (op == BTN_RIGHT)
-            {
-                camProfile_Menu ++;
-                if(camProfile_Menu >= Profile_Max)
-                    camProfile_Menu = 0;
-        
-                camProfile = camProfile_Menu;
-                GetCamCfg(0);
-                GetCamCfg_Menu(0);
-                SetCamCfg(&camCfg_Menu, 0);
-            }
+            else
+                camMenuStatus = CAM_STATUS_PROFILE;
+        }
         break;
 
-        case CAM_STATUS_BRIGHTNESS:
-            if (op == BTN_UP)
-            {
-                if(cameraID == RUNCAM_MICRO_V1)
-                    camMenuStatus = CAM_STATUS_SAVE_EXIT;
-                else
-                    camMenuStatus = CAM_STATUS_PROFILE;
-            }
-            else if (op == BTN_DOWN)
-                camMenuStatus = CAM_STATUS_SHARPNESS;
-            else if (op == BTN_RIGHT)
-            {
-                if (last_op == BTN_MID)
-                {
-                    cnt = 0;
-                    step = 1;
-                }
-                else if (last_op == BTN_RIGHT)
-                {
-                    cnt++;
-                    cnt &= 0x7f;
-                }
-
-                step = cnt >> 3;
-                if (!step)
-                    step = 1;
-
-                camCfg_Menu.brightness += step;
-                if (camCfg_Menu.brightness > BRIGHTNESS_MAX)
-                    camCfg_Menu.brightness = BRIGHTNESS_MAX;
-
-                Runcam_SetBrightness(camCfg_Menu.brightness);
-            }
-            else if (op == BTN_LEFT)
-            {
-                if (last_op == BTN_MID)
-                {
-                    cnt = 0;
-                    step = 1;
-                } 
-                else if (last_op == BTN_LEFT)
-                {
-                    cnt++;
-                    cnt &= 0x7f;
-                }
-
-                step = cnt >> 3;
-                if (!step)
-                    step = 1;
-
-                camCfg_Menu.brightness -= step;
-                if (camCfg_Menu.brightness < BRIGHTNESS_MIN)
-                    camCfg_Menu.brightness = BRIGHTNESS_MIN;
-
-                Runcam_SetBrightness(camCfg_Menu.brightness);
-            }
-        break;
-            
-        case CAM_STATUS_SHARPNESS:
-            if(last_op != BTN_MID)
-                break;
-
-            if(op == BTN_UP)
-                camMenuStatus = CAM_STATUS_BRIGHTNESS;
-            else if(op == BTN_DOWN)
-                camMenuStatus = CAM_STATUS_CONTRAST;
-            else if(op == BTN_RIGHT)
-            {
-                camCfg_Menu.sharpness ++;
-                if(camCfg_Menu.sharpness > SHARPNESS_MAX)
-                    camCfg_Menu.sharpness = SHARPNESS_MAX;
-                Runcam_SetSharpness(camCfg_Menu.sharpness);
-            }
-            else if(op == BTN_LEFT)
-            {
-                camCfg_Menu.sharpness --;
-                if(camCfg_Menu.sharpness > SHARPNESS_MAX)
-                    camCfg_Menu.sharpness = SHARPNESS_MIN;
-                Runcam_SetSharpness(camCfg_Menu.sharpness);
-            }
-        break;
-        
-        case CAM_STATUS_CONTRAST:
-            if(last_op != BTN_MID)
-                break;
-
-            if(op == BTN_UP)
-               camMenuStatus = CAM_STATUS_SHARPNESS;
-            if(op == BTN_DOWN)
-                camMenuStatus = CAM_STATUS_SATURATION;
-            else if(op == BTN_RIGHT)
-            {
-                camCfg_Menu.contrast ++;
-                if(camCfg_Menu.contrast > CONTRAST_MAX)
-                    camCfg_Menu.contrast = CONTRAST_MAX;
-                Runcam_SetContrast(camCfg_Menu.contrast);
-            }
-            else if(op == BTN_LEFT)
-            {
-                camCfg_Menu.contrast --;
-                if(camCfg_Menu.contrast > CONTRAST_MAX)
-                    camCfg_Menu.contrast = CONTRAST_MIN;
-                Runcam_SetContrast(camCfg_Menu.contrast);
-            }
-        break;
-
-        case CAM_STATUS_SATURATION:
-            if(last_op != BTN_MID)
-                break;
-
-            if(op == BTN_UP)
-                camMenuStatus = CAM_STATUS_CONTRAST;
-            else if(op == BTN_DOWN)
-                camMenuStatus = CAM_STATUS_WBMODE;
-            else if(op == BTN_RIGHT)
-            {
-                camCfg_Menu.saturation ++;
-                if(camCfg_Menu.saturation > SATURATION_MAX)
-                    camCfg_Menu.saturation = SATURATION_MAX;
-                Runcam_SetSaturation(camCfg_Menu.saturation);
-            }
-            else if(op == BTN_LEFT)
-            {
-                camCfg_Menu.saturation --;
-                if(camCfg_Menu.saturation > SATURATION_MAX)
-                    camCfg_Menu.saturation = SATURATION_MIN;
-                Runcam_SetSaturation(camCfg_Menu.saturation);
-            }
-        break;
-
-        case CAM_STATUS_WBMODE:
-            if(last_op != BTN_MID)
-                break;
-
-            if(op == BTN_UP)
-                camMenuStatus = CAM_STATUS_SATURATION;
-            else if(op == BTN_DOWN)
-            {
-                if(camCfg_Menu.wbMode)
-                    camMenuStatus = CAM_STATUS_WBRED;
-                else if(cameraID == RUNCAM_MICRO_V2)
-                    camMenuStatus = CAM_STATUS_HVFLIP;
-                else
-                    camMenuStatus = CAM_STATUS_RESET;
-            }
-            else if(op == BTN_RIGHT)
-            {
-                camCfg_Menu.wbMode ++;
-                if(camCfg_Menu.wbMode > WBMODE_MAX)
-                    camCfg_Menu.wbMode = WBMODE_MAX;
-                Runcam_SetWB(camCfg_Menu.wbRed, camCfg_Menu.wbBlue, camCfg_Menu.wbMode);
-            }
-            else if(op == BTN_LEFT)
-            {
-                camCfg_Menu.wbMode --;
-                if(camCfg_Menu.wbMode > WBMODE_MAX)
-                    camCfg_Menu.wbMode = WBMODE_MIN;
-                Runcam_SetWB(camCfg_Menu.wbRed, camCfg_Menu.wbBlue, camCfg_Menu.wbMode);
-            }
-        break;
-
-        case CAM_STATUS_WBRED:
-            if(op == BTN_UP)
-                camMenuStatus = CAM_STATUS_WBMODE;
-            else if(op == BTN_DOWN)
-                camMenuStatus = CAM_STATUS_WBBLUE;
-            else if(op == BTN_RIGHT)
-            {
-                if(last_op == BTN_MID)
-                {
-                    cnt = 0;
-                    step = 1;
-                }
-                else if(last_op == BTN_RIGHT)
-                {
-                    cnt++;
-                    cnt &= 0x7f;
-                }
-                
-                step = cnt >> 3;
-                if(!step) step = 1;
-                camCfg_Menu.wbRed[camCfg_Menu.wbMode-1] += step;
-
-                Runcam_SetWB(camCfg_Menu.wbRed, camCfg_Menu.wbBlue, camCfg_Menu.wbMode);
-            }
-            else if(op == BTN_LEFT)
-            {
-                if(last_op == BTN_MID)
-                {
-                    cnt = 0;
-                    step = 1;
-                }
-                else if(last_op == BTN_LEFT)
-                {
-                    cnt++;
-                    cnt &= 0x7f;
-                }
-                
-                step = cnt >> 3;
-                if(!step) step = 1;
-                camCfg_Menu.wbRed[camCfg_Menu.wbMode-1] -= step;
-
-                Runcam_SetWB(camCfg_Menu.wbRed, camCfg_Menu.wbBlue, camCfg_Menu.wbMode);
-            }
-        break;
-
-        case CAM_STATUS_WBBLUE:
-            if(op == BTN_UP)
-                camMenuStatus = CAM_STATUS_WBRED;
-            else if(op == BTN_DOWN)
-            {
-                if(cameraID == RUNCAM_MICRO_V2)
-                    camMenuStatus = CAM_STATUS_HVFLIP;
-                else
-                    camMenuStatus = CAM_STATUS_RESET;
-            }
-            else if(op == BTN_RIGHT)
-            {
-                if(last_op == BTN_MID)
-                {
-                    cnt = 0;
-                    step = 1;
-                }
-                else if(last_op == BTN_RIGHT)
-                {
-                    cnt++;
-                    cnt &= 0x7f;
-                }
-                
-                step = cnt >> 3;
-                if(!step) step = 1;
-                camCfg_Menu.wbBlue[camCfg_Menu.wbMode-1] += step;
-
-                Runcam_SetWB(camCfg_Menu.wbRed, camCfg_Menu.wbBlue, camCfg_Menu.wbMode);
-            }
-            else if(op == BTN_LEFT)
-            {
-                if(last_op == BTN_MID)
-                {
-                    cnt = 0;
-                    step = 1;
-                }
-                else if(last_op == BTN_LEFT)
-                {
-                    cnt++;
-                    cnt &= 0x7f;
-                }
-                
-                step = cnt >> 3;
-                if(!step) step = 1;
-                camCfg_Menu.wbBlue[camCfg_Menu.wbMode-1] -= step;
-
-                Runcam_SetWB(camCfg_Menu.wbRed, camCfg_Menu.wbBlue, camCfg_Menu.wbMode);
-            }
-        break;
-
-        case CAM_STATUS_HVFLIP:
-            if(last_op != BTN_MID)
-                break;
-
-            if(op == BTN_UP)
-            {
-                if(camCfg_Menu.wbMode)
-                    camMenuStatus = CAM_STATUS_WBBLUE;
-                else
-                    camMenuStatus = CAM_STATUS_WBMODE;
-            }
-            else if(op == BTN_DOWN)
-            {
-                if(cameraID == RUNCAM_MICRO_V2)
-                    camMenuStatus = CAM_STATUS_NIGHTMODE;
-                else
-                    camMenuStatus = CAM_STATUS_RESET;
-            }
-            else if(op == BTN_RIGHT || op == BTN_LEFT)
-            {
-                camCfg_Menu.hvFlip = 1 - camCfg_Menu.hvFlip;
-                Runcam_SetHVFlip(camCfg_Menu.hvFlip);
-            }
-        break;
-
-        case CAM_STATUS_NIGHTMODE:
-            if(last_op != BTN_MID)
-                break;
-                
-            if(op == BTN_UP)
-            {
-                if(cameraID == RUNCAM_MICRO_V2)
-                    camMenuStatus = CAM_STATUS_HVFLIP;
-                else if(camCfg_Menu.wbMode)
-                    camMenuStatus = CAM_STATUS_WBBLUE;
-                else
-                    camMenuStatus = CAM_STATUS_WBMODE;
-            }
-            else if(op == BTN_DOWN)
-            {
-                if(cameraID == RUNCAM_MICRO_V2)
-                    camMenuStatus = CAM_STATUS_VDO_RATIO;
-                else
-                    camMenuStatus = CAM_STATUS_RESET;
-            }
-            else if(op == BTN_RIGHT || op == BTN_LEFT)
-            {
-                camCfg_Menu.nightMode = 1 - camCfg_Menu.nightMode;
-                Runcam_SetNightMode(camCfg_Menu.nightMode);
-            }
-        break;
-
-        case CAM_STATUS_VDO_RATIO:
-            if(last_op != BTN_MID)
-                break;
-
-            if(op == BTN_UP)
-            {
-                if(cameraID == RUNCAM_MICRO_V2)
-                    camMenuStatus = CAM_STATUS_NIGHTMODE;
-                else if(camCfg_Menu.wbMode)
-                    camMenuStatus = CAM_STATUS_WBBLUE;
-                else
-                    camMenuStatus = CAM_STATUS_WBMODE;
-            }
-            else if(op == BTN_DOWN)
-                camMenuStatus = CAM_STATUS_RESET;
-            else if(op == BTN_RIGHT)
-            {
-                camMenuSetVdoRatioInit();
-                camMenuStatus = CAM_STATUS_SET_VDO_RATIO_4_3;
-            }
-        break;
-
-        case CAM_STATUS_SET_VDO_RATIO_4_3:
-            if(last_op != BTN_MID)
-                break;
-
-            if(op == BTN_UP)
-                camMenuStatus = CAM_STATUS_SET_VDO_RATIO_RETURN;
-            else if(op == BTN_DOWN)
-                camMenuStatus = CAM_STATUS_SET_VDO_RATIO_16_9_CROP;
-            else if(op == BTN_RIGHT)
-            {
-                Runcam_SetVdoRatio(0);
-                memset(osd_buf,0x20,sizeof(osd_buf));
-                strcpy(osd_buf[1]+osd_menu_offset+2, " NEED TO REPOWER VTX");
-                camMenuStatus = CAM_STATUS_REPOWER;
-            }
-        break;
-
-        case CAM_STATUS_SET_VDO_RATIO_16_9_CROP:
-            if(last_op != BTN_MID)
-                break;
-
-            if(op == BTN_UP)
-                camMenuStatus = CAM_STATUS_SET_VDO_RATIO_4_3;
-            else if(op == BTN_DOWN)
-                camMenuStatus = CAM_STATUS_SET_VDO_RATIO_16_9_FULL;
-            else if(op == BTN_RIGHT)
-            {
-                Runcam_SetVdoRatio(1);
-                memset(osd_buf,0x20,sizeof(osd_buf));
-                strcpy(osd_buf[1]+osd_menu_offset+2, " NEED TO REPOWER VTX");
-                camMenuStatus = CAM_STATUS_REPOWER;
-            }
-        break;
-
-        case CAM_STATUS_SET_VDO_RATIO_16_9_FULL:
-            if(last_op != BTN_MID)
-                break;
-
-            if(op == BTN_UP)
-                camMenuStatus = CAM_STATUS_SET_VDO_RATIO_16_9_CROP;
-            else if(op == BTN_DOWN)
-                camMenuStatus = CAM_STATUS_SET_VDO_RATIO_RETURN;
-            else if(op == BTN_RIGHT)
-            {
-                Runcam_SetVdoRatio(2);
-                memset(osd_buf,0x20,sizeof(osd_buf));
-                strcpy(osd_buf[1]+osd_menu_offset+2, " NEED TO REPOWER VTX");
-                camMenuStatus = CAM_STATUS_REPOWER;
-            }
-        break;
-
-        case CAM_STATUS_SET_VDO_RATIO_RETURN:
-            if(last_op != BTN_MID)
-                break;
-
-            if(op == BTN_UP)
-                camMenuStatus = CAM_STATUS_SET_VDO_RATIO_16_9_FULL;
-            else if(op == BTN_DOWN)
-                    camMenuStatus = CAM_STATUS_SET_VDO_RATIO_4_3;
-            else if(op == BTN_RIGHT)
-            {
-                camMenuInit();
-                camMenuStatus = CAM_STATUS_VDO_RATIO;
-            }
-        break;
-
-        case CAM_STATUS_RESET:
-            if(last_op != BTN_MID)
-                break;
-
-            if(op == BTN_UP)
-            {
-                if(cameraID == RUNCAM_MICRO_V2)
-                    camMenuStatus = CAM_STATUS_VDO_RATIO;
-                else if(camCfg_Menu.wbMode)
-                    camMenuStatus = CAM_STATUS_WBBLUE;
-                else
-                    camMenuStatus = CAM_STATUS_WBMODE;
-            }
-            else if(op == BTN_DOWN)
-                camMenuStatus = CAM_STATUS_EXIT;
-            else if(op == BTN_RIGHT)
-            {
-                if(cameraID == RUNCAM_MICRO_V1)
-                {
-                    camCfg_Menu.brightness = camParameterInit[0][0];
-                    camCfg_Menu.sharpness = camParameterInit[0][1];
-                    camCfg_Menu.saturation = camParameterInit[0][2];
-                    camCfg_Menu.contrast = camParameterInit[0][3];
-                    camCfg_Menu.hvFlip = camParameterInit[0][4];
-                    camCfg_Menu.nightMode = camParameterInit[0][5];
-                    camCfg_Menu.wbMode = camParameterInit[0][6];
-                    for(i=0;i<WBMODE_MAX;i++)
-                    {
-                        camCfg_Menu.wbRed[i] = camParameterInit[0][7+i];
-                        camCfg_Menu.wbBlue[i] = camParameterInit[0][11+i];
-                    }
-                }
-                else if(cameraID == RUNCAM_MICRO_V2)
-                {
-                    camCfg_Menu.brightness = camParameterInit[camProfile_Menu+1][0];
-                    camCfg_Menu.sharpness = camParameterInit[camProfile_Menu+1][1];
-                    camCfg_Menu.saturation = camParameterInit[camProfile_Menu+1][2];
-                    camCfg_Menu.contrast = camParameterInit[camProfile_Menu+1][3];
-                    camCfg_Menu.hvFlip = camParameterInit[camProfile_Menu+1][4];
-                    camCfg_Menu.nightMode = camParameterInit[camProfile_Menu+1][5];
-                    camCfg_Menu.wbMode = camParameterInit[camProfile_Menu+1][6];
-                    for(i=0;i<WBMODE_MAX;i++)
-                    {
-                        camCfg_Menu.wbRed[i] = camParameterInit[camProfile_Menu+1][7+i];
-                        camCfg_Menu.wbBlue[i] = camParameterInit[camProfile_Menu+1][11+i];
-                    }
-                }
-                SetCamCfg(&camCfg_Menu, 0);
-            }
-        break;
-
-        case CAM_STATUS_EXIT:
-            if(last_op != BTN_MID)
-                break;
-
-            if(op == BTN_UP)
-                camMenuStatus = CAM_STATUS_RESET;
-            else if(op == BTN_DOWN)
-                camMenuStatus = CAM_STATUS_SAVE_EXIT;
-            else if(op == BTN_RIGHT)
-            {
-                camMenuStatus = CAM_STATUS_IDLE;
-                msp_tx_cnt = 0;
-                ret = 1;
-                SetCamCfg(&camCfg, 0);
-            }
-        break;
-
-        case CAM_STATUS_SAVE_EXIT:
-            if(last_op != BTN_MID)
-                break;
-
-            if(op == BTN_UP)
-                camMenuStatus = CAM_STATUS_EXIT;
-            else if(op == BTN_DOWN){
-                if(cameraID == RUNCAM_MICRO_V1)
-                    camMenuStatus = CAM_STATUS_BRIGHTNESS;
-                else
-                    camMenuStatus = CAM_STATUS_PROFILE;
-            }
-            else if(op == BTN_RIGHT)
-            {
-                camMenuStatus = CAM_STATUS_IDLE;
-                msp_tx_cnt = 0;
-                ret = 1;
-                SaveCamCfg_Menu();
-            }
-        break;
-
-        case CAM_STATUS_REPOWER:
+    case CAM_STATUS_PROFILE:
+        if (last_op != BTN_MID)
             break;
 
-        default:break;
-    }//switch(camMenuStatus)
+        if (op == BTN_UP)
+            camMenuStatus = CAM_STATUS_SAVE_EXIT;
+        else if (op == BTN_DOWN)
+            camMenuStatus = CAM_STATUS_BRIGHTNESS;
+        else if (op == BTN_LEFT) {
+            camProfile_Menu--;
+            if (camProfile_Menu >= Profile_Max)
+                camProfile_Menu = Profile_Max - 1;
+
+            camProfile = camProfile_Menu;
+            GetCamCfg(0);
+            GetCamCfg_Menu(0);
+            SetCamCfg(&camCfg_Menu, 0);
+        } else if (op == BTN_RIGHT) {
+            camProfile_Menu++;
+            if (camProfile_Menu >= Profile_Max)
+                camProfile_Menu = 0;
+
+            camProfile = camProfile_Menu;
+            GetCamCfg(0);
+            GetCamCfg_Menu(0);
+            SetCamCfg(&camCfg_Menu, 0);
+        }
+        break;
+
+    case CAM_STATUS_BRIGHTNESS:
+        if (op == BTN_UP) {
+            if (cameraID == RUNCAM_MICRO_V1)
+                camMenuStatus = CAM_STATUS_SAVE_EXIT;
+            else
+                camMenuStatus = CAM_STATUS_PROFILE;
+        } else if (op == BTN_DOWN)
+            camMenuStatus = CAM_STATUS_SHARPNESS;
+        else if (op == BTN_RIGHT) {
+            if (last_op == BTN_MID) {
+                cnt = 0;
+                step = 1;
+            } else if (last_op == BTN_RIGHT) {
+                cnt++;
+                cnt &= 0x7f;
+            }
+
+            step = cnt >> 3;
+            if (!step)
+                step = 1;
+
+            camCfg_Menu.brightness += step;
+            if (camCfg_Menu.brightness > BRIGHTNESS_MAX)
+                camCfg_Menu.brightness = BRIGHTNESS_MAX;
+
+            Runcam_SetBrightness(camCfg_Menu.brightness);
+        } else if (op == BTN_LEFT) {
+            if (last_op == BTN_MID) {
+                cnt = 0;
+                step = 1;
+            } else if (last_op == BTN_LEFT) {
+                cnt++;
+                cnt &= 0x7f;
+            }
+
+            step = cnt >> 3;
+            if (!step)
+                step = 1;
+
+            camCfg_Menu.brightness -= step;
+            if (camCfg_Menu.brightness < BRIGHTNESS_MIN)
+                camCfg_Menu.brightness = BRIGHTNESS_MIN;
+
+            Runcam_SetBrightness(camCfg_Menu.brightness);
+        }
+        break;
+
+    case CAM_STATUS_SHARPNESS:
+        if (last_op != BTN_MID)
+            break;
+
+        if (op == BTN_UP)
+            camMenuStatus = CAM_STATUS_BRIGHTNESS;
+        else if (op == BTN_DOWN)
+            camMenuStatus = CAM_STATUS_CONTRAST;
+        else if (op == BTN_RIGHT) {
+            camCfg_Menu.sharpness++;
+            if (camCfg_Menu.sharpness > SHARPNESS_MAX)
+                camCfg_Menu.sharpness = SHARPNESS_MAX;
+            Runcam_SetSharpness(camCfg_Menu.sharpness);
+        } else if (op == BTN_LEFT) {
+            camCfg_Menu.sharpness--;
+            if (camCfg_Menu.sharpness > SHARPNESS_MAX)
+                camCfg_Menu.sharpness = SHARPNESS_MIN;
+            Runcam_SetSharpness(camCfg_Menu.sharpness);
+        }
+        break;
+
+    case CAM_STATUS_CONTRAST:
+        if (last_op != BTN_MID)
+            break;
+
+        if (op == BTN_UP)
+            camMenuStatus = CAM_STATUS_SHARPNESS;
+        if (op == BTN_DOWN)
+            camMenuStatus = CAM_STATUS_SATURATION;
+        else if (op == BTN_RIGHT) {
+            camCfg_Menu.contrast++;
+            if (camCfg_Menu.contrast > CONTRAST_MAX)
+                camCfg_Menu.contrast = CONTRAST_MAX;
+            Runcam_SetContrast(camCfg_Menu.contrast);
+        } else if (op == BTN_LEFT) {
+            camCfg_Menu.contrast--;
+            if (camCfg_Menu.contrast > CONTRAST_MAX)
+                camCfg_Menu.contrast = CONTRAST_MIN;
+            Runcam_SetContrast(camCfg_Menu.contrast);
+        }
+        break;
+
+    case CAM_STATUS_SATURATION:
+        if (last_op != BTN_MID)
+            break;
+
+        if (op == BTN_UP)
+            camMenuStatus = CAM_STATUS_CONTRAST;
+        else if (op == BTN_DOWN)
+            camMenuStatus = CAM_STATUS_WBMODE;
+        else if (op == BTN_RIGHT) {
+            camCfg_Menu.saturation++;
+            if (camCfg_Menu.saturation > SATURATION_MAX)
+                camCfg_Menu.saturation = SATURATION_MAX;
+            Runcam_SetSaturation(camCfg_Menu.saturation);
+        } else if (op == BTN_LEFT) {
+            camCfg_Menu.saturation--;
+            if (camCfg_Menu.saturation > SATURATION_MAX)
+                camCfg_Menu.saturation = SATURATION_MIN;
+            Runcam_SetSaturation(camCfg_Menu.saturation);
+        }
+        break;
+
+    case CAM_STATUS_WBMODE:
+        if (last_op != BTN_MID)
+            break;
+
+        if (op == BTN_UP)
+            camMenuStatus = CAM_STATUS_SATURATION;
+        else if (op == BTN_DOWN) {
+            if (camCfg_Menu.wbMode)
+                camMenuStatus = CAM_STATUS_WBRED;
+            else if (cameraID == RUNCAM_MICRO_V2)
+                camMenuStatus = CAM_STATUS_HVFLIP;
+            else
+                camMenuStatus = CAM_STATUS_RESET;
+        } else if (op == BTN_RIGHT) {
+            camCfg_Menu.wbMode++;
+            if (camCfg_Menu.wbMode > WBMODE_MAX)
+                camCfg_Menu.wbMode = WBMODE_MAX;
+            Runcam_SetWB(camCfg_Menu.wbRed, camCfg_Menu.wbBlue, camCfg_Menu.wbMode);
+        } else if (op == BTN_LEFT) {
+            camCfg_Menu.wbMode--;
+            if (camCfg_Menu.wbMode > WBMODE_MAX)
+                camCfg_Menu.wbMode = WBMODE_MIN;
+            Runcam_SetWB(camCfg_Menu.wbRed, camCfg_Menu.wbBlue, camCfg_Menu.wbMode);
+        }
+        break;
+
+    case CAM_STATUS_WBRED:
+        if (op == BTN_UP)
+            camMenuStatus = CAM_STATUS_WBMODE;
+        else if (op == BTN_DOWN)
+            camMenuStatus = CAM_STATUS_WBBLUE;
+        else if (op == BTN_RIGHT) {
+            if (last_op == BTN_MID) {
+                cnt = 0;
+                step = 1;
+            } else if (last_op == BTN_RIGHT) {
+                cnt++;
+                cnt &= 0x7f;
+            }
+
+            step = cnt >> 3;
+            if (!step)
+                step = 1;
+            camCfg_Menu.wbRed[camCfg_Menu.wbMode - 1] += step;
+
+            Runcam_SetWB(camCfg_Menu.wbRed, camCfg_Menu.wbBlue, camCfg_Menu.wbMode);
+        } else if (op == BTN_LEFT) {
+            if (last_op == BTN_MID) {
+                cnt = 0;
+                step = 1;
+            } else if (last_op == BTN_LEFT) {
+                cnt++;
+                cnt &= 0x7f;
+            }
+
+            step = cnt >> 3;
+            if (!step)
+                step = 1;
+            camCfg_Menu.wbRed[camCfg_Menu.wbMode - 1] -= step;
+
+            Runcam_SetWB(camCfg_Menu.wbRed, camCfg_Menu.wbBlue, camCfg_Menu.wbMode);
+        }
+        break;
+
+    case CAM_STATUS_WBBLUE:
+        if (op == BTN_UP)
+            camMenuStatus = CAM_STATUS_WBRED;
+        else if (op == BTN_DOWN) {
+            if (cameraID == RUNCAM_MICRO_V2)
+                camMenuStatus = CAM_STATUS_HVFLIP;
+            else
+                camMenuStatus = CAM_STATUS_RESET;
+        } else if (op == BTN_RIGHT) {
+            if (last_op == BTN_MID) {
+                cnt = 0;
+                step = 1;
+            } else if (last_op == BTN_RIGHT) {
+                cnt++;
+                cnt &= 0x7f;
+            }
+
+            step = cnt >> 3;
+            if (!step)
+                step = 1;
+            camCfg_Menu.wbBlue[camCfg_Menu.wbMode - 1] += step;
+
+            Runcam_SetWB(camCfg_Menu.wbRed, camCfg_Menu.wbBlue, camCfg_Menu.wbMode);
+        } else if (op == BTN_LEFT) {
+            if (last_op == BTN_MID) {
+                cnt = 0;
+                step = 1;
+            } else if (last_op == BTN_LEFT) {
+                cnt++;
+                cnt &= 0x7f;
+            }
+
+            step = cnt >> 3;
+            if (!step)
+                step = 1;
+            camCfg_Menu.wbBlue[camCfg_Menu.wbMode - 1] -= step;
+
+            Runcam_SetWB(camCfg_Menu.wbRed, camCfg_Menu.wbBlue, camCfg_Menu.wbMode);
+        }
+        break;
+
+    case CAM_STATUS_HVFLIP:
+        if (last_op != BTN_MID)
+            break;
+
+        if (op == BTN_UP) {
+            if (camCfg_Menu.wbMode)
+                camMenuStatus = CAM_STATUS_WBBLUE;
+            else
+                camMenuStatus = CAM_STATUS_WBMODE;
+        } else if (op == BTN_DOWN) {
+            if (cameraID == RUNCAM_MICRO_V2)
+                camMenuStatus = CAM_STATUS_NIGHTMODE;
+            else
+                camMenuStatus = CAM_STATUS_RESET;
+        } else if (op == BTN_RIGHT || op == BTN_LEFT) {
+            camCfg_Menu.hvFlip = 1 - camCfg_Menu.hvFlip;
+            Runcam_SetHVFlip(camCfg_Menu.hvFlip);
+        }
+        break;
+
+    case CAM_STATUS_NIGHTMODE:
+        if (last_op != BTN_MID)
+            break;
+
+        if (op == BTN_UP) {
+            if (cameraID == RUNCAM_MICRO_V2)
+                camMenuStatus = CAM_STATUS_HVFLIP;
+            else if (camCfg_Menu.wbMode)
+                camMenuStatus = CAM_STATUS_WBBLUE;
+            else
+                camMenuStatus = CAM_STATUS_WBMODE;
+        } else if (op == BTN_DOWN) {
+            if (cameraID == RUNCAM_MICRO_V2)
+                camMenuStatus = CAM_STATUS_VDO_RATIO;
+            else
+                camMenuStatus = CAM_STATUS_RESET;
+        } else if (op == BTN_RIGHT || op == BTN_LEFT) {
+            camCfg_Menu.nightMode = 1 - camCfg_Menu.nightMode;
+            Runcam_SetNightMode(camCfg_Menu.nightMode);
+        }
+        break;
+
+    case CAM_STATUS_VDO_RATIO:
+        if (last_op != BTN_MID)
+            break;
+
+        if (op == BTN_UP) {
+            if (cameraID == RUNCAM_MICRO_V2)
+                camMenuStatus = CAM_STATUS_NIGHTMODE;
+            else if (camCfg_Menu.wbMode)
+                camMenuStatus = CAM_STATUS_WBBLUE;
+            else
+                camMenuStatus = CAM_STATUS_WBMODE;
+        } else if (op == BTN_DOWN)
+            camMenuStatus = CAM_STATUS_RESET;
+        else if (op == BTN_RIGHT) {
+            camMenuSetVdoRatioInit();
+            camMenuStatus = CAM_STATUS_SET_VDO_RATIO_4_3;
+        }
+        break;
+
+    case CAM_STATUS_SET_VDO_RATIO_4_3:
+        if (last_op != BTN_MID)
+            break;
+
+        if (op == BTN_UP)
+            camMenuStatus = CAM_STATUS_SET_VDO_RATIO_RETURN;
+        else if (op == BTN_DOWN)
+            camMenuStatus = CAM_STATUS_SET_VDO_RATIO_16_9_CROP;
+        else if (op == BTN_RIGHT) {
+            Runcam_SetVdoRatio(0);
+            memset(osd_buf, 0x20, sizeof(osd_buf));
+            strcpy(osd_buf[1] + osd_menu_offset + 2, " NEED TO REPOWER VTX");
+            camMenuStatus = CAM_STATUS_REPOWER;
+        }
+        break;
+
+    case CAM_STATUS_SET_VDO_RATIO_16_9_CROP:
+        if (last_op != BTN_MID)
+            break;
+
+        if (op == BTN_UP)
+            camMenuStatus = CAM_STATUS_SET_VDO_RATIO_4_3;
+        else if (op == BTN_DOWN)
+            camMenuStatus = CAM_STATUS_SET_VDO_RATIO_16_9_FULL;
+        else if (op == BTN_RIGHT) {
+            Runcam_SetVdoRatio(1);
+            memset(osd_buf, 0x20, sizeof(osd_buf));
+            strcpy(osd_buf[1] + osd_menu_offset + 2, " NEED TO REPOWER VTX");
+            camMenuStatus = CAM_STATUS_REPOWER;
+        }
+        break;
+
+    case CAM_STATUS_SET_VDO_RATIO_16_9_FULL:
+        if (last_op != BTN_MID)
+            break;
+
+        if (op == BTN_UP)
+            camMenuStatus = CAM_STATUS_SET_VDO_RATIO_16_9_CROP;
+        else if (op == BTN_DOWN)
+            camMenuStatus = CAM_STATUS_SET_VDO_RATIO_RETURN;
+        else if (op == BTN_RIGHT) {
+            Runcam_SetVdoRatio(2);
+            memset(osd_buf, 0x20, sizeof(osd_buf));
+            strcpy(osd_buf[1] + osd_menu_offset + 2, " NEED TO REPOWER VTX");
+            camMenuStatus = CAM_STATUS_REPOWER;
+        }
+        break;
+
+    case CAM_STATUS_SET_VDO_RATIO_RETURN:
+        if (last_op != BTN_MID)
+            break;
+
+        if (op == BTN_UP)
+            camMenuStatus = CAM_STATUS_SET_VDO_RATIO_16_9_FULL;
+        else if (op == BTN_DOWN)
+            camMenuStatus = CAM_STATUS_SET_VDO_RATIO_4_3;
+        else if (op == BTN_RIGHT) {
+            camMenuInit();
+            camMenuStatus = CAM_STATUS_VDO_RATIO;
+        }
+        break;
+
+    case CAM_STATUS_RESET:
+        if (last_op != BTN_MID)
+            break;
+
+        if (op == BTN_UP) {
+            if (cameraID == RUNCAM_MICRO_V2)
+                camMenuStatus = CAM_STATUS_VDO_RATIO;
+            else if (camCfg_Menu.wbMode)
+                camMenuStatus = CAM_STATUS_WBBLUE;
+            else
+                camMenuStatus = CAM_STATUS_WBMODE;
+        } else if (op == BTN_DOWN)
+            camMenuStatus = CAM_STATUS_EXIT;
+        else if (op == BTN_RIGHT) {
+            if (cameraID == RUNCAM_MICRO_V1) {
+                camCfg_Menu.brightness = camParameterInit[0][0];
+                camCfg_Menu.sharpness = camParameterInit[0][1];
+                camCfg_Menu.saturation = camParameterInit[0][2];
+                camCfg_Menu.contrast = camParameterInit[0][3];
+                camCfg_Menu.hvFlip = camParameterInit[0][4];
+                camCfg_Menu.nightMode = camParameterInit[0][5];
+                camCfg_Menu.wbMode = camParameterInit[0][6];
+                for (i = 0; i < WBMODE_MAX; i++) {
+                    camCfg_Menu.wbRed[i] = camParameterInit[0][7 + i];
+                    camCfg_Menu.wbBlue[i] = camParameterInit[0][11 + i];
+                }
+            } else if (cameraID == RUNCAM_MICRO_V2) {
+                camCfg_Menu.brightness = camParameterInit[camProfile_Menu + 1][0];
+                camCfg_Menu.sharpness = camParameterInit[camProfile_Menu + 1][1];
+                camCfg_Menu.saturation = camParameterInit[camProfile_Menu + 1][2];
+                camCfg_Menu.contrast = camParameterInit[camProfile_Menu + 1][3];
+                camCfg_Menu.hvFlip = camParameterInit[camProfile_Menu + 1][4];
+                camCfg_Menu.nightMode = camParameterInit[camProfile_Menu + 1][5];
+                camCfg_Menu.wbMode = camParameterInit[camProfile_Menu + 1][6];
+                for (i = 0; i < WBMODE_MAX; i++) {
+                    camCfg_Menu.wbRed[i] = camParameterInit[camProfile_Menu + 1][7 + i];
+                    camCfg_Menu.wbBlue[i] = camParameterInit[camProfile_Menu + 1][11 + i];
+                }
+            }
+            SetCamCfg(&camCfg_Menu, 0);
+        }
+        break;
+
+    case CAM_STATUS_EXIT:
+        if (last_op != BTN_MID)
+            break;
+
+        if (op == BTN_UP)
+            camMenuStatus = CAM_STATUS_RESET;
+        else if (op == BTN_DOWN)
+            camMenuStatus = CAM_STATUS_SAVE_EXIT;
+        else if (op == BTN_RIGHT) {
+            camMenuStatus = CAM_STATUS_IDLE;
+            msp_tx_cnt = 0;
+            ret = 1;
+            SetCamCfg(&camCfg, 0);
+        }
+        break;
+
+    case CAM_STATUS_SAVE_EXIT:
+        if (last_op != BTN_MID)
+            break;
+
+        if (op == BTN_UP)
+            camMenuStatus = CAM_STATUS_EXIT;
+        else if (op == BTN_DOWN) {
+            if (cameraID == RUNCAM_MICRO_V1)
+                camMenuStatus = CAM_STATUS_BRIGHTNESS;
+            else
+                camMenuStatus = CAM_STATUS_PROFILE;
+        } else if (op == BTN_RIGHT) {
+            camMenuStatus = CAM_STATUS_IDLE;
+            msp_tx_cnt = 0;
+            ret = 1;
+            SaveCamCfg_Menu();
+        }
+        break;
+
+    case CAM_STATUS_REPOWER:
+        break;
+
+    default:
+        break;
+    } // switch(camMenuStatus)
 
     last_op = op;
     camMenuStringUpdate(camMenuStatus);
@@ -1248,99 +1154,85 @@ uint8_t camStatusUpdate(uint8_t op)
 }
 #endif
 
-void camMenuDrawBracket(void)
-{
-    if(cameraID == RUNCAM_MICRO_V1)
-    {
-        osd_buf[CAM_STATUS_PROFILE][osd_menu_offset+17] = ' ';
-        osd_buf[CAM_STATUS_PROFILE][osd_menu_offset+29] = ' ';
+void camMenuDrawBracket(void) {
+    if (cameraID == RUNCAM_MICRO_V1) {
+        osd_buf[CAM_STATUS_PROFILE][osd_menu_offset + 17] = ' ';
+        osd_buf[CAM_STATUS_PROFILE][osd_menu_offset + 29] = ' ';
+    } else {
+        osd_buf[CAM_STATUS_PROFILE][osd_menu_offset + 17] = '<';
+        osd_buf[CAM_STATUS_PROFILE][osd_menu_offset + 29] = '>';
     }
-    else
-    {
-        osd_buf[CAM_STATUS_PROFILE][osd_menu_offset+17] = '<';
-        osd_buf[CAM_STATUS_PROFILE][osd_menu_offset+29] = '>';
+    osd_buf[CAM_STATUS_BRIGHTNESS][osd_menu_offset + 19] = '<';
+    osd_buf[CAM_STATUS_BRIGHTNESS][osd_menu_offset + 29] = '>';
+    osd_buf[CAM_STATUS_SHARPNESS][osd_menu_offset + 19] = '<';
+    osd_buf[CAM_STATUS_SHARPNESS][osd_menu_offset + 29] = '>';
+    osd_buf[CAM_STATUS_CONTRAST][osd_menu_offset + 19] = '<';
+    osd_buf[CAM_STATUS_CONTRAST][osd_menu_offset + 29] = '>';
+    osd_buf[CAM_STATUS_SATURATION][osd_menu_offset + 19] = '<';
+    osd_buf[CAM_STATUS_SATURATION][osd_menu_offset + 29] = '>';
+    osd_buf[CAM_STATUS_WBMODE][osd_menu_offset + 19] = '<';
+    osd_buf[CAM_STATUS_WBMODE][osd_menu_offset + 29] = '>';
+    if (camCfg_Menu.wbMode == 0) {
+        osd_buf[CAM_STATUS_WBRED][osd_menu_offset + 19] = ' ';
+        osd_buf[CAM_STATUS_WBRED][osd_menu_offset + 29] = ' ';
+        osd_buf[CAM_STATUS_WBBLUE][osd_menu_offset + 19] = ' ';
+        osd_buf[CAM_STATUS_WBBLUE][osd_menu_offset + 29] = ' ';
+    } else {
+        osd_buf[CAM_STATUS_WBRED][osd_menu_offset + 19] = '<';
+        osd_buf[CAM_STATUS_WBRED][osd_menu_offset + 29] = '>';
+        osd_buf[CAM_STATUS_WBBLUE][osd_menu_offset + 19] = '<';
+        osd_buf[CAM_STATUS_WBBLUE][osd_menu_offset + 29] = '>';
     }
-    osd_buf[CAM_STATUS_BRIGHTNESS][osd_menu_offset+19] = '<';
-    osd_buf[CAM_STATUS_BRIGHTNESS][osd_menu_offset+29] = '>';
-    osd_buf[CAM_STATUS_SHARPNESS][osd_menu_offset+19] = '<';
-    osd_buf[CAM_STATUS_SHARPNESS][osd_menu_offset+29] = '>';
-    osd_buf[CAM_STATUS_CONTRAST][osd_menu_offset+19] = '<';
-    osd_buf[CAM_STATUS_CONTRAST][osd_menu_offset+29] = '>';
-    osd_buf[CAM_STATUS_SATURATION][osd_menu_offset+19] = '<';
-    osd_buf[CAM_STATUS_SATURATION][osd_menu_offset+29] = '>';
-    osd_buf[CAM_STATUS_WBMODE][osd_menu_offset+19] = '<';
-    osd_buf[CAM_STATUS_WBMODE][osd_menu_offset+29] = '>';
-    if(camCfg_Menu.wbMode == 0)
-    {
-        osd_buf[CAM_STATUS_WBRED][osd_menu_offset+19] = ' ';
-        osd_buf[CAM_STATUS_WBRED][osd_menu_offset+29] = ' ';
-        osd_buf[CAM_STATUS_WBBLUE][osd_menu_offset+19] = ' ';
-        osd_buf[CAM_STATUS_WBBLUE][osd_menu_offset+29] = ' ';
-    }
-    else
-    {
-        osd_buf[CAM_STATUS_WBRED][osd_menu_offset+19] = '<';
-        osd_buf[CAM_STATUS_WBRED][osd_menu_offset+29] = '>';
-        osd_buf[CAM_STATUS_WBBLUE][osd_menu_offset+19] = '<';
-        osd_buf[CAM_STATUS_WBBLUE][osd_menu_offset+29] = '>';
-    }
-    if(cameraID == RUNCAM_MICRO_V2)
-    {
-        osd_buf[CAM_STATUS_HVFLIP][osd_menu_offset+19] = '<';
-        osd_buf[CAM_STATUS_HVFLIP][osd_menu_offset+29] = '>';
-        osd_buf[CAM_STATUS_NIGHTMODE][osd_menu_offset+19] = '<';
-        osd_buf[CAM_STATUS_NIGHTMODE][osd_menu_offset+29] = '>';
+    if (cameraID == RUNCAM_MICRO_V2) {
+        osd_buf[CAM_STATUS_HVFLIP][osd_menu_offset + 19] = '<';
+        osd_buf[CAM_STATUS_HVFLIP][osd_menu_offset + 29] = '>';
+        osd_buf[CAM_STATUS_NIGHTMODE][osd_menu_offset + 19] = '<';
+        osd_buf[CAM_STATUS_NIGHTMODE][osd_menu_offset + 29] = '>';
     }
 }
 
-
-void camMenuInit()
-{
+void camMenuInit() {
     uint8_t i = 0;
-    
-    memset(osd_buf,0x20,sizeof(osd_buf));
+
+    memset(osd_buf, 0x20, sizeof(osd_buf));
     disp_mode = DISPLAY_CMS;
-    if(cameraID == 0)
-         Cam_Button_ENTER();
-    else
-    {
-        strcpy(osd_buf[i++]+osd_menu_offset+2, "----CAMERA MENU----");
-        strcpy(osd_buf[i++]+osd_menu_offset+2, " PROFILE");
-        strcpy(osd_buf[i++]+osd_menu_offset+2, " BRIGHTNESS");
-        strcpy(osd_buf[i++]+osd_menu_offset+2, " SHARPNESS");
-        strcpy(osd_buf[i++]+osd_menu_offset+2, " CONTRAST");
-        strcpy(osd_buf[i++]+osd_menu_offset+2, " SATURATION");
-        strcpy(osd_buf[i++]+osd_menu_offset+2, " WB MODE");
-        strcpy(osd_buf[i++]+osd_menu_offset+2, " WB RED");
-        strcpy(osd_buf[i++]+osd_menu_offset+2, " WB BLUE");
-        strcpy(osd_buf[i++]+osd_menu_offset+2, " HV FLIP");
-        strcpy(osd_buf[i++]+osd_menu_offset+2, " MAX GAIN");
-        strcpy(osd_buf[i++]+osd_menu_offset+2, " ASPECT RATIO");
-        if(cameraID == RUNCAM_MICRO_V1)
-            strcpy(osd_buf[i-1]+osd_menu_offset+19, "NOT SUPPORT");
-        strcpy(osd_buf[i++]+osd_menu_offset+2,  " RESET");
-        strcpy(osd_buf[i++]+osd_menu_offset+2,  " EXIT");
-        strcpy(osd_buf[i++]+osd_menu_offset+2,  " SAVE&EXIT");
+    if (cameraID == 0)
+        Cam_Button_ENTER();
+    else {
+        strcpy(osd_buf[i++] + osd_menu_offset + 2, "----CAMERA MENU----");
+        strcpy(osd_buf[i++] + osd_menu_offset + 2, " PROFILE");
+        strcpy(osd_buf[i++] + osd_menu_offset + 2, " BRIGHTNESS");
+        strcpy(osd_buf[i++] + osd_menu_offset + 2, " SHARPNESS");
+        strcpy(osd_buf[i++] + osd_menu_offset + 2, " CONTRAST");
+        strcpy(osd_buf[i++] + osd_menu_offset + 2, " SATURATION");
+        strcpy(osd_buf[i++] + osd_menu_offset + 2, " WB MODE");
+        strcpy(osd_buf[i++] + osd_menu_offset + 2, " WB RED");
+        strcpy(osd_buf[i++] + osd_menu_offset + 2, " WB BLUE");
+        strcpy(osd_buf[i++] + osd_menu_offset + 2, " HV FLIP");
+        strcpy(osd_buf[i++] + osd_menu_offset + 2, " MAX GAIN");
+        strcpy(osd_buf[i++] + osd_menu_offset + 2, " ASPECT RATIO");
+        if (cameraID == RUNCAM_MICRO_V1)
+            strcpy(osd_buf[i - 1] + osd_menu_offset + 19, "NOT SUPPORT");
+        strcpy(osd_buf[i++] + osd_menu_offset + 2, " RESET");
+        strcpy(osd_buf[i++] + osd_menu_offset + 2, " EXIT");
+        strcpy(osd_buf[i++] + osd_menu_offset + 2, " SAVE&EXIT");
 
         camMenuDrawBracket();
-        if(cameraID == RUNCAM_MICRO_V1)
+        if (cameraID == RUNCAM_MICRO_V1)
             camMenuStringUpdate(CAM_STATUS_BRIGHTNESS);
         else
             camMenuStringUpdate(CAM_STATUS_PROFILE);
-        
     }
 }
 
-void camMenuSetVdoRatioInit()
-{
-    
-    memset(osd_buf,0x20,sizeof(osd_buf));
-    strcpy(osd_buf[0]+osd_menu_offset+2, "--VIDEO FORMAT--");
-    strcpy(osd_buf[1]+osd_menu_offset+3, "SET 720P 4:3  DEFAULT");
-    strcpy(osd_buf[2]+osd_menu_offset+3, "SET 720P 16:9 CROP");
-    strcpy(osd_buf[3]+osd_menu_offset+3, "SET 720P 16:9 FULL");
-    strcpy(osd_buf[4]+osd_menu_offset+3, "RETURN");
-    osd_buf[1][osd_menu_offset+2] = '>';
+void camMenuSetVdoRatioInit() {
+    memset(osd_buf, 0x20, sizeof(osd_buf));
+    strcpy(osd_buf[0] + osd_menu_offset + 2, "--VIDEO FORMAT--");
+    strcpy(osd_buf[1] + osd_menu_offset + 3, "SET 720P 4:3  DEFAULT");
+    strcpy(osd_buf[2] + osd_menu_offset + 3, "SET 720P 16:9 CROP");
+    strcpy(osd_buf[3] + osd_menu_offset + 3, "SET 720P 16:9 FULL");
+    strcpy(osd_buf[4] + osd_menu_offset + 3, "RETURN");
+    osd_buf[1][osd_menu_offset + 2] = '>';
 }
 
 const char *cam_names[] = {"   MICRO V2", "    NANO V2", "  NANO LITE"};

--- a/src/camera.h
+++ b/src/camera.h
@@ -2,60 +2,61 @@
 #define __CAMERA_H_
 
 #include <stdint.h>
+
 #include "common.h"
 
-#define CAM_PROFILE_NUM          4
+#define CAM_PROFILE_NUM 4
 
-#define RUNCAM_MICRO_V1             0x42
-#define RUNCAM_MICRO_V2             0x44
+#define RUNCAM_MICRO_V1 0x42
+#define RUNCAM_MICRO_V2 0x44
 
-#define CAM_BRIGHTNESS_INITIAL      0x80
-#define CAM_SHARPNESS_INITIAL       1
-#define CAM_SATURATION_INITIAL      3
-#define CAM_CONTRAST_INITIAL        1
-#define CAM_HVFLIP_INITIAL          0
-#define CAM_NIGHTMODE_INITIAL       1
-#define CAM_WBRED_INITIAL           0xC7    // 0x314>>2
-#define CAM_WBBLUE_INITIAL          0xCA    // 0x328>>2
-#define CAM_WBMODE_INITIAL          0
+#define CAM_BRIGHTNESS_INITIAL 0x80
+#define CAM_SHARPNESS_INITIAL  1
+#define CAM_SATURATION_INITIAL 3
+#define CAM_CONTRAST_INITIAL   1
+#define CAM_HVFLIP_INITIAL     0
+#define CAM_NIGHTMODE_INITIAL  1
+#define CAM_WBRED_INITIAL      0xC7 // 0x314>>2
+#define CAM_WBBLUE_INITIAL     0xCA // 0x328>>2
+#define CAM_WBMODE_INITIAL     0
 
-#define BRIGHTNESS_MIN              0x40
-#define BRIGHTNESS_MAX              0xC0
-#define SHARPNESS_MIN               0x00
-#define SHARPNESS_MAX               0x02
-#define SATURATION_MIN              0x00
-#define SATURATION_MAX              0x06
-#define CONTRAST_MIN                0x00
-#define CONTRAST_MAX                0x02
-#define HVFLIP_MAX                  0x01
-#define NIGHTMODE_MAX               0x01
-#define WBMODE_MIN                  0x00
-#define WBMODE_MAX                  0x04
+#define BRIGHTNESS_MIN 0x40
+#define BRIGHTNESS_MAX 0xC0
+#define SHARPNESS_MIN  0x00
+#define SHARPNESS_MAX  0x02
+#define SATURATION_MIN 0x00
+#define SATURATION_MAX 0x06
+#define CONTRAST_MIN   0x00
+#define CONTRAST_MAX   0x02
+#define HVFLIP_MAX     0x01
+#define NIGHTMODE_MAX  0x01
+#define WBMODE_MIN     0x00
+#define WBMODE_MAX     0x04
 
-typedef enum{
+typedef enum {
     CAM_720P50,
     CAM_720P60,
     CAM_720P60_NEW,
     CAM_720P30,
-}camFPSType_e;
+} camFPSType_e;
 
-typedef enum{
+typedef enum {
     VDO_720P60_16_9,
     VDO_720P60_4_3,
     VDO_720P30_16_9,
     VDO_720P30_4_3,
     VDO_TYPE_MAX,
-}VdoFormatType_e;
+} VdoFormatType_e;
 
-typedef enum{
-    //Profile_MicroV1,
+typedef enum {
+    // Profile_MicroV1,
     Profile_MicroV2,
     Profile_NanoV2,
     Profile_NanoLite,
     Profile_Max,
-}RuncamV2Profile_e;
+} RuncamV2Profile_e;
 
-typedef struct{
+typedef struct {
     uint8_t brightness;
     uint8_t sharpness;
     uint8_t saturation;
@@ -65,9 +66,9 @@ typedef struct{
     uint8_t wbMode;
     uint8_t wbRed[WBMODE_MAX];
     uint8_t wbBlue[WBMODE_MAX];
-}cameraConfig_t;
+} cameraConfig_t;
 
-typedef enum{
+typedef enum {
     CAM_STATUS_IDLE = 0,
     CAM_STATUS_PROFILE,
     CAM_STATUS_BRIGHTNESS,
@@ -89,7 +90,7 @@ typedef enum{
     CAM_STATUS_SET_VDO_RATIO_RETURN,
     CAM_STATUS_END,
     CAM_STATUS_REPOWER,
-}camStatusType_e;
+} camStatusType_e;
 
 void CameraInit();
 uint8_t camStatusUpdate(uint8_t op);

--- a/src/common.h
+++ b/src/common.h
@@ -4,12 +4,12 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "toolchain.h"
 #include "sfr_def.h"
 #include "sfr_ext.h"
+#include "toolchain.h"
 
 #define VERSION 0x41
-#define BETA 0x04
+#define BETA    0x04
 
 //#define HDZERO_WHOOP
 //#define HDZERO_WHOOP_LITE
@@ -18,36 +18,36 @@
 //#define HDZERO_FREESTYLE
 
 #if defined HDZERO_WHOOP
-#define VTX_ID          0x54
+#define VTX_ID 0x54
 #elif defined HDZERO_WHOOP_LITE
-#define VTX_ID          0x55
+#define VTX_ID 0x55
 #elif defined HDZERO_RACE_V1
-#define VTX_ID          0x56
+#define VTX_ID 0x56
 #elif defined HDZERO_RACE_V2
-#define VTX_ID          0x57
+#define VTX_ID 0x57
 #elif defined HDZERO_FREESTYLE
-#define VTX_ID          0x58
+#define VTX_ID 0x58
 #else
-#define VTX_ID          0x00
+#define VTX_ID 0x00
 #endif
 
 #if defined HDZERO_WHOOP
-#define VTX_NAME    "     HDZ WHOOP"
+#define VTX_NAME "     HDZ WHOOP"
 #elif defined HDZERO_WHOOP_LITE
-#define VTX_NAME    "HDZ WHOOP LITE"
+#define VTX_NAME "HDZ WHOOP LITE"
 #elif defined HDZERO_RACE_V1
-#define VTX_NAME    "   HDZ RACE V1"
+#define VTX_NAME "   HDZ RACE V1"
 #elif defined HDZERO_RACE_V2
-#define VTX_NAME    "   HDZ RACE V2"
+#define VTX_NAME "   HDZ RACE V2"
 #elif defined HDZERO_FREESTYLE
-#define VTX_NAME    " HDZ FREESTYLE"
+#define VTX_NAME " HDZ FREESTYLE"
 #else
-#define VTX_NAME    "              "
+#define VTX_NAME "              "
 #endif
 
 // system
 #define assert(c)
-#define dbg_pt(a)   DBG_PIN0 = a
+#define dbg_pt(a) DBG_PIN0 = a
 
 #define EXTEND_BUF
 //#define EXTEND_BUF1
@@ -89,64 +89,64 @@
 #define IS_RX 0
 
 // time
-#define TIMER0_1S       9588
-#define TIMER0_1SD2     (TIMER0_1S>>1)
-#define TIMER0_1SD16    (TIMER0_1S>>4)
-#define I2C_BIT_DLY     40
-#define MS_DLY          (237)
-#define MS_DLY_SDCC     (2746)
-#define PRESS_L         3
-#define PRESS_LL        8
-#define PWR_LMT_SEC     10
-#define WAIT_SA_CONFIG  9
-#define CFG_TO_SEC      10
-#define CAM_DET_DLY     1000
-#define DISPF_TIME      3   // 3/8s
+#define TIMER0_1S      9588
+#define TIMER0_1SD2    (TIMER0_1S >> 1)
+#define TIMER0_1SD16   (TIMER0_1S >> 4)
+#define I2C_BIT_DLY    40
+#define MS_DLY         (237)
+#define MS_DLY_SDCC    (2746)
+#define PRESS_L        3
+#define PRESS_LL       8
+#define PWR_LMT_SEC    10
+#define WAIT_SA_CONFIG 9
+#define CFG_TO_SEC     10
+#define CAM_DET_DLY    1000
+#define DISPF_TIME     3 // 3/8s
 
 // gpio
-#define SCL             P0_0
-#define SDA             P0_1
-#define CAM_SCL         P0_0
-#define CAM_SDA         P0_1
+#define SCL     P0_0
+#define SDA     P0_1
+#define CAM_SCL P0_0
+#define CAM_SDA P0_1
 #ifdef HDZERO_FREESTYLE
-#define PA_EN           P0_2
+#define PA_EN P0_2
 #else
-#define LED_1           P0_2
+#define LED_1 P0_2
 #endif
 #ifdef USE_SMARTAUDIO
-#define SUART_PORT      P0_3
+#define SUART_PORT P0_3
 #else
-#define TC3587_RSTB     P0_3
+#define TC3587_RSTB P0_3
 #endif
-#define CAM_PWM         P0_4
-#define BTN_1           P0_5
+#define CAM_PWM P0_4
+#define BTN_1   P0_5
 
-#define SPI_CS          P1_0
-#define SPI_CK          P1_1
-#define SPI_DI          P0_6
-#define SPI_DO          P0_7
+#define SPI_CS P1_0
+#define SPI_CK P1_1
+#define SPI_DI P0_6
+#define SPI_DO P0_7
 
 // uart
 #ifndef REV_UART
-#define Mon_tx(ch)      RS_tx1(ch)
-#define Mon_rx()        RS_rx1()
-#define Mon_ready()     RS_ready1()
-#define _outchar(c)     RS_tx1(c)
-#define CMS_tx(ch)      RS_tx(ch)
-#define CMS_rx()        RS_rx()
-#define CMS_ready()     RS_ready()
+#define Mon_tx(ch)  RS_tx1(ch)
+#define Mon_rx()    RS_rx1()
+#define Mon_ready() RS_ready1()
+#define _outchar(c) RS_tx1(c)
+#define CMS_tx(ch)  RS_tx(ch)
+#define CMS_rx()    RS_rx()
+#define CMS_ready() RS_ready()
 #else
-#define Mon_tx(ch)      RS_tx(ch)
-#define Mon_rx()        RS_rx()
-#define Mon_ready()     RS_ready()
-#define _outchar(c)     RS_tx(c)
-#define CMS_tx(ch)      RS_tx1(ch)
-#define CMS_rx()        RS_rx1()
-#define CMS_ready()     RS_ready1()
+#define Mon_tx(ch)  RS_tx(ch)
+#define Mon_rx()    RS_rx()
+#define Mon_ready() RS_ready()
+#define _outchar(c) RS_tx(c)
+#define CMS_tx(ch)  RS_tx1(ch)
+#define CMS_rx()    RS_rx1()
+#define CMS_ready() RS_ready1()
 #endif
 
-#define Rom_tx(ch)      RS_tx(ch)
-#define Rom_rx()        RS_rx()
-#define Rom_ready()     RS_ready()
+#define Rom_tx(ch)  RS_tx(ch)
+#define Rom_rx()    RS_rx()
+#define Rom_ready() RS_ready()
 
 #endif /* __COMMON_H_ */

--- a/src/dm6300.h
+++ b/src/dm6300.h
@@ -2,6 +2,7 @@
 #define __DM6300_H_
 
 #include "common.h"
+#include "hardware.h"
 
 #ifdef HDZERO_FREESTYLE
 #define PIT_POWER 0x18 // 2dbm

--- a/src/dm6300.h
+++ b/src/dm6300.h
@@ -4,15 +4,15 @@
 #include "common.h"
 
 #ifdef HDZERO_FREESTYLE
-	#define PIT_POWER 0x18  //2dbm
+#define PIT_POWER 0x18 // 2dbm
 #else
-	#define PIT_POWER 0x26
+#define PIT_POWER 0x26
 #endif
 
 void DM6300_Init(uint8_t ch, uint8_t bw);
 void DM6300_EFUSE1();
 void DM6300_EFUSE2();
-//void DM6300_CalibRF();
+// void DM6300_CalibRF();
 void DM6300_SetChannel(uint8_t ch);
 void DM6300_SetPower(uint8_t pwr, uint8_t freq, uint8_t offset);
 int16_t DM6300_GetTemp();
@@ -26,12 +26,12 @@ void DM6300_init5();
 void DM6300_init6(uint8_t sel);
 void DM6300_init7(uint8_t sel);
 void DM6300_RFTest();
-//void DM6300_M0();
+// void DM6300_M0();
 
 extern int16_t auxadc_offset;
-extern uint8_t table_power[FREQ_MAX_EXT+1][POWER_MAX+1];
+extern uint8_t table_power[FREQ_MAX_EXT + 1][POWER_MAX + 1];
 
-extern uint32_t dcoc_ih,dcoc_qh;
+extern uint32_t dcoc_ih, dcoc_qh;
 
 extern uint8_t dm6300_init_done;
 #endif /* __DM6300_H_ */

--- a/src/global.c
+++ b/src/global.c
@@ -1,5 +1,6 @@
-#include "common.h"
 #include "global.h"
+
+#include "common.h"
 #include "print.h"
 
 #ifdef _DEBUG_MODE
@@ -22,7 +23,7 @@ uint8_t stricmp(uint8_t *ptr1, uint8_t *ptr2) {
         if ((lhs == 0) || (rhs == 0))
             return 1;
     }
-	return 0;
+    return 0;
 }
 
 // trick the pre-compiler into doing some generic programing for us
@@ -85,11 +86,10 @@ void WAIT(uint16_t ms) {
     }
 }
 #else
-void WAIT(uint32_t ms)
-{
-    uint32_t i,j;
-    for(i=0;i<ms;i++) {
-        for(j=0;j<MS_DLY;j++) {
+void WAIT(uint32_t ms) {
+    uint32_t i, j;
+    for (i = 0; i < ms; i++) {
+        for (j = 0; j < MS_DLY; j++) {
         }
     }
 }

--- a/src/global.h
+++ b/src/global.h
@@ -1,6 +1,8 @@
 #ifndef __GLOBAL_H_
 #define __GLOBAL_H_
 
+#include "stdint.h"
+
 #define HI_BYTE(a) ((a >> 8) & 0xFF)
 #define LO_BYTE(a) (a & 0xFF)
 

--- a/src/global.h
+++ b/src/global.h
@@ -1,11 +1,11 @@
 #ifndef __GLOBAL_H_
 #define __GLOBAL_H_
 
-#define HI_BYTE(a) 	((a>>8)&0xFF)
-#define LO_BYTE(a) 	(a&0xFF)
+#define HI_BYTE(a) ((a >> 8) & 0xFF)
+#define LO_BYTE(a) (a & 0xFF)
 
-#define ASSERT(a) 
-#define abs(a) ( ((a)<0)?(-(a)):(a))
+#define ASSERT(a)
+#define abs(a) (((a) < 0) ? (-(a)) : (a))
 
 uint8_t Asc2Bin(uint8_t *s);
 uint16_t Asc4Bin(uint8_t *s);
@@ -13,7 +13,7 @@ uint32_t Asc8Bin(uint8_t *s);
 
 uint8_t stricmp(uint8_t *ptr1, uint8_t *ptr2);
 
-void uint8ToString(uint8_t dec, uint8_t* Str);
+void uint8ToString(uint8_t dec, uint8_t *Str);
 
 #ifdef SDCC
 void WAIT(uint16_t ms);

--- a/src/hardware.c
+++ b/src/hardware.c
@@ -1,26 +1,28 @@
-#include "common.h"
-#include "sfr_ext.h"
-#include "global.h"
-#include "uart.h"
-#include "print.h"
-#include "monitor.h"
-#include "isr.h"
 #include "hardware.h"
+
+#include "camera.h"
+#include "common.h"
+#include "dm6300.h"
+#include "global.h"
 #include "i2c.h"
 #include "i2c_device.h"
-#include "spi.h"
-#include "dm6300.h"
-#include "smartaudio_protocol.h"
-#include "msp_displayport.h"
-#include "camera.h"
+#include "isr.h"
 #include "lifetime.h"
+#include "monitor.h"
+#include "msp_displayport.h"
+#include "print.h"
+#include "sfr_ext.h"
+#include "smartaudio_protocol.h"
+#include "spi.h"
+#include "uart.h"
 
-uint8_t KEYBOARD_ON = 0; //avoid conflict between keyboard and cam_control
+uint8_t KEYBOARD_ON = 0; // avoid conflict between keyboard and cam_control
 uint8_t EE_VALID = 0;
 
 #ifdef HDZERO_FREESTYLE
 uint8_t powerLock = 1;
 #endif
+
 /**********************************
 //
 //  POWER MODE
@@ -46,7 +48,7 @@ BWType_e RF_BW = BW_27M;
 uint8_t g_IS_ARMED = 0;
 uint8_t g_IS_PARALYZE = 0;
 
-uint8_t cfg_step = 0;   // 0:idle, 1:freq, 2:power, 3:LP_MODE
+uint8_t cfg_step = 0; // 0:idle, 1:freq, 2:power, 3:LP_MODE
 
 uint8_t cfg_to_cnt = 0;
 uint8_t pwr_lmt_done = 0;
@@ -55,7 +57,7 @@ int16_t temperature = 0;
 uint8_t pwr_offset = 0;
 uint8_t heat_protect = 0;
 
-uint8_t last_SA_lock = 0; 
+uint8_t last_SA_lock = 0;
 uint8_t cur_pwr = 0;
 
 uint8_t led_status = 0;
@@ -84,14 +86,13 @@ uint8_t BPLED[] = {
     0xC6, // C
     0x8E, // F
     0x0E  // F.
-    };
+};
 
 uint8_t dispF_cnt = 0xff;
-    
-void Set_720P50(uint8_t page)
-{
+
+void Set_720P50(uint8_t page) {
     WriteReg(page, 0x21, 0x25);
-    
+
     WriteReg(page, 0x40, 0x00);
     WriteReg(page, 0x41, 0x25);
     WriteReg(page, 0x42, 0xD0);
@@ -104,14 +105,13 @@ void Set_720P50(uint8_t page)
     WriteReg(page, 0x52, 0x04);
     WriteReg(page, 0x53, 0x00);
     WriteReg(page, 0x54, 0x3C);
-                   
+
     WriteReg(page, 0x06, 0x01);
 }
 
-void Set_720P60(uint8_t page)
-{
+void Set_720P60(uint8_t page) {
     WriteReg(page, 0x21, 0x1F);
-    
+
     WriteReg(page, 0x40, 0x00);
     WriteReg(page, 0x41, 0x25);
     WriteReg(page, 0x42, 0xD0);
@@ -124,17 +124,16 @@ void Set_720P60(uint8_t page)
     WriteReg(page, 0x52, 0x04);
     WriteReg(page, 0x53, 0x00);
     WriteReg(page, 0x54, 0x3C);
-    
+
     WriteReg(page, 0x06, 0x01);
 }
 
-void Set_720P30(uint8_t page, uint8_t is_43)
-{
-    if(is_43)
+void Set_720P30(uint8_t page, uint8_t is_43) {
+    if (is_43)
         WriteReg(page, 0x21, 0x28);
     else
         WriteReg(page, 0x21, 0x1F);
-    
+
     WriteReg(page, 0x40, 0x00);
     WriteReg(page, 0x41, 0x25);
     WriteReg(page, 0x42, 0xB0);
@@ -147,45 +146,43 @@ void Set_720P30(uint8_t page, uint8_t is_43)
     WriteReg(page, 0x52, 0x04);
     WriteReg(page, 0x53, 0x00);
     WriteReg(page, 0x54, 0x3C);
-    
+
     WriteReg(page, 0x06, 0x01);
 }
 
-void Setting_Save()
-{
+void Setting_Save() {
     uint8_t rcv = 0;
 
-    #if(0)
-    if(cameraID == 0){
-        CAM_WriteCFG(0,RF_FREQ,RF_POWER,MODE);
-        CAM_WriteCFG(0,RF_FREQ,RF_POWER,MODE);
-        CAM_WriteCFG(0,RF_FREQ,RF_POWER,MODE);
+#if (0)
+    if (cameraID == 0) {
+        CAM_WriteCFG(0, RF_FREQ, RF_POWER, MODE);
+        CAM_WriteCFG(0, RF_FREQ, RF_POWER, MODE);
+        CAM_WriteCFG(0, RF_FREQ, RF_POWER, MODE);
     }
-    #endif
-    
-    if(EE_VALID){
+#endif
+
+    if (EE_VALID) {
         rcv |= I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_RF_FREQ, RF_FREQ);
         rcv |= I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_RF_POWER, RF_POWER);
         rcv |= I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_LPMODE, LP_MODE);
         rcv |= I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_PITMODE, PIT_MODE);
         rcv |= I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_25MW, OFFSET_25MW);
-        #ifdef _DEBUG_MODE
-        if(!rcv)
+#ifdef _DEBUG_MODE
+        if (!rcv)
             debugf("\r\nEEPROM write success");
-        #endif
+#endif
     }
 
-    #ifdef _DEBUG_MODE
+#ifdef _DEBUG_MODE
     debugf("\r\nSetting Save:  RF_FREQ=%d, RF_POWER=%d, LP_MODE=%d, PIT_MODE=%d",
-        (uint16_t)RF_FREQ, (uint16_t)RF_POWER, (uint16_t)LP_MODE, (uint16_t)PIT_MODE);
-    #endif
+           (uint16_t)RF_FREQ, (uint16_t)RF_POWER, (uint16_t)LP_MODE, (uint16_t)PIT_MODE);
+#endif
 }
 
-void CFG_Back()
-{
+void CFG_Back() {
     RF_FREQ = (RF_FREQ > FREQ_MAX_EXT) ? 0 : RF_FREQ;
     RF_POWER = (RF_POWER > POWER_MAX) ? 0 : RF_POWER;
-    LP_MODE  = (LP_MODE > 2) ? 0 : LP_MODE;
+    LP_MODE = (LP_MODE > 2) ? 0 : LP_MODE;
     PIT_MODE = (PIT_MODE > PIT_0MW) ? PIT_OFF : PIT_MODE;
     OFFSET_25MW = (OFFSET_25MW > 20) ? 0 : OFFSET_25MW;
 }
@@ -193,191 +190,188 @@ void CFG_Back()
 void GetVtxParameter() {
     unsigned char CODE_SEG *ptr = (unsigned char CODE_SEG *)0xFFE8;
     uint8_t i, j;
-    XDATA_SEG uint8_t tab[FREQ_MAX+1][POWER_MAX+1];
+    XDATA_SEG uint8_t tab[FREQ_MAX + 1][POWER_MAX + 1];
     uint8_t flash_vld = 1;
     uint8_t ee_vld = 1;
 
     EE_VALID = !I2C_Write8_Wait(10, ADDR_EEPROM, 0x40, 0xFF);
-    
-    #ifdef _DEBUG_MODE
+
+#ifdef _DEBUG_MODE
     debugf("\r\nEE_VALID:%x", (uint16_t)EE_VALID);
-    #endif
-    
-    if(EE_VALID){ // eeprom valid
-        
-        #ifdef FIX_EEP
-        for(i=0;i<=FREQ_MAX;i++) {
-            for(j=0;j<=POWER_MAX;j++){
-                I2C_Write8(ADDR_EEPROM, i*_Wait(10, POWER_MAX+1) + j, table_power[i][j]);
+#endif
+
+    if (EE_VALID) { // eeprom valid
+
+#ifdef FIX_EEP
+        for (i = 0; i <= FREQ_MAX; i++) {
+            for (j = 0; j <= POWER_MAX; j++) {
+                I2C_Write8(ADDR_EEPROM, i * _Wait(10, POWER_MAX + 1) + j, table_power[i][j]);
             }
         }
-        #endif
+#endif
         // RF Tab
-        for(i=0;i<=FREQ_MAX;i++) {
-            for(j=0;j<=POWER_MAX;j++){
-                tab[i][j] = I2C_Read8_Wait(10, ADDR_EEPROM, i*(POWER_MAX+1) + j);
-                if(tab[i][j] == 0xFF)
+        for (i = 0; i <= FREQ_MAX; i++) {
+            for (j = 0; j <= POWER_MAX; j++) {
+                tab[i][j] = I2C_Read8_Wait(10, ADDR_EEPROM, i * (POWER_MAX + 1) + j);
+                if (tab[i][j] == 0xFF)
                     ee_vld = 0;
             }
         }
-        
-        if(ee_vld){
-            #ifdef _DEBUG_MODE
+
+        if (ee_vld) {
+#ifdef _DEBUG_MODE
             debugf("\r\nUSE EEPROM for rf_pwr_tab.");
-            #endif
-            for(i=0;i<=FREQ_MAX;i++) {
-                for(j=0;j<=POWER_MAX;j++){
+#endif
+            for (i = 0; i <= FREQ_MAX; i++) {
+                for (j = 0; j <= POWER_MAX; j++) {
                     table_power[i][j] = tab[i][j];
-                    #ifndef _RF_CALIB
-                    if(j==0)     //25mw +3dbm
-                        table_power[i][j] +=  0xC;
-                    #endif
+#ifndef _RF_CALIB
+                    if (j == 0) // 25mw +3dbm
+                        table_power[i][j] += 0xC;
+#endif
                 }
             }
-            
-            //ch9 5760M use ch4 5769M;ch10 5800 use ch5 5806
-            for(j=0;j<=POWER_MAX;j++){
+
+            // ch9 5760M use ch4 5769M;ch10 5800 use ch5 5806
+            for (j = 0; j <= POWER_MAX; j++) {
                 table_power[8][j] = tab[3][j];
                 table_power[9][j] = tab[4][j];
-                if(j==0){     //25mw +3dbm
+                if (j == 0) { // 25mw +3dbm
                     table_power[8][j] += 0x0C;
                     table_power[9][j] += 0x0C;
                 }
             }
-        }else{
-            #ifdef _DEBUG_MODE
+        } else {
+#ifdef _DEBUG_MODE
             debugf("\r\nEEPROM is NOT initialized. Use default rf_pwr_tab.");
-            #endif
-            
-            #ifdef _RF_CALIB
-            for(i=0;i<=FREQ_MAX;i++) {
-                for(j=0;j<=POWER_MAX;j++){
-                    I2C_Write8(ADDR_EEPROM, i*_Wait(10, POWER_MAX+1) + j, table_power[i][j]);
+#endif
+
+#ifdef _RF_CALIB
+            for (i = 0; i <= FREQ_MAX; i++) {
+                for (j = 0; j <= POWER_MAX; j++) {
+                    I2C_Write8(ADDR_EEPROM, i * _Wait(10, POWER_MAX + 1) + j, table_power[i][j]);
                 }
             }
-            #endif
+#endif
         }
-        
+
         // VTX Setting
         RF_FREQ = I2C_Read8(ADDR_EEPROM, EEP_ADDR_RF_FREQ);
         RF_POWER = I2C_Read8(ADDR_EEPROM, EEP_ADDR_RF_POWER);
         LP_MODE = I2C_Read8(ADDR_EEPROM, EEP_ADDR_LPMODE);
         PIT_MODE = I2C_Read8(ADDR_EEPROM, EEP_ADDR_PITMODE);
         OFFSET_25MW = I2C_Read8(ADDR_EEPROM, EEP_ADDR_25MW);
-        
-        if(RF_FREQ == 0xff || RF_POWER == 0xff || LP_MODE == 0xff || PIT_MODE == 0xff || OFFSET_25MW == 0xff){
+
+        if (RF_FREQ == 0xff || RF_POWER == 0xff || LP_MODE == 0xff || PIT_MODE == 0xff || OFFSET_25MW == 0xff) {
             CFG_Back();
             I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_RF_FREQ, RF_FREQ);
             I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_RF_POWER, RF_POWER);
             I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_LPMODE, LP_MODE);
             I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_PITMODE, PIT_MODE);
             I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_25MW, OFFSET_25MW);
-            #ifdef _DEBUG_MODE
+#ifdef _DEBUG_MODE
             debugf("\r\nEEPROM is NOT initialized. USE CAM for VTX setting.");
-            #endif
-        }else{
+#endif
+        } else {
             CFG_Back();
-            #ifdef _DEBUG_MODE
+#ifdef _DEBUG_MODE
             debugf("\r\nUSE EEPROM for VTX setting:RF_FREQ=%d, RF_POWER=%d, LPMODE=%d PIT_MODE=%d", (uint16_t)RF_FREQ, (uint16_t)RF_POWER, (uint16_t)LP_MODE, (uint16_t)PIT_MODE);
-            #endif
+#endif
         }
-        
-        //last_SA_lock
-        #ifdef USE_SMARTAUDIO
+
+// last_SA_lock
+#ifdef USE_SMARTAUDIO
         last_SA_lock = I2C_Read8_Wait(10, ADDR_EEPROM, EEP_ADDR_SA_LOCK);
         WAIT(10);
-        if(last_SA_lock == 0xff){
+        if (last_SA_lock == 0xff) {
             last_SA_lock = 0;
             I2C_Write8(ADDR_EEPROM, EEP_ADDR_SA_LOCK, last_SA_lock);
         }
-        #ifdef _DEBUG_MODE
+#ifdef _DEBUG_MODE
         debugf("\r\nlast_SA_lock %x", (uint16_t)last_SA_lock);
-        #endif
-        #endif
+#endif
+#endif
 
-        #ifdef HDZERO_FREESTYLE
-        //powerLock
+#ifdef HDZERO_FREESTYLE
+        // powerLock
         powerLock = 0x01 & I2C_Read8_Wait(10, ADDR_EEPROM, EEP_ADDR_POWER_LOCK);
-        #endif
-    }
-    else{
-        for(i=0;i<=FREQ_MAX;i++) {
-            for(j=0;j<=POWER_MAX;j++){
+#endif
+    } else {
+        for (i = 0; i <= FREQ_MAX; i++) {
+            for (j = 0; j <= POWER_MAX; j++) {
                 tab[i][j] = *ptr;
                 ptr++;
-                if(tab[i][j] == 0xFF)
+                if (tab[i][j] == 0xFF)
                     flash_vld = 0;
             }
         }
 
-        if(flash_vld){ // flash valid
-            #ifdef _DEBUG_MODE
+        if (flash_vld) { // flash valid
+#ifdef _DEBUG_MODE
             debugf("\r\nUse Flash rf_pwr_tab space.");
-            #endif
-            for(i=0;i<=FREQ_MAX;i++) {
-                for(j=0;j<=POWER_MAX;j++) {
+#endif
+            for (i = 0; i <= FREQ_MAX; i++) {
+                for (j = 0; j <= POWER_MAX; j++) {
                     table_power[i][j] = tab[i][j];
-                    if(j==0)
+                    if (j == 0)
                         table_power[i][j] += 0x0c;
                 }
             }
-            
-            //ch9 5760M use ch4 5769M;ch10 5800 use ch5 5806
-            for(j=0;j<=POWER_MAX;j++){
+
+            // ch9 5760M use ch4 5769M;ch10 5800 use ch5 5806
+            for (j = 0; j <= POWER_MAX; j++) {
                 table_power[8][j] = tab[3][j];
                 table_power[9][j] = tab[4][j];
-                if(j==0){     //25mw +3dbm
+                if (j == 0) { // 25mw +3dbm
                     table_power[8][j] += 0x0C;
                     table_power[9][j] += 0x0C;
                 }
             }
         }
-        #ifdef _DEBUG_MODE
+#ifdef _DEBUG_MODE
         else
             debugf("\r\nUse default rf_pwr_tab.");
-        
+
         debugf("\r\nUSE CAM for VTX setting.");
-        #endif
+#endif
     }
-    
-    #ifdef _DEBUG_MODE
-    for(i=0; i<=FREQ_MAX_EXT; i++){
+
+#ifdef _DEBUG_MODE
+    for (i = 0; i <= FREQ_MAX_EXT; i++) {
         debugf("\r\nrf_pwr_tab[%d]=", (uint16_t)i);
-        for(j=0;j<=POWER_MAX;j++)
+        for (j = 0; j <= POWER_MAX; j++)
             debugf(" %x", (uint16_t)table_power[i][j]);
     }
     debugf("\r\nUSE EEPROM for VTX setting:RF_FREQ=%d, RF_POWER=%d, LPMODE=%d PIT_MODE=%d", (uint16_t)RF_FREQ, (uint16_t)RF_POWER, (uint16_t)LP_MODE, (uint16_t)PIT_MODE);
-    #endif
+#endif
 }
 
-void Init_6300RF(uint8_t freq, uint8_t pwr)
-{
+void Init_6300RF(uint8_t freq, uint8_t pwr) {
     WriteReg(0, 0x8F, 0x00);
     WriteReg(0, 0x8F, 0x01);
     DM6300_Init(freq, RF_BW);
     DM6300_SetChannel(freq);
 #ifndef VIDEO_PAT
 #ifdef HDZERO_FREESTYLE
-    if((pwr == 3) && (!g_IS_ARMED))
+    if ((pwr == 3) && (!g_IS_ARMED))
         pwr_lmt_done = 0;
-    else 
+    else
 #endif
 #endif
-	{
-	    DM6300_SetPower(pwr, freq, pwr_offset);
-	    cur_pwr = pwr;
-	}
-	WriteReg(0, 0x8F, 0x11);
-    #ifdef _DEBUG_MODE
+    {
+        DM6300_SetPower(pwr, freq, pwr_offset);
+        cur_pwr = pwr;
+    }
+    WriteReg(0, 0x8F, 0x11);
+#ifdef _DEBUG_MODE
     debugf("\r\nInit_6300RF(%x, %x)", (uint16_t)freq, (uint16_t)pwr);
-    #endif
+#endif
 }
 
-void Init_HW()
-{
-//--------- gpio init -----------------
+void Init_HW() {
+    //--------- gpio init -----------------
     SPI_Init();
-    
+
     LED_BLUE_ON;
     led_status = ON;
 
@@ -385,315 +379,365 @@ void Init_HW()
     Set_720P60(0);
     WriteReg(0, 0x50, 0x01);
     RF_FREQ = 0;
-//--------- eeprom --------------------
+    //--------- eeprom --------------------
     GetVtxParameter();
 
 #ifdef _RF_CALIB
-    RF_POWER = 0;   //max power
-    RF_FREQ  = 0;   //ch1
+    RF_POWER = 0; // max power
+    RF_FREQ = 0;  // ch1
 #else
     RF_POWER = 0;
 #endif
-    
+
     Init_6300RF(RF_FREQ, RF_POWER);
     DM6300_AUXADC_Calib();
 #else
-    #ifdef HDZERO_FREESTYLE
-        LED_TC3587_Init();
-    #endif
-//--------- eeprom --------------------
+#ifdef HDZERO_FREESTYLE
+    LED_TC3587_Init();
+#endif
+    //--------- eeprom --------------------
     GetVtxParameter();
     Get_EEP_LifeTime();
-//---------- Camera ---------------
+    //---------- Camera ---------------
     CameraInit();
 //--------- dm6300 --------------------
-    // move to RF_Delay_Init()
+// move to RF_Delay_Init()
 #endif
 
-    
-//---------- DC IQ --------------------
-    //WriteReg(0, 0x25, 0xf6);
-    //WriteReg(0, 0x26, 0x00);
+    //---------- DC IQ --------------------
+    // WriteReg(0, 0x25, 0xf6);
+    // WriteReg(0, 0x26, 0x00);
 }
 #ifdef USE_TEMPERATURE_SENSOR
-void TempDetect()
-{
+void TempDetect() {
     static uint8_t init = 1;
-    int16_t temp_new,temp_new0; 
-    
-    if(temp_tflg){
+    int16_t temp_new, temp_new0;
+
+    if (temp_tflg) {
         temp_tflg = 0;
-        
-        if(init){
+
+        if (init) {
             init = 0;
             temp0 = DM6300_GetTemp();
             temp0 <<= 2;
-            
-            temperature = I2C_Read8(ADDR_TEMPADC, 0); //NCT75 MSB 8bit
-            //temperature >>= 5; //LM75AD
 
-            if(temperature >= 0x7D) //MAX +125 
+            temperature = I2C_Read8(ADDR_TEMPADC, 0); // NCT75 MSB 8bit
+            // temperature >>= 5; //LM75AD
+
+            if (temperature >= 0x7D) // MAX +125
                 temperature = 0x7D;
-            temperature <<= 2; //filter * 4           
-        }
-        else{
+            temperature <<= 2; // filter * 4
+        } else {
             temp_new0 = DM6300_GetTemp();
-            
+
             temp_new = I2C_Read8(ADDR_TEMPADC, 0);
-            if(temp_new >= 0x7D) //MAX +125 
-                temp_new = 0x7D;            
-            //temp_new >>= 5; //LM75AD
-            
-            temperature = temperature - (temperature>>2) + temp_new;
-            
-            temp0 = temp0 - (temp0>>2) + temp_new0;
-            
-            #ifdef _DEBUG_MODE
-            //verbosef("\r\ntempADC  detect: temp = %d, temp_new = %d", (uint16_t)(temperature>>2), (uint16_t)temp_new);
-            //verbosef("\r\ntemp6300 detect: temp = 0x%x, temp_new = 0x%x", (uint16_t)(temp0>>2), (uint16_t)temp_new0);
-            #endif
-              
+            if (temp_new >= 0x7D) // MAX +125
+                temp_new = 0x7D;
+            // temp_new >>= 5; //LM75AD
+
+            temperature = temperature - (temperature >> 2) + temp_new;
+
+            temp0 = temp0 - (temp0 >> 2) + temp_new0;
+
+#ifdef _DEBUG_MODE
+// verbosef("\r\ntempADC  detect: temp = %d, temp_new = %d", (uint16_t)(temperature>>2), (uint16_t)temp_new);
+// verbosef("\r\ntemp6300 detect: temp = 0x%x, temp_new = 0x%x", (uint16_t)(temp0>>2), (uint16_t)temp_new0);
+#endif
         }
     }
 }
 #else
-void TempDetect()
-{
+void TempDetect() {
     static uint8_t init = 1;
     int16_t temp_new;
-    
-    if(!dm6300_init_done)
+
+    if (!dm6300_init_done)
         return;
 
-    if(temp_tflg){
+    if (temp_tflg) {
         temp_tflg = 0;
-        
-        if(init){
+
+        if (init) {
             init = 0;
             temperature = DM6300_GetTemp();
             temperature <<= 2;
-        }
-        else{
+        } else {
             temp_new = DM6300_GetTemp();
-            temperature = temperature - (temperature>>2) + temp_new;
-            
-            #ifdef _DEBUG_MODE
-            //verbosef("\r\ntemp detect: temp = %x, temp_new = %x", (uint16_t)(temperature>>2), (uint16_t)temp_new);
-            #endif
+            temperature = temperature - (temperature >> 2) + temp_new;
+
+#ifdef _DEBUG_MODE
+// verbosef("\r\ntemp detect: temp = %x, temp_new = %x", (uint16_t)(temperature>>2), (uint16_t)temp_new);
+#endif
         }
     }
 }
 #endif
 
-
 #ifdef USE_TEMPERATURE_SENSOR
-void PowerAutoSwitch()
-{
+void PowerAutoSwitch() {
     int16_t temp;
     static uint8_t last_ofs = 0;
-	
-    if(pwr_sflg)
+
+    if (pwr_sflg)
         pwr_sflg = 0;
     else
         return;
-	
-    temp = temperature >> 2;  //ADC temp
+
+    temp = temperature >> 2; // ADC temp
     last_ofs = pwr_offset;
-    
-    if(temp < 25)      pwr_offset = 0;  
-    else if(temp < 30) pwr_offset = 1;
-    else if(temp < 35) pwr_offset = 2;
-    else if(temp < 38) pwr_offset = 3;
-    else if(temp < 40) pwr_offset = 4;
-    else if(temp < 43) pwr_offset = 5;  
-    else if(temp < 45) pwr_offset = 6;
-    else if(temp < 48) pwr_offset = 7;  
-    else if(temp < 50) pwr_offset = 8;
-    else if(temp < 53) pwr_offset = 9;
-    else if(temp < 55) pwr_offset = 10; 
-    else if(temp < 58) pwr_offset = 11;
-    else if(temp < 60) pwr_offset = 12;
-    else if(temp < 63) pwr_offset = 13;
-    else if(temp < 65) pwr_offset = 14; 
-    else if(temp < 68) pwr_offset = 15;
-    else if(temp < 70) pwr_offset = 16; 
-    else if(temp < 73) pwr_offset = 17;
-    else if(temp < 75) pwr_offset = 18;
-    else if(temp < 78) pwr_offset = 19;
-    else if(temp < 80) pwr_offset = 20;
-    else               pwr_offset = 20;
 
-    #ifdef HDZERO_WHOOP_LITE
+    if (temp < 25)
+        pwr_offset = 0;
+    else if (temp < 30)
+        pwr_offset = 1;
+    else if (temp < 35)
+        pwr_offset = 2;
+    else if (temp < 38)
+        pwr_offset = 3;
+    else if (temp < 40)
+        pwr_offset = 4;
+    else if (temp < 43)
+        pwr_offset = 5;
+    else if (temp < 45)
+        pwr_offset = 6;
+    else if (temp < 48)
+        pwr_offset = 7;
+    else if (temp < 50)
+        pwr_offset = 8;
+    else if (temp < 53)
+        pwr_offset = 9;
+    else if (temp < 55)
+        pwr_offset = 10;
+    else if (temp < 58)
+        pwr_offset = 11;
+    else if (temp < 60)
+        pwr_offset = 12;
+    else if (temp < 63)
+        pwr_offset = 13;
+    else if (temp < 65)
+        pwr_offset = 14;
+    else if (temp < 68)
+        pwr_offset = 15;
+    else if (temp < 70)
+        pwr_offset = 16;
+    else if (temp < 73)
+        pwr_offset = 17;
+    else if (temp < 75)
+        pwr_offset = 18;
+    else if (temp < 78)
+        pwr_offset = 19;
+    else if (temp < 80)
+        pwr_offset = 20;
+    else
+        pwr_offset = 20;
+
+#ifdef HDZERO_WHOOP_LITE
     pwr_offset >>= 1;
-    #endif
+#endif
 
-    if((!g_IS_ARMED) && (last_ofs == pwr_offset));
+    if ((!g_IS_ARMED) && (last_ofs == pwr_offset))
+        ;
     else {
-    	DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
-        #ifdef _DEBUG_MODE
-        verbosef("\r\nPowerAutoSwitch: temp = %x%x, ",(uint16_t)(temp>>8),(uint16_t)(temp&0xff));
+        DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
+#ifdef _DEBUG_MODE
+        verbosef("\r\nPowerAutoSwitch: temp = %x%x, ", (uint16_t)(temp >> 8), (uint16_t)(temp & 0xff));
         verbosef("pwr_offset = %d", (uint16_t)pwr_offset);
-        #endif
+#endif
         cur_pwr = RF_POWER;
     }
 }
 #else
-void PowerAutoSwitch()
-{
+void PowerAutoSwitch() {
     int16_t temp;
     static uint8_t last_ofs = 0;
-	
-    if(pwr_sflg)
+
+    if (pwr_sflg)
         pwr_sflg = 0;
     else
         return;
-	
+
     temp = temperature >> 2;
-    
-    if(RF_POWER == 0){
-        if(temp < 0x479)      pwr_offset = 0;
-        else if(temp < 0x488) pwr_offset = 1;
-        else if(temp < 0x4A2) pwr_offset = 2;
-        else if(temp < 0x4B5) pwr_offset = 3;
-        else if(temp < 0x4C7) pwr_offset = 4;
-        else if(temp < 0x4DD) pwr_offset = 5;
-        else if(temp < 0x4F0) pwr_offset = 6;
-        else if(temp < 0x500) pwr_offset = 7;
-        else if(temp < 0x512) pwr_offset = 8;
-        else if(temp < 0x524) pwr_offset = 9;
-        else if(temp < 0x534) pwr_offset = 10;
-        else if(temp < 0x544) pwr_offset = 11;
-        else if(temp < 0x554) pwr_offset = 12;
-        else if(temp < 0x564) pwr_offset = 13;
-        else if(temp < 0x574) pwr_offset = 14;
-        else if(temp < 0x582) pwr_offset = 15;
-        else if(temp < 0x592) pwr_offset = 16;
-        else if(temp < 0x59D) pwr_offset = 17;
-        else if(temp < 0x5AC) pwr_offset = 18;
-        else                  pwr_offset = 19;
-    }
-    else {
-        if(temp < 0x479)      pwr_offset = 0;
-        else if(temp < 0x488) pwr_offset = 1;
-        else if(temp < 0x4A2) pwr_offset = 2;
-        else if(temp < 0x4B5) pwr_offset = 3;
-        else if(temp < 0x4C7) pwr_offset = 4;
-        else if(temp < 0x4DD) pwr_offset = 5;
-        else if(temp < 0x4F0) pwr_offset = 6;
-        else if(temp < 0x500) pwr_offset = 7;
-        else if(temp < 0x512) pwr_offset = 8;
-        else if(temp < 0x523) pwr_offset = 9;
-        else if(temp < 0x533) pwr_offset = 10;
-        else if(temp < 0x543) pwr_offset = 11;
-        else if(temp < 0x552) pwr_offset = 12;
-        else if(temp < 0x562) pwr_offset = 13;
-        else if(temp < 0x572) pwr_offset = 14;
-        else if(temp < 0x580) pwr_offset = 15;
-        else if(temp < 0x590) pwr_offset = 16;
-        else if(temp < 0x59B) pwr_offset = 17;
-        else if(temp < 0x5AA) pwr_offset = 18;
-        else                  pwr_offset = 19;
+
+    if (RF_POWER == 0) {
+        if (temp < 0x479)
+            pwr_offset = 0;
+        else if (temp < 0x488)
+            pwr_offset = 1;
+        else if (temp < 0x4A2)
+            pwr_offset = 2;
+        else if (temp < 0x4B5)
+            pwr_offset = 3;
+        else if (temp < 0x4C7)
+            pwr_offset = 4;
+        else if (temp < 0x4DD)
+            pwr_offset = 5;
+        else if (temp < 0x4F0)
+            pwr_offset = 6;
+        else if (temp < 0x500)
+            pwr_offset = 7;
+        else if (temp < 0x512)
+            pwr_offset = 8;
+        else if (temp < 0x524)
+            pwr_offset = 9;
+        else if (temp < 0x534)
+            pwr_offset = 10;
+        else if (temp < 0x544)
+            pwr_offset = 11;
+        else if (temp < 0x554)
+            pwr_offset = 12;
+        else if (temp < 0x564)
+            pwr_offset = 13;
+        else if (temp < 0x574)
+            pwr_offset = 14;
+        else if (temp < 0x582)
+            pwr_offset = 15;
+        else if (temp < 0x592)
+            pwr_offset = 16;
+        else if (temp < 0x59D)
+            pwr_offset = 17;
+        else if (temp < 0x5AC)
+            pwr_offset = 18;
+        else
+            pwr_offset = 19;
+    } else {
+        if (temp < 0x479)
+            pwr_offset = 0;
+        else if (temp < 0x488)
+            pwr_offset = 1;
+        else if (temp < 0x4A2)
+            pwr_offset = 2;
+        else if (temp < 0x4B5)
+            pwr_offset = 3;
+        else if (temp < 0x4C7)
+            pwr_offset = 4;
+        else if (temp < 0x4DD)
+            pwr_offset = 5;
+        else if (temp < 0x4F0)
+            pwr_offset = 6;
+        else if (temp < 0x500)
+            pwr_offset = 7;
+        else if (temp < 0x512)
+            pwr_offset = 8;
+        else if (temp < 0x523)
+            pwr_offset = 9;
+        else if (temp < 0x533)
+            pwr_offset = 10;
+        else if (temp < 0x543)
+            pwr_offset = 11;
+        else if (temp < 0x552)
+            pwr_offset = 12;
+        else if (temp < 0x562)
+            pwr_offset = 13;
+        else if (temp < 0x572)
+            pwr_offset = 14;
+        else if (temp < 0x580)
+            pwr_offset = 15;
+        else if (temp < 0x590)
+            pwr_offset = 16;
+        else if (temp < 0x59B)
+            pwr_offset = 17;
+        else if (temp < 0x5AA)
+            pwr_offset = 18;
+        else
+            pwr_offset = 19;
     }
 
-    if(temp_err)
+    if (temp_err)
         pwr_offset = 10;
-    
-    if(last_ofs != pwr_offset){
-        #ifdef _DEBUG_MODE
-        verbosef("\r\nPowerAutoSwitch:Yes %x %x",temp, (uint16_t)pwr_offset);
-        #endif
+
+    if (last_ofs != pwr_offset) {
+#ifdef _DEBUG_MODE
+        verbosef("\r\nPowerAutoSwitch:Yes %x %x", temp, (uint16_t)pwr_offset);
+#endif
         DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
         cur_pwr = RF_POWER;
-    }else{
-        #ifdef _DEBUG_MODE
-        verbosef("\r\nPowerAutoSwitch: No %x %x",temp, (uint16_t)pwr_offset);
-        #endif
+    } else {
+#ifdef _DEBUG_MODE
+        verbosef("\r\nPowerAutoSwitch: No %x %x", temp, (uint16_t)pwr_offset);
+#endif
     }
-    
+
     last_ofs = pwr_offset;
 }
 #endif
-void HeatProtect()
-{
+void HeatProtect() {
     static uint16_t cur_sec = 0;
     static uint8_t sec = 0;
     static uint8_t cnt = 0;
     int16_t temp;
-    
-    #ifdef USE_TEMPERATURE_SENSOR
+
+#ifdef USE_TEMPERATURE_SENSOR
     int16_t temp_max = 0x5A;
-    #else
+#else
     int16_t temp_max = 0x5C0;
     int16_t temp_err_data = 0x700;
-    #endif
+#endif
 
-    if(!g_IS_ARMED){
-        if(heat_protect == 0){
-            if(cur_sec != seconds){
+    if (!g_IS_ARMED) {
+        if (heat_protect == 0) {
+            if (cur_sec != seconds) {
                 cur_sec = seconds;
                 sec++;
-                if(sec >= 4){
+                if (sec >= 4) {
                     sec = 0;
                     temp = temperature >> 2;
-                    //temp = temperature >> 5;  //LM75AD
-                    #ifdef _DEBUG_MODE
-                    #ifdef USE_TEMPERATURE_SENSOR
+// temp = temperature >> 5;  //LM75AD
+#ifdef _DEBUG_MODE
+#ifdef USE_TEMPERATURE_SENSOR
                     verbosef("\r\nHeat detect: temp = %d, pwr_offset=%d", (uint16_t)temp, (uint16_t)pwr_offset);
-                    #else
-                    verbosef("\r\nHeat Protect detect: %x",temp);
-                    #endif
-                    #endif
-                    
-                    #ifdef USE_TEMPERATURE_SENSOR
+#else
+                    verbosef("\r\nHeat Protect detect: %x", temp);
+#endif
+#endif
+
+#ifdef USE_TEMPERATURE_SENSOR
                     ;
-                    #else
-                    if(temp > temp_err_data){
+#else
+                    if (temp > temp_err_data) {
                         temp_err = 1;
                         return;
                     }
-                    #endif
-                    
-                    #ifdef USE_TEMPERATURE_SENSOR
-                    if(temp >= temp_max){
-                    #else
-                    if((temp_err== 0) && temp >= temp_max){
-                    #endif
+#endif
+
+#ifdef USE_TEMPERATURE_SENSOR
+                    if (temp >= temp_max) {
+#else
+                    if ((temp_err == 0) && temp >= temp_max) {
+#endif
                         cnt++;
-                        if(cnt == 3){
-                            #ifdef _DEBUG_MODE
+                        if (cnt == 3) {
+#ifdef _DEBUG_MODE
                             debugf("\r\nHeat Protect.");
-                            #endif
+#endif
                             heat_protect = 1;
-                            #ifdef HDZERO_FREESTYLE
+#ifdef HDZERO_FREESTYLE
                             WriteReg(0, 0x8F, 0x00);
-                            msp_set_vtx_config(POWER_MAX+1, 0);
-                            #else
+                            msp_set_vtx_config(POWER_MAX + 1, 0);
+#else
                             DM6300_SetPower(0, RF_FREQ, 0);
                             msp_set_vtx_config(0, 0);
-                            #endif
+#endif
                             cur_pwr = 0;
                             pwr_offset = 0;
                             pwr_lmt_done = pwr_lmt_sec = 0;
                             cnt = 0;
                         }
-                    }
-                    else cnt = 0;
+                    } else
+                        cnt = 0;
                 }
             }
-        }
-        else {
-            if(cur_sec != seconds){
+        } else {
+            if (cur_sec != seconds) {
                 cur_sec = seconds;
-                led_status = 1-led_status;
-                if(led_status == ON)
+                led_status = 1 - led_status;
+                if (led_status == ON)
                     LED_BLUE_ON;
                 else
                     LED_BLUE_OFF;
             }
         }
-    }
-    else{
-        if(heat_protect){
+    } else {
+        if (heat_protect) {
             LED_BLUE_OFF;
             led_status = OFF;
         }
@@ -701,65 +745,63 @@ void HeatProtect()
     }
 }
 
-void PwrLMT()
-{
+void PwrLMT() {
     static uint8_t p_init = 1;
-    
-    if(cur_pwr > POWER_MAX)
+
+    if (cur_pwr > POWER_MAX)
         return;
-    
+
 #ifndef _RF_CALIB
-    if(SA_lock){          //Smart Audio
+    if (SA_lock) { // Smart Audio
         HeatProtect();
-        if(!heat_protect){
-            if(pwr_lmt_done == 0){
-                if(pwr_tflg){
+        if (!heat_protect) {
+            if (pwr_lmt_done == 0) {
+                if (pwr_tflg) {
                     pwr_tflg = 0;
                     pwr_lmt_sec++;
-                    
-                    #ifdef HDZERO_FREESTYLE
-                    //test: power plus every sec 
-                    if(pwr_lmt_sec >= 3){
-                        if(RF_POWER == 3){
-                            if(p_init){
+
+#ifdef HDZERO_FREESTYLE
+                    // test: power plus every sec
+                    if (pwr_lmt_sec >= 3) {
+                        if (RF_POWER == 3) {
+                            if (p_init) {
                                 p = table_power[RF_FREQ][3] - 0x1C;
                                 p_init = 0;
                             }
-                                
+
                             SPI_Write(0x6, 0xFF0, 0x00000018);
-                            
-                            if(p >= table_power[RF_FREQ][3]){
+
+                            if (p >= table_power[RF_FREQ][3]) {
                                 p = table_power[RF_FREQ][3];
-                            }else{
+                            } else {
                                 p += 0x4;
-                                debugf("\r\npwr_plus 2dbm,p=%x",(uint16_t)p);
+                                debugf("\r\npwr_plus 2dbm,p=%x", (uint16_t)p);
                             }
-                            
+
                             SPI_Write(0x3, 0xD1C, (uint32_t)p);
-                            SPI_Write(0x3, 0x330, 0x31F); //1W
+                            SPI_Write(0x3, 0x330, 0x31F); // 1W
                         }
                     }
-                    #endif
-                        
-                    #ifdef _DEBUG_MODE
+#endif
+
+#ifdef _DEBUG_MODE
                     debugf("\r\npwr_lmt_sec %x", (uint16_t)pwr_lmt_sec);
-                    #endif
-                    if(pwr_lmt_sec >= PWR_LMT_SEC){
+#endif
+                    if (pwr_lmt_sec >= PWR_LMT_SEC) {
                         DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
                         cur_pwr = RF_POWER;
                         pwr_lmt_done = 1;
                         pwr_lmt_sec = 0;
-                        //test: power init reset   
+                        // test: power init reset
                         p_init = 1;
-                        
-                        #ifdef _DEBUG_MODE
+
+#ifdef _DEBUG_MODE
                         debugf("\r\nPower limit done.");
-                        #endif
+#endif
                         Prompt();
                     }
                 }
-            }
-            else{
+            } else {
                 PowerAutoSwitch();
             }
         }
@@ -771,69 +813,65 @@ void PwrLMT()
             PowerAutoSwitch();
     }
     */
-    else if(g_IS_ARMED){    //Armed
+    else if (g_IS_ARMED) { // Armed
         PowerAutoSwitch();
-    }
-    else{                   //Disarmed
-        if(PIT_MODE){
+    } else { // Disarmed
+        if (PIT_MODE) {
             /*if(cur_pwr == 0mW)
                 set 0mW;
             else
                 set 0.1mW;*/
-        }
-        else if(LP_MODE){
-            //DM6300_SetPower(0, RF_FREQ, 0);
-            //cur_pwr = 0;
-        }
-        else{
+        } else if (LP_MODE) {
+            // DM6300_SetPower(0, RF_FREQ, 0);
+            // cur_pwr = 0;
+        } else {
             HeatProtect();
-            if(!heat_protect){
-                if(pwr_lmt_done == 0){
-                    if(pwr_tflg){
+            if (!heat_protect) {
+                if (pwr_lmt_done == 0) {
+                    if (pwr_tflg) {
                         pwr_tflg = 0;
                         pwr_lmt_sec++;
-                        
-                        #ifdef HDZERO_FREESTYLE
-                        //test: power plus every sec 
-                        if(pwr_lmt_sec >= 3){
-                            if(RF_POWER == 3){
-                                if(p_init){
+
+#ifdef HDZERO_FREESTYLE
+                        // test: power plus every sec
+                        if (pwr_lmt_sec >= 3) {
+                            if (RF_POWER == 3) {
+                                if (p_init) {
                                     p = table_power[RF_FREQ][3] - 0x1C;
                                     p_init = 0;
                                 }
-                                SPI_Write(0x6, 0xFF0, 0x00000018); //set page
-                                
-                                if(p >= table_power[RF_FREQ][3])
+                                SPI_Write(0x6, 0xFF0, 0x00000018); // set page
+
+                                if (p >= table_power[RF_FREQ][3])
                                     p = table_power[RF_FREQ][3];
-                                else{ 
+                                else {
                                     p += 0x4;
-                                    debugf("\r\npwr_plus 2dbm,p=%x",(uint16_t)p + pwr_offset);
+                                    debugf("\r\npwr_plus 2dbm,p=%x", (uint16_t)p + pwr_offset);
                                 }
-                                SPI_Write(0x3, 0xD1C, (uint32_t)(p+pwr_offset)); //digital offset
-                                SPI_Write(0x3, 0x330, 0x31F); // analog offset 1W
+                                SPI_Write(0x3, 0xD1C, (uint32_t)(p + pwr_offset)); // digital offset
+                                SPI_Write(0x3, 0x330, 0x31F);                      // analog offset 1W
                             }
                         }
-                        #endif//HDZERO_FREESTYLE
-                            
-                        #ifdef _DEBUG_MODE
+#endif // HDZERO_FREESTYLE
+
+#ifdef _DEBUG_MODE
                         debugf("\r\npwr_lmt_sec %x", (uint16_t)pwr_lmt_sec);
-                        #endif
-                        if(pwr_lmt_sec >= PWR_LMT_SEC){
+#endif
+                        if (pwr_lmt_sec >= PWR_LMT_SEC) {
                             DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
                             cur_pwr = RF_POWER;
                             pwr_lmt_done = 1;
                             pwr_lmt_sec = 0;
-                            //test: power init reset   
+                            // test: power init reset
                             p_init = 1;
-                            
-                            #ifdef _DEBUG_MODE
+
+#ifdef _DEBUG_MODE
                             debugf("\r\nPower limit done.");
-                            #endif
+#endif
                             Prompt();
                         }
                     }
-                }
-                else{
+                } else {
                     PowerAutoSwitch();
                 }
             }
@@ -844,11 +882,10 @@ void PwrLMT()
 #endif
 }
 
-void Flicker_LED(uint8_t n)
-{
+void Flicker_LED(uint8_t n) {
     uint8_t i;
-    for(i=0; i<n; i++){
-    	LED_BLUE_OFF;
+    for (i = 0; i < n; i++) {
+        LED_BLUE_OFF;
         WAIT(120);
         LED_BLUE_ON;
         WAIT(120);
@@ -856,102 +893,100 @@ void Flicker_LED(uint8_t n)
     led_status = ON;
 }
 
-void Video_Detect()
-{
+void Video_Detect() {
     static uint16_t last_sec = 0;
     static uint8_t sec = 0;
     uint8_t vdet;
     uint16_t val = 0;
-    
-    if(last_sec != seconds){
+
+    if (last_sec != seconds) {
         last_sec = seconds;
         sec++;
-        
+
 #ifdef _DEBUG_TC3587
-    val = I2C_Read16(ADDR_TC3587, 0x0062);
-    debugf("\r\n0x0062 = 0x%x", val);
-    val = I2C_Read16(ADDR_TC3587, 0x0064);
-    debugf("\r\n0x0064 = 0x%x", val);
-    val = I2C_Read16(ADDR_TC3587, 0x0066);
-    debugf("\r\n0x0066 = 0x%x", val);
-    val = I2C_Read16(ADDR_TC3587, 0x0068);
-    debugf("\r\n0x0068 = 0x%x", val);
-    val = I2C_Read16(ADDR_TC3587, 0x006A);
-    debugf("\r\n0x006A = 0x%x", val);
-    val = I2C_Read16(ADDR_TC3587, 0x006C);
-    debugf("\r\n0x006C = 0x%x", val);
-    val = I2C_Read16(ADDR_TC3587, 0x006E);
-    debugf("\r\n0x006E = 0x%x", val);
-    val = I2C_Read16(ADDR_TC3587, 0x0070);
-    debugf("\r\n0x0070 = 0x%x", val);
-    val = I2C_Read16(ADDR_TC3587, 0x0080);
-    debugf("\r\n0x0080 = 0x%x", val);
-    val = I2C_Read16(ADDR_TC3587, 0x0082);
-    debugf("\r\n0x0082 = 0x%x", val);
-    val = I2C_Read16(ADDR_TC3587, 0x0084);
-    debugf("\r\n0x0084 = 0x%x", val);
-    val = I2C_Read16(ADDR_TC3587, 0x0086);
-    debugf("\r\n0x0086 = 0x%x", val);
-    val = I2C_Read16(ADDR_TC3587, 0x0088);
-    debugf("\r\n0x0088 = 0x%x", val);
-    val = I2C_Read16(ADDR_TC3587, 0x008A);
-    debugf("\r\n0x008A = 0x%x", val);
-    val = I2C_Read16(ADDR_TC3587, 0x008C);
-    debugf("\r\n0x008C = 0x%x", val);
-    val = I2C_Read16(ADDR_TC3587, 0x008E);
-    debugf("\r\n0x008E = 0x%x", val);
-    val = I2C_Read16(ADDR_TC3587, 0x0090);
-    debugf("\r\n0x0090 = 0x%x", val);
-    val = I2C_Read16(ADDR_TC3587, 0x00F8);
-    debugf("\r\n0x00F8 = 0x%x", val);
-    I2C_Write16(ADDR_TC3587, 0x0064, 0x01ff);
-    I2C_Write16(ADDR_TC3587, 0x0068, 0x0000);
-    I2C_Write16(ADDR_TC3587, 0x006C, 0x0000);
-    I2C_Write16(ADDR_TC3587, 0x0080, 0x0000);
-    I2C_Write16(ADDR_TC3587, 0x0082, 0x0000);
-    I2C_Write16(ADDR_TC3587, 0x0084, 0x0000);
-    I2C_Write16(ADDR_TC3587, 0x0086, 0x0000);
-    I2C_Write16(ADDR_TC3587, 0x0088, 0x0000);
-    I2C_Write16(ADDR_TC3587, 0x008A, 0x0000);
-    I2C_Write16(ADDR_TC3587, 0x008C, 0x0000);
-    I2C_Write16(ADDR_TC3587, 0x008E, 0x0000);
-    I2C_Write16(ADDR_TC3587, 0x0090, 0x0000);
+        val = I2C_Read16(ADDR_TC3587, 0x0062);
+        debugf("\r\n0x0062 = 0x%x", val);
+        val = I2C_Read16(ADDR_TC3587, 0x0064);
+        debugf("\r\n0x0064 = 0x%x", val);
+        val = I2C_Read16(ADDR_TC3587, 0x0066);
+        debugf("\r\n0x0066 = 0x%x", val);
+        val = I2C_Read16(ADDR_TC3587, 0x0068);
+        debugf("\r\n0x0068 = 0x%x", val);
+        val = I2C_Read16(ADDR_TC3587, 0x006A);
+        debugf("\r\n0x006A = 0x%x", val);
+        val = I2C_Read16(ADDR_TC3587, 0x006C);
+        debugf("\r\n0x006C = 0x%x", val);
+        val = I2C_Read16(ADDR_TC3587, 0x006E);
+        debugf("\r\n0x006E = 0x%x", val);
+        val = I2C_Read16(ADDR_TC3587, 0x0070);
+        debugf("\r\n0x0070 = 0x%x", val);
+        val = I2C_Read16(ADDR_TC3587, 0x0080);
+        debugf("\r\n0x0080 = 0x%x", val);
+        val = I2C_Read16(ADDR_TC3587, 0x0082);
+        debugf("\r\n0x0082 = 0x%x", val);
+        val = I2C_Read16(ADDR_TC3587, 0x0084);
+        debugf("\r\n0x0084 = 0x%x", val);
+        val = I2C_Read16(ADDR_TC3587, 0x0086);
+        debugf("\r\n0x0086 = 0x%x", val);
+        val = I2C_Read16(ADDR_TC3587, 0x0088);
+        debugf("\r\n0x0088 = 0x%x", val);
+        val = I2C_Read16(ADDR_TC3587, 0x008A);
+        debugf("\r\n0x008A = 0x%x", val);
+        val = I2C_Read16(ADDR_TC3587, 0x008C);
+        debugf("\r\n0x008C = 0x%x", val);
+        val = I2C_Read16(ADDR_TC3587, 0x008E);
+        debugf("\r\n0x008E = 0x%x", val);
+        val = I2C_Read16(ADDR_TC3587, 0x0090);
+        debugf("\r\n0x0090 = 0x%x", val);
+        val = I2C_Read16(ADDR_TC3587, 0x00F8);
+        debugf("\r\n0x00F8 = 0x%x", val);
+        I2C_Write16(ADDR_TC3587, 0x0064, 0x01ff);
+        I2C_Write16(ADDR_TC3587, 0x0068, 0x0000);
+        I2C_Write16(ADDR_TC3587, 0x006C, 0x0000);
+        I2C_Write16(ADDR_TC3587, 0x0080, 0x0000);
+        I2C_Write16(ADDR_TC3587, 0x0082, 0x0000);
+        I2C_Write16(ADDR_TC3587, 0x0084, 0x0000);
+        I2C_Write16(ADDR_TC3587, 0x0086, 0x0000);
+        I2C_Write16(ADDR_TC3587, 0x0088, 0x0000);
+        I2C_Write16(ADDR_TC3587, 0x008A, 0x0000);
+        I2C_Write16(ADDR_TC3587, 0x008C, 0x0000);
+        I2C_Write16(ADDR_TC3587, 0x008E, 0x0000);
+        I2C_Write16(ADDR_TC3587, 0x0090, 0x0000);
 #endif
 
-        if(heat_protect)
+        if (heat_protect)
             return;
 
-        if(cameraID){
-            for(i=0; i<5; i++){
+        if (cameraID) {
+            for (i = 0; i < 5; i++) {
                 val |= I2C_Read16(ADDR_TC3587, 0x006A);
                 val |= I2C_Read16(ADDR_TC3587, 0x006E);
             }
-            if(val){
+            if (val) {
                 LED_BLUE_ON;
                 led_status = ON;
-            }else{
+            } else {
                 LED_BLUE_OFF;
                 led_status = OFF;
             }
             return;
         }
-        
+
         vdet = ReadReg(0, 0x02) >> 4;
-            
+
         led_status = vdet;
-        if(led_status == ON)
+        if (led_status == ON)
             LED_BLUE_ON;
         else
             LED_BLUE_OFF;
-            
-        if(sec == 3){
+
+        if (sec == 3) {
             sec = 0;
-            if(vdet){ // video loss
-                if(CAM_MODE == CAM_720P50){
+            if (vdet) { // video loss
+                if (CAM_MODE == CAM_720P50) {
                     Set_720P60(IS_RX);
                     CAM_MODE = CAM_720P60;
-                }
-                else if(CAM_MODE == CAM_720P60){
+                } else if (CAM_MODE == CAM_720P60) {
                     Set_720P50(IS_RX);
                     CAM_MODE = CAM_720P50;
                 }
@@ -960,201 +995,197 @@ void Video_Detect()
     }
 }
 
-void Imp_RF_Param()
-{
+void Imp_RF_Param() {
     DM6300_SetChannel(RF_FREQ);
-    if(LP_MODE && !g_IS_ARMED)
+    if (LP_MODE && !g_IS_ARMED)
         return;
 #ifndef VIDEO_PAT
 #ifdef HDZERO_FREESTYLE
-    if(RF_POWER == 3 && !g_IS_ARMED)
+    if (RF_POWER == 3 && !g_IS_ARMED)
         pwr_lmt_done = 0;
     else
 #endif
 #endif
-    DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
+        DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
     cur_pwr = RF_POWER;
 }
 
-void Button1_SP()
-{
+void Button1_SP() {
     debugf("\r\nButton1_SP.");
     cfg_to_cnt = 0;
-    switch(cfg_step){
-        case 0:
-            cfg_step = 1;
-            if((RF_FREQ == 8) || (RF_FREQ==9))
-                dispF_cnt = 0;
-            CFG_Back();
-        
-            //exit 0mW
-            if(vtx_pit_save == PIT_0MW){
-                #ifdef _DEBUG_MODE
-                debugf("\n\rcfg_step(0),DM6300 init");
-                #endif
-                Init_6300RF(RF_FREQ, RF_POWER);
-                DM6300_AUXADC_Calib();
-                cur_pwr = RF_POWER;
-            }
-            //reset pitmode
-            vtx_pit_save = PIT_OFF;
-            PIT_MODE = PIT_OFF;
-            break;
-        case 1:
-            //exit 0mW
-            if(vtx_pit_save == PIT_0MW){
-                #ifdef _DEBUG_MODE
-                debugf("\n\rcfg_step(1),DM6300 init");
-                #endif
-                Init_6300RF(RF_FREQ, RF_POWER);
-                DM6300_AUXADC_Calib();
-                cur_pwr = RF_POWER;
-            }
-            //reset pitmode
-            vtx_pit_save = PIT_OFF;
-            PIT_MODE = PIT_OFF;
-            
-            if(RF_FREQ >= FREQ_MAX_EXT) RF_FREQ = 0;
-            else RF_FREQ++;
-        
-            if((RF_FREQ == 8) || (RF_FREQ == 9))
-                dispF_cnt = 0;
-            Imp_RF_Param();
-            Setting_Save();
-            msp_set_vtx_config(RF_POWER, 1);
-            
-            if(LP_MODE){
-                cur_pwr = 0;
-                DM6300_SetPower(0, RF_FREQ, 0);
-            }else{
-                DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
-                cur_pwr = RF_POWER;
-            }
-            break;
-        case 2:
-            if(vtx_pit_save == PIT_0MW){
-                //exit 0mW
-                #ifdef _DEBUG_MODE
-                debugf("\n\rcfg_step(2),DM6300 init");
-                #endif
-                Init_6300RF(RF_FREQ, RF_POWER);
-                DM6300_AUXADC_Calib();
-                cur_pwr = RF_POWER;
-            }
-            //reset pitmode
-            vtx_pit_save = PIT_OFF;
-            PIT_MODE = PIT_OFF;
-            
-            if(RF_POWER >= POWER_MAX) RF_POWER = 0;
-            else RF_POWER++;
-            #ifdef HDZERO_FREESTYLE
-            if(powerLock)
-                RF_POWER &= 0x01;
-            #endif
-            Imp_RF_Param();
-            Setting_Save();
-            
-            msp_set_vtx_config(RF_POWER, 1);
-            if(LP_MODE){ // limit power to 25mW
-                DM6300_SetPower(0, RF_FREQ, 0);
-                cur_pwr = 0;
-            }else{
-            #ifndef VIDEO_PAT
-            #ifdef HDZERO_FREESTYLE
-                if(RF_POWER == 3 && !g_IS_ARMED)
-                    pwr_lmt_done = 0;
-                else
-            #endif
-            #endif
-                {
-                DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
-                cur_pwr = RF_POWER;
-            	}
-            }
-            break;
-        case 3:
-            if(vtx_pit_save == PIT_0MW){
-                //exit 0mW
-                #ifdef _DEBUG_MODE
-                debugf("\n\rcfg_step(3),DM6300 init");
-                #endif
-                Init_6300RF(RF_FREQ, RF_POWER);
-                DM6300_AUXADC_Calib();
-                cur_pwr = RF_POWER;
-            }
-            //reset pitmode
-            vtx_pit_save = PIT_OFF;
-            PIT_MODE = PIT_OFF;
+    switch (cfg_step) {
+    case 0:
+        cfg_step = 1;
+        if ((RF_FREQ == 8) || (RF_FREQ == 9))
+            dispF_cnt = 0;
+        CFG_Back();
 
-            LP_MODE ++;
-            if(LP_MODE > 2)
-                LP_MODE = 0;
+        // exit 0mW
+        if (vtx_pit_save == PIT_0MW) {
+#ifdef _DEBUG_MODE
+            debugf("\n\rcfg_step(0),DM6300 init");
+#endif
+            Init_6300RF(RF_FREQ, RF_POWER);
+            DM6300_AUXADC_Calib();
+            cur_pwr = RF_POWER;
+        }
+        // reset pitmode
+        vtx_pit_save = PIT_OFF;
+        PIT_MODE = PIT_OFF;
+        break;
+    case 1:
+        // exit 0mW
+        if (vtx_pit_save == PIT_0MW) {
+#ifdef _DEBUG_MODE
+            debugf("\n\rcfg_step(1),DM6300 init");
+#endif
+            Init_6300RF(RF_FREQ, RF_POWER);
+            DM6300_AUXADC_Calib();
+            cur_pwr = RF_POWER;
+        }
+        // reset pitmode
+        vtx_pit_save = PIT_OFF;
+        PIT_MODE = PIT_OFF;
 
-            if(LP_MODE)
-            {
-                DM6300_SetPower(0, RF_FREQ, 0); // limit power to 25mW
-                cur_pwr = 0;
-                #ifdef _DEBUG_MODE
-                debugf("\n\rEnter LP_MODE");
-                #endif
-            }
+        if (RF_FREQ >= FREQ_MAX_EXT)
+            RF_FREQ = 0;
+        else
+            RF_FREQ++;
+
+        if ((RF_FREQ == 8) || (RF_FREQ == 9))
+            dispF_cnt = 0;
+        Imp_RF_Param();
+        Setting_Save();
+        msp_set_vtx_config(RF_POWER, 1);
+
+        if (LP_MODE) {
+            cur_pwr = 0;
+            DM6300_SetPower(0, RF_FREQ, 0);
+        } else {
+            DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
+            cur_pwr = RF_POWER;
+        }
+        break;
+    case 2:
+        if (vtx_pit_save == PIT_0MW) {
+// exit 0mW
+#ifdef _DEBUG_MODE
+            debugf("\n\rcfg_step(2),DM6300 init");
+#endif
+            Init_6300RF(RF_FREQ, RF_POWER);
+            DM6300_AUXADC_Calib();
+            cur_pwr = RF_POWER;
+        }
+        // reset pitmode
+        vtx_pit_save = PIT_OFF;
+        PIT_MODE = PIT_OFF;
+
+        if (RF_POWER >= POWER_MAX)
+            RF_POWER = 0;
+        else
+            RF_POWER++;
+#ifdef HDZERO_FREESTYLE
+        if (powerLock)
+            RF_POWER &= 0x01;
+#endif
+        Imp_RF_Param();
+        Setting_Save();
+
+        msp_set_vtx_config(RF_POWER, 1);
+        if (LP_MODE) { // limit power to 25mW
+            DM6300_SetPower(0, RF_FREQ, 0);
+            cur_pwr = 0;
+        } else {
+#ifndef VIDEO_PAT
+#ifdef HDZERO_FREESTYLE
+            if (RF_POWER == 3 && !g_IS_ARMED)
+                pwr_lmt_done = 0;
             else
+#endif
+#endif
             {
-                DM6300_SetPower(RF_POWER, RF_FREQ, 0);
+                DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
+                cur_pwr = RF_POWER;
             }
+        }
+        break;
+    case 3:
+        if (vtx_pit_save == PIT_0MW) {
+// exit 0mW
+#ifdef _DEBUG_MODE
+            debugf("\n\rcfg_step(3),DM6300 init");
+#endif
+            Init_6300RF(RF_FREQ, RF_POWER);
+            DM6300_AUXADC_Calib();
+            cur_pwr = RF_POWER;
+        }
+        // reset pitmode
+        vtx_pit_save = PIT_OFF;
+        PIT_MODE = PIT_OFF;
 
-            msp_set_vtx_config(RF_POWER, 1);
-        
-            Setting_Save();
-            break;
+        LP_MODE++;
+        if (LP_MODE > 2)
+            LP_MODE = 0;
+
+        if (LP_MODE) {
+            DM6300_SetPower(0, RF_FREQ, 0); // limit power to 25mW
+            cur_pwr = 0;
+#ifdef _DEBUG_MODE
+            debugf("\n\rEnter LP_MODE");
+#endif
+        } else {
+            DM6300_SetPower(RF_POWER, RF_FREQ, 0);
+        }
+
+        msp_set_vtx_config(RF_POWER, 1);
+
+        Setting_Save();
+        break;
     }
-    //debugf("\r\nShort Press: cfg_step=%d, RF_FREQ=%d, RF_POWER=%d", (uint16_t)cfg_step, (uint16_t)RF_FREQ, (uint16_t)RF_POWER);
+    // debugf("\r\nShort Press: cfg_step=%d, RF_FREQ=%d, RF_POWER=%d", (uint16_t)cfg_step, (uint16_t)RF_FREQ, (uint16_t)RF_POWER);
 }
 
-void Button1_LP()
-{
-    #ifdef _DEBUG_MODE
+void Button1_LP() {
+#ifdef _DEBUG_MODE
     debugf("\r\nButton1_LP.");
-    #endif
+#endif
     cfg_to_cnt = 0;
-    switch(cfg_step){
-        case 0:
-            cfg_step = 2;
-            CFG_Back();
-            Init_MAX7315(0xFF);
-            break;
-        case 1:
-            cfg_step = 2;
-            Init_MAX7315(0xFF);
-            break;
-        case 2:
-        case 3:
-            cfg_step = 0;
-            Init_MAX7315(0x00);
-            WAIT(100);
-            Init_MAX7315(0xFF);
-            break;
+    switch (cfg_step) {
+    case 0:
+        cfg_step = 2;
+        CFG_Back();
+        Init_MAX7315(0xFF);
+        break;
+    case 1:
+        cfg_step = 2;
+        Init_MAX7315(0xFF);
+        break;
+    case 2:
+    case 3:
+        cfg_step = 0;
+        Init_MAX7315(0x00);
+        WAIT(100);
+        Init_MAX7315(0xFF);
+        break;
     }
-    //debugf("\r\nShort Press: cfg_step=%d, FREQ_CFG=%d, POWER_CFG=%d", (uint16_t)cfg_step, (uint16_t)FREQ_CFG, (uint16_t)POWER_CFG);
+    // debugf("\r\nShort Press: cfg_step=%d, FREQ_CFG=%d, POWER_CFG=%d", (uint16_t)cfg_step, (uint16_t)FREQ_CFG, (uint16_t)POWER_CFG);
 }
 
-void Button1_LLP()
-{
-    #ifdef _DEBUG_MODE
+void Button1_LLP() {
+#ifdef _DEBUG_MODE
     debugf("\r\nButton1_LLP.");
-    #endif
+#endif
     cfg_to_cnt = 0;
-    if(cfg_step == 0){
+    if (cfg_step == 0) {
         cfg_step = 3;
         CFG_Back();
         Init_MAX7315(0xFF);
     }
 }
 
-void Flicker_MAX(uint8_t ch, uint8_t cnt)
-{
+void Flicker_MAX(uint8_t ch, uint8_t cnt) {
     uint8_t i;
-    for(i=0; i<cnt; i++){
+    for (i = 0; i < cnt; i++) {
         Init_MAX7315(0xFF);
         WAIT(90);
         Init_MAX7315(ch);
@@ -1170,126 +1201,120 @@ void BlinkPhase() {
         bp = BPLED[14];
         I2C_Write8(ADDR_KEYBOARD, 0x01, bp);
         I2C_Write8(ADDR_KEYBOARD, 0x03, 0x00);
-    }else{
-        switch(cfg_step){
-            case 0:
-                //Init_MAX7315(0xFF);
-                break;
+    } else {
+        switch (cfg_step) {
+        case 0:
+            // Init_MAX7315(0xFF);
+            break;
 
-            case 1:
-                if(RF_FREQ <= 7) 
-                    bp = BPLED[RF_FREQ+1];
-                else if(RF_FREQ == 8)   //F2
-                    bp = BPLED[2];
-                else if(RF_FREQ == 9)   //F4
-                    bp = BPLED[4];
-                I2C_Write8(ADDR_KEYBOARD, 0x01, bp);
-                I2C_Write8(ADDR_KEYBOARD, 0x03, 0x00);
-                break;
+        case 1:
+            if (RF_FREQ <= 7)
+                bp = BPLED[RF_FREQ + 1];
+            else if (RF_FREQ == 8) // F2
+                bp = BPLED[2];
+            else if (RF_FREQ == 9) // F4
+                bp = BPLED[4];
+            I2C_Write8(ADDR_KEYBOARD, 0x01, bp);
+            I2C_Write8(ADDR_KEYBOARD, 0x03, 0x00);
+            break;
 
-            case 2:
-                bp = BPLED[RF_POWER+1] & 0x7F;
-                I2C_Write8(ADDR_KEYBOARD, 0x01, bp);
-                I2C_Write8(ADDR_KEYBOARD, 0x03, 0x00);
-                break;
+        case 2:
+            bp = BPLED[RF_POWER + 1] & 0x7F;
+            I2C_Write8(ADDR_KEYBOARD, 0x01, bp);
+            I2C_Write8(ADDR_KEYBOARD, 0x03, 0x00);
+            break;
 
-            case 3:
-                bp = BPLED[LP_MODE+1];
-                I2C_Write8(ADDR_KEYBOARD, 0x01, bp);
-                I2C_Write8(ADDR_KEYBOARD, 0x03, 0x00);
-                break;
+        case 3:
+            bp = BPLED[LP_MODE + 1];
+            I2C_Write8(ADDR_KEYBOARD, 0x01, bp);
+            I2C_Write8(ADDR_KEYBOARD, 0x03, 0x00);
+            break;
         }
     }
 }
 
-void CFGTimeout()
-{
-    if(cfg_step != 0){ // timeout
-        if(cfg_tflg){
+void CFGTimeout() {
+    if (cfg_step != 0) { // timeout
+        if (cfg_tflg) {
             cfg_tflg = 0;
             cfg_to_cnt++;
-            if(cfg_to_cnt >= CFG_TO_SEC){
+            if (cfg_to_cnt >= CFG_TO_SEC) {
                 CFG_Back();
                 cfg_step = 0;
-                
+
                 Init_MAX7315(0xFF);
-                #ifdef _DEBUG_MODE
+#ifdef _DEBUG_MODE
                 debugf("\r\nCFG Timeout.");
-                #endif
+#endif
                 Prompt();
             }
         }
     }
 }
 
-void OnButton1()
-{
+void OnButton1() {
     static uint8_t btn_down = 0;
     static uint8_t sec = 0;
     static uint8_t leave_respond = 0;
     static uint16_t cur_sec = 0;
     static uint8_t last_keyon = 0;
-    
-    if(cur_sec != seconds){
+
+    if (cur_sec != seconds) {
         cur_sec = seconds;
-        
+
         USE_MAX7315 = !I2C_Write8(ADDR_MAX7315, 0x09, 0);
         USE_PCA9554 = !I2C_Write8(ADDR_PCA9554, 0x09, 0);
-        
+
         KEYBOARD_ON = USE_MAX7315 | USE_PCA9554;
-        if(KEYBOARD_ON && (last_keyon == 0))
+        if (KEYBOARD_ON && (last_keyon == 0))
             Init_MAX7315(0xFF);
         last_keyon = KEYBOARD_ON;
     }
-     
-    if(KEYBOARD_ON == 0){
+
+    if (KEYBOARD_ON == 0) {
         WriteReg(0, 0xB0, 0x3E);
-        
+
         btn_down = sec = leave_respond = 0;
         cfg_step = 0;
         cfg_to_cnt = 0;
-    }else{
+    } else {
         WriteReg(0, 0xB0, 0x3F);
-        
-        if(btn_down == 0){
-            if(BTN_1 == 0){
+
+        if (btn_down == 0) {
+            if (BTN_1 == 0) {
                 WAIT(16);
-                if(BTN_1 == 0){
+                if (BTN_1 == 0) {
                     btn_down = 1;
                     sec = 0;
                 }
             }
-        }
-        else{
-            if(BTN_1){
-                if(leave_respond == 2) // long long press
+        } else {
+            if (BTN_1) {
+                if (leave_respond == 2) // long long press
                     Button1_LLP();
-                else if(leave_respond == 1) // long press
+                else if (leave_respond == 1) // long press
                     Button1_LP();
-                else if(leave_respond == 0) // short press
+                else if (leave_respond == 0) // short press
                     Button1_SP();
 
                 leave_respond = 0;
                 btn_down = 0;
                 sec = 0;
-            }
-            else if(btn1_tflg){
+            } else if (btn1_tflg) {
                 btn1_tflg = 0;
                 sec++;
-                if(sec == PRESS_L){
+                if (sec == PRESS_L) {
                     // enter long
-                    if(cfg_step <= 1){
+                    if (cfg_step <= 1) {
                         Flicker_MAX(0x0C, 3);
                         leave_respond = 1;
-                    }
-                    else{
+                    } else {
                         Button1_LP();
                         leave_respond = 3;
                     }
-                }
-                else if(sec == PRESS_LL){
+                } else if (sec == PRESS_LL) {
                     // enter long long
-                    if(cfg_step == 0 && leave_respond != 3){
+                    if (cfg_step == 0 && leave_respond != 3) {
                         Flicker_MAX(0x47, 3);
                         leave_respond = 2;
                     }
@@ -1297,7 +1322,7 @@ void OnButton1()
             }
         }
     }
-    
+
     BlinkPhase();
     CFGTimeout();
 }

--- a/src/hardware.c
+++ b/src/hardware.c
@@ -368,6 +368,9 @@ void Init_6300RF(uint8_t freq, uint8_t pwr)
 	    cur_pwr = pwr;
 	}
 	WriteReg(0, 0x8F, 0x11);
+    #ifdef _DEBUG_MODE
+    debugf("\r\nInit_6300RF(%x, %x)", (uint16_t)freq, (uint16_t)pwr);
+    #endif
 }
 
 void Init_HW()

--- a/src/hardware.h
+++ b/src/hardware.h
@@ -1,79 +1,81 @@
 #ifndef __HARDWARE_H_
 #define __HARDWARE_H_
 
-#include "stdint.h"
 #include "common.h"
 #include "i2c.h"
 #include "i2c_device.h"
+#include "stdint.h"
 
-typedef enum{
+typedef enum {
     ON,
     OFF,
-}ledType_e;
-typedef enum{
+} ledType_e;
+
+typedef enum {
     BW_27M,
     BW_20M
-}BWType_e;
-#define PWR_DEFAULT     2
-#define SPARKLE_T       20
+} BWType_e;
+
+#define PWR_DEFAULT 2
+#define SPARKLE_T   20
 
 // vtx parameter
-#define EEP_ADDR_RF_FREQ         0x80
-#define EEP_ADDR_RF_POWER        0x81
-#define EEP_ADDR_LPMODE          0x82
-#define EEP_ADDR_PITMODE         0x83
-#define EEP_ADDR_25MW            0x84
-#define EEP_ADDR_SA_LOCK         0x88
-#define EEP_ADDR_POWER_LOCK      0x89
-#define EEP_ADDR_VTX_CONFIG      0x8a
+#define EEP_ADDR_RF_FREQ    0x80
+#define EEP_ADDR_RF_POWER   0x81
+#define EEP_ADDR_LPMODE     0x82
+#define EEP_ADDR_PITMODE    0x83
+#define EEP_ADDR_25MW       0x84
+#define EEP_ADDR_SA_LOCK    0x88
+#define EEP_ADDR_POWER_LOCK 0x89
+#define EEP_ADDR_VTX_CONFIG 0x8a
 
-#define EEP_ADDR_LIFETIME_0      0xF0
-#define EEP_ADDR_LIFETIME_1      0xF1
-#define EEP_ADDR_LIFETIME_2      0xF2
-#define EEP_ADDR_LIFETIME_3      0xF3
+#define EEP_ADDR_LIFETIME_0  0xF0
+#define EEP_ADDR_LIFETIME_1  0xF1
+#define EEP_ADDR_LIFETIME_2  0xF2
+#define EEP_ADDR_LIFETIME_3  0xF3
 // camera parameter
-#define EEP_ADDR_CAM_PROFILE     0x3f  //
-                                       // [3:0] used for runcam v1
-                                       // [7:4] used for runcam v2
- 
+#define EEP_ADDR_CAM_PROFILE 0x3f //
+                                  // [3:0] used for runcam v1
+                                  // [7:4] used for runcam v2
+
 //                              Micro V1    Micro V2  Nano V2     Nano Lite
-#define EEP_ADDR_CAM_BRIGHTNESS  0x40//      0x50      0x60        0x70
-#define EEP_ADDR_CAM_SHARPNESS   0x41//      0x51      0x61        0x71
-#define EEP_ADDR_CAM_SATURATION  0x42//      0x52      0x62        0x72
-#define EEP_ADDR_CAM_CONTRAST    0x43//      0x53      0x63        0x73
-#define EEP_ADDR_CAM_HVFLIP      0x44//      0x54      0x64        0x74
-#define EEP_ADDR_CAM_NIGHTMODE   0x45//      0x55      0x65        0x75
+#define EEP_ADDR_CAM_BRIGHTNESS 0x40 //      0x50      0x60        0x70
+#define EEP_ADDR_CAM_SHARPNESS  0x41 //      0x51      0x61        0x71
+#define EEP_ADDR_CAM_SATURATION 0x42 //      0x52      0x62        0x72
+#define EEP_ADDR_CAM_CONTRAST   0x43 //      0x53      0x63        0x73
+#define EEP_ADDR_CAM_HVFLIP     0x44 //      0x54      0x64        0x74
+#define EEP_ADDR_CAM_NIGHTMODE  0x45 //      0x55      0x65        0x75
 //#define EEP_ADDR_CAM_RATIO       0x46//      0x56      0x66        0x76
-#define EEP_ADDR_CAM_WBMODE      0x47//      0x57      0x67        0x77
-#define EEP_ADDR_CAM_WBRED       0x48//      0x58      0x68        0x78
+#define EEP_ADDR_CAM_WBMODE     0x47 //      0x57      0x67        0x77
+#define EEP_ADDR_CAM_WBRED      0x48 //      0x58      0x68        0x78
 //#define EEP_ADDR_CAM_WBRED       0x49//      0x59      0x69        0x79
 //#define EEP_ADDR_CAM_WBRED       0x4a//      0x5a      0x6a        0x7a
 //#define EEP_ADDR_CAM_WBRED       0x4b//      0x5b      0x6b        0x7b
-#define EEP_ADDR_CAM_WBBLUE      0x4c//      0x5c      0x6c        0x7c
+#define EEP_ADDR_CAM_WBBLUE     0x4c //      0x5c      0x6c        0x7c
 //#define EEP_ADDR_CAM_WBBLUE      0x4d//      0x5d      0x6d        0x7d
 //#define EEP_ADDR_CAM_WBBLUE      0x4e//      0x5e      0x6e        0x7e
-//#define EEP_ADDR_CAM_WBBLUE      0x4f//      0x5f      0x6f        0x7f    
+//#define EEP_ADDR_CAM_WBBLUE      0x4f//      0x5f      0x6f        0x7f
 
-#define EEP_ADDR_DCOC_EN        0xC0
-#define EEP_ADDR_DCOC_IH        0xC1
-#define EEP_ADDR_DCOC_IL        0xC2
-#define EEP_ADDR_DCOC_QH        0xC3
-#define EEP_ADDR_DCOC_QL        0xC4
+#define EEP_ADDR_DCOC_EN 0xC0
+#define EEP_ADDR_DCOC_IH 0xC1
+#define EEP_ADDR_DCOC_IL 0xC2
+#define EEP_ADDR_DCOC_QH 0xC3
+#define EEP_ADDR_DCOC_QL 0xC4
 
-#define FREQ_MAX        7
-#define FREQ_MAX_EXT    9
+#define FREQ_MAX     7
+#define FREQ_MAX_EXT 9
 #if defined HDZERO_FREESTYLE
-    #define POWER_MAX   3
+#define POWER_MAX 3
 #else
-    #define POWER_MAX   1
+#define POWER_MAX 1
 #endif
 
 #ifdef HDZERO_FREESTYLE
-    #define LED_BLUE_ON     I2C_Write16(ADDR_TC3587, 0x0014, 0x0000)
-    #define LED_BLUE_OFF    I2C_Write16(ADDR_TC3587, 0x0014, 0x8000)
+#define LED_BLUE_ON  I2C_Write16(ADDR_TC3587, 0x0014, 0x0000)
+#define LED_BLUE_OFF I2C_Write16(ADDR_TC3587, 0x0014, 0x8000)
 #else
-    #define LED_BLUE_ON     LED_1 = ON
-    #define LED_BLUE_OFF    LED_1 = OFF
+#define LED_BLUE_ON  LED_1 = ON
+#define LED_BLUE_OFF LED_1 = OFF
 #endif
 
 void Init_HW();

--- a/src/i2c_device.c
+++ b/src/i2c_device.c
@@ -1,17 +1,18 @@
-#include "common.h"
-#include "i2c.h"
 #include "i2c_device.h"
-#include "print.h"
-#include "global.h"
+
 #include "camera.h"
+#include "common.h"
+#include "global.h"
 #include "hardware.h"
+#include "i2c.h"
+#include "print.h"
 
 /////////////////////////////////////////////////////////////////
 // MAX7315
 /*
 (1) 0 -> light up;  1-> turn off
 (2) blink phase 0 reg: 0x01
-    blink phase 1 reg: 0x09  
+    blink phase 1 reg: 0x09
      _______
     |  [0]  |
  [5]|       |[1]
@@ -36,17 +37,16 @@
     E -> 0x86
     r -> 0xAF
     F -> 0x8E
-    
+
     (3) reg 0x0F: blink flip
         [0]: 1 -> flip enable
         [1]: 0 -> phase0; 1 -> phase1
 */
 
 uint8_t USE_MAX7315 = 0;
-uint8_t USE_PCA9554 = 0; 
+uint8_t USE_PCA9554 = 0;
 
-void Init_MAX7315(uint32_t val)
-{
+void Init_MAX7315(uint32_t val) {
     I2C_Write8(ADDR_KEYBOARD, 0x01, val);  // set blink phase 0
     I2C_Write8(ADDR_KEYBOARD, 0x0F, 0x01); // use phase 0
     I2C_Write8(ADDR_KEYBOARD, 0x03, 0x00); // set MAX7315 data pin output
@@ -55,73 +55,70 @@ void Init_MAX7315(uint32_t val)
 /////////////////////////////////////////////////////////////////
 // TC3587
 #ifdef HDZERO_FREESTYLE
-void LED_TC3587_Init()
-{
+void LED_TC3587_Init() {
     I2C_Write16(ADDR_TC3587, 0x0002, 0x0001);
-    I2C_Write16(ADDR_TC3587, 0x0002, 0x0000); //srst
-    
-    I2C_Write16(ADDR_TC3587, 0x000E, 0x8000); //GPIO PD[23]--GPIO[15]
-    I2C_Write16(ADDR_TC3587, 0x0010, 0x7FFF); //output
-    I2C_Write16(ADDR_TC3587, 0x0014, 0x8000); //output 
+    I2C_Write16(ADDR_TC3587, 0x0002, 0x0000); // srst
+
+    I2C_Write16(ADDR_TC3587, 0x000E, 0x8000); // GPIO PD[23]--GPIO[15]
+    I2C_Write16(ADDR_TC3587, 0x0010, 0x7FFF); // output
+    I2C_Write16(ADDR_TC3587, 0x0014, 0x8000); // output
 }
 #endif
 
-void Init_TC3587()
-{
+void Init_TC3587() {
     uint16_t val = 0;
 
-    #ifdef TC3587_RSTB
-	TC3587_RSTB = 0;
-	WAIT(80);
-	TC3587_RSTB = 1;
-	WAIT(20);
-	#endif
+#ifdef TC3587_RSTB
+    TC3587_RSTB = 0;
+    WAIT(80);
+    TC3587_RSTB = 1;
+    WAIT(20);
+#endif
 
-    //detect TC3587
-    #ifdef _DEBUG_MODE
+// detect TC3587
+#ifdef _DEBUG_MODE
     debugf("\r\nDetecte TC3587...");
-    #endif
-    while(1){
+#endif
+    while (1) {
         val = I2C_Read16(ADDR_TC3587, 0x0000);
-        if(val == 0x4401){
+        if (val == 0x4401) {
             LED_BLUE_ON;
             led_status = ON;
             break;
-        }else{
-            if(led_status == ON){
+        } else {
+            if (led_status == ON) {
                 LED_BLUE_OFF;
                 led_status = OFF;
                 WAIT(50);
-            }else{
+            } else {
                 LED_BLUE_ON;
                 led_status = ON;
                 WAIT(20);
             }
         }
     }
-    #ifdef _DEBUG_MODE
+#ifdef _DEBUG_MODE
     debugf("\r\nFound TC3587");
-    #endif
-    
+#endif
+
     I2C_Write16(ADDR_TC3587, 0x0002, 0x0001);
-    I2C_Write16(ADDR_TC3587, 0x0002, 0x0000); //srst
-    
-    I2C_Write16(ADDR_TC3587, 0x0004, 0x026f); //config
-    
-    I2C_Write16(ADDR_TC3587, 0x0006, 0x0062); //fifo
-    I2C_Write16(ADDR_TC3587, 0x0008, 0x0061); //data format
-    
-    I2C_Write16(ADDR_TC3587, 0x0060, 0x800a); //mipi phy timing delay ; 0x800a
-    
-    I2C_Write16(ADDR_TC3587, 0x0018, 0x0111); //pll
-    I2C_Write16(ADDR_TC3587, 0x0018, 0x0113); //pll
-    I2C_Write16(ADDR_TC3587, 0x0016, 0x3057); //pll
-    I2C_Write16(ADDR_TC3587, 0x0020, 0x0000); //clk config
-    I2C_Write16(ADDR_TC3587, 0x000c, 0x0101); //mclk
-    I2C_Write16(ADDR_TC3587, 0x0018, 0x0111); //pll //0111
-    I2C_Write16(ADDR_TC3587, 0x0018, 0x0113); //pll //0113
+    I2C_Write16(ADDR_TC3587, 0x0002, 0x0000); // srst
+
+    I2C_Write16(ADDR_TC3587, 0x0004, 0x026f); // config
+
+    I2C_Write16(ADDR_TC3587, 0x0006, 0x0062); // fifo
+    I2C_Write16(ADDR_TC3587, 0x0008, 0x0061); // data format
+
+    I2C_Write16(ADDR_TC3587, 0x0060, 0x800a); // mipi phy timing delay ; 0x800a
+
+    I2C_Write16(ADDR_TC3587, 0x0018, 0x0111); // pll
+    I2C_Write16(ADDR_TC3587, 0x0018, 0x0113); // pll
+    I2C_Write16(ADDR_TC3587, 0x0016, 0x3057); // pll
+    I2C_Write16(ADDR_TC3587, 0x0020, 0x0000); // clk config
+    I2C_Write16(ADDR_TC3587, 0x000c, 0x0101); // mclk
+    I2C_Write16(ADDR_TC3587, 0x0018, 0x0111); // pll //0111
+    I2C_Write16(ADDR_TC3587, 0x0018, 0x0113); // pll //0113
     I2C_Write16(ADDR_TC3587, 0x0002, 0x0001);
     I2C_Write16(ADDR_TC3587, 0x0002, 0x0000);
-    //WAIT(100);
+    // WAIT(100);
 }
-

--- a/src/i2c_device.h
+++ b/src/i2c_device.h
@@ -3,15 +3,14 @@
 
 #include "common.h"
 
-#define ADDR_MAX7315    0x20
-#define ADDR_PCA9554    0x38
+#define ADDR_MAX7315 0x20
+#define ADDR_PCA9554 0x38
 
-#define ADDR_TP2825     0x44
-#define ADDR_TC3587     0x0E
-#define ADDR_EEPROM     0x50
-#define ADDR_TEMPADC    0x48
-#define ADDR_RUNCAM     0x21
-
+#define ADDR_TP2825  0x44
+#define ADDR_TC3587  0x0E
+#define ADDR_EEPROM  0x50
+#define ADDR_TEMPADC 0x48
+#define ADDR_RUNCAM  0x21
 
 void Init_MAX7315(uint32_t val);
 #ifdef HDZERO_FREESTYLE
@@ -20,8 +19,8 @@ void LED_TC3587_Init();
 void Init_TC3587();
 
 extern uint8_t USE_MAX7315;
-extern uint8_t USE_PCA9554; 
+extern uint8_t USE_PCA9554;
 
-#define ADDR_KEYBOARD   (USE_MAX7315 ? ADDR_MAX7315 : ADDR_PCA9554)
+#define ADDR_KEYBOARD (USE_MAX7315 ? ADDR_MAX7315 : ADDR_PCA9554)
 
-#endif
+#endif /* __I2C_DEVICE_H_ */

--- a/src/isr.c
+++ b/src/isr.c
@@ -1,7 +1,7 @@
+#include "isr.h"
+
 #include "common.h"
 #include "global.h"
-#include "uart.h"
-#include "isr.h"
 #include "uart.h"
 
 BIT_TYPE btn1_tflg = 0;
@@ -16,50 +16,48 @@ BIT_TYPE RS0_ERR = 0;
 IDATA_SEG volatile uint16_t timer_ms10x = 0;
 uint16_t seconds = 0;
 
-void CPU_init(void)
-{
-    SCON0 = 0x50;   // [7:6] uart0 mode: 0x01 = 8bit, variable baudrate(related to timer1)
-                    // [4]   uart0 rx enable
+void CPU_init(void) {
+    SCON0 = 0x50; // [7:6] uart0 mode: 0x01 = 8bit, variable baudrate(related to timer1)
+                  // [4]   uart0 rx enable
 
-    SCON1 = 0x50;   // [7:6] uart1 mode: 0x01 = 8bit, variable baudrate(related to timer1)
-                    // [4]   uart1 rx enable
+    SCON1 = 0x50; // [7:6] uart1 mode: 0x01 = 8bit, variable baudrate(related to timer1)
+                  // [4]   uart1 rx enable
 
-    PCON  = 0xC0;   // [7]   double rate for uart0
-                    // [6]   double rate for uart1
+    PCON = 0xC0; // [7]   double rate for uart0
+                 // [6]   double rate for uart1
 
-    TMOD  = 0x20;   // [7]   timer1 enabled by pin gate1
-                    // [6]   timer1: 0=as timer, 1=as counter
-                    // [5:4] tmier1 mode: 0x10 = 8bit timer with 8bit auto-reload
-                    // [3]   timer0 enabled by pin gate0
-                    // [2]   timer0: 0=as timer, 1=as counter
-                    // [1:0] tmier0 mode: 0x01 = 16bit timer, {TH0,TL0} cascaded
+    TMOD = 0x20; // [7]   timer1 enabled by pin gate1
+                 // [6]   timer1: 0=as timer, 1=as counter
+                 // [5:4] tmier1 mode: 0x10 = 8bit timer with 8bit auto-reload
+                 // [3]   timer0 enabled by pin gate0
+                 // [2]   timer0: 0=as timer, 1=as counter
+                 // [1:0] tmier0 mode: 0x01 = 16bit timer, {TH0,TL0} cascaded
 
-    CKCON = 0x1F;   // [4]   timer1 uses a divide-by-N of the system clock frequency. 0:N=12; 1:N=4
-                    // [3]   timer0 uses a divide-by-N of the system clock frequency. 0:N=12; 1:N=4
-    
-    TH0   = 139;
-    TL0   = 0;
-    
-    TH1   = 0xEC;   // [7:0] in timer mode 0x10:   ----------------->> 148.5MHz: 0x87; 100MHz: 0xAF; 54MHz: 0xD4; 27MHz: 0xEA
-                    //	               f(clk)
-                    //  BaudRate = --------------  (M=16 or 32, decided by PCON double rate flag)
-                    //             N*(256-TH1)*M   (N=4 or 12, decided by CKCON [4])
-                    // 19200  - 0x87
-                    // 115200 - 0xEC    256 - 148.5M/64/115200 = 0xEC  0.7%
-                    // 230400 - 0xF6    256 - 148.5M/64/230400 = 0xF6  0.7%
-                    // 250000 - 0xF7    256 - 148.5M/64/250000 = 0xF7  3.125%
+    CKCON = 0x1F; // [4]   timer1 uses a divide-by-N of the system clock frequency. 0:N=12; 1:N=4
+                  // [3]   timer0 uses a divide-by-N of the system clock frequency. 0:N=12; 1:N=4
 
-    TCON  = 0x50;   // [6]   enable timer1
-                    // [4]   enable timer0
+    TH0 = 139;
+    TL0 = 0;
 
-    IE    = 0xD2;   // [7]   enable global interupts  1
-                    // [6]   enable uart1  interupt   1
-                    // [5]   enable timer2 interupt   0
-                    // [4]   enable uart0  interupt   1 
-                    // [3]   enable timer1 interupt   0 
-                    // [2]   enable INT1   interupt   0 
-                    // [1]   enable timer0 interupt   0
-                    // [0]   enable INT0   interupt   0
-    IP    = 0x10;   // UART0=higher priority, Timer 0 = low
-    
+    TH1 = 0xEC; // [7:0] in timer mode 0x10:   ----------------->> 148.5MHz: 0x87; 100MHz: 0xAF; 54MHz: 0xD4; 27MHz: 0xEA
+                //	               f(clk)
+                //  BaudRate = --------------  (M=16 or 32, decided by PCON double rate flag)
+                //             N*(256-TH1)*M   (N=4 or 12, decided by CKCON [4])
+                // 19200  - 0x87
+                // 115200 - 0xEC    256 - 148.5M/64/115200 = 0xEC  0.7%
+                // 230400 - 0xF6    256 - 148.5M/64/230400 = 0xF6  0.7%
+                // 250000 - 0xF7    256 - 148.5M/64/250000 = 0xF7  3.125%
+
+    TCON = 0x50; // [6]   enable timer1
+                 // [4]   enable timer0
+
+    IE = 0xD2; // [7]   enable global interupts  1
+               // [6]   enable uart1  interupt   1
+               // [5]   enable timer2 interupt   0
+               // [4]   enable uart0  interupt   1
+               // [3]   enable timer1 interupt   0
+               // [2]   enable INT1   interupt   0
+               // [1]   enable timer0 interupt   0
+               // [0]   enable INT0   interupt   0
+    IP = 0x10; // UART0=higher priority, Timer 0 = low
 }

--- a/src/isr.h
+++ b/src/isr.h
@@ -17,7 +17,6 @@ extern BIT_TYPE timer_8hz;
 extern BIT_TYPE timer_16hz;
 extern BIT_TYPE RS0_ERR;
 
-
 void CPU_init(void);
 
 #endif /* __ISR_H_ */

--- a/src/lifetime.c
+++ b/src/lifetime.c
@@ -4,8 +4,8 @@
 uint32_t sysLifeTime = 0;
 uint32_t sysLifeTime_last = 0;
 uint8_t LifeTimeOP = 0;
-void Get_EEP_LifeTime(void)
-{
+
+void Get_EEP_LifeTime(void) {
     uint8_t u8;
 
     u8 = I2C_Read8(ADDR_EEPROM, EEP_ADDR_LIFETIME_0);
@@ -17,8 +17,7 @@ void Get_EEP_LifeTime(void)
     u8 = I2C_Read8(ADDR_EEPROM, EEP_ADDR_LIFETIME_3);
     sysLifeTime += (uint32_t)u8 << 24;
 
-    if(sysLifeTime == 0xffffffff)
-    {
+    if (sysLifeTime == 0xffffffff) {
         I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_LIFETIME_0, 0x00);
         I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_LIFETIME_1, 0x00);
         I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_LIFETIME_2, 0x00);
@@ -27,10 +26,9 @@ void Get_EEP_LifeTime(void)
     }
 
     sysLifeTime_last = sysLifeTime;
-
 }
-void Update_EEP_LifeTime(void)
-{
+
+void Update_EEP_LifeTime(void) {
     uint8_t u8;
     uint32_t diff;
     static uint16_t lstSeconds = 0;
@@ -44,78 +42,66 @@ void Update_EEP_LifeTime(void)
 #ifdef _RF_CALIB
     return;
 #endif
-    
-    if(seconds - lstSeconds >= 10)
-    {
-        sysLifeTime ++;
+
+    if (seconds - lstSeconds >= 10) {
+        sysLifeTime++;
         lstSeconds = seconds;
-        if(sysLifeTime >= 3599999)
+        if (sysLifeTime >= 3599999)
             sysLifeTime = 3599999;
-    }
-    else
-    {
+    } else {
         return;
     }
 
     diff = sysLifeTime_last ^ sysLifeTime;
 
-    #ifdef _DEBUG_LIFETIME
-    debugf("\r\nsysLifeTime:%ld",sysLifeTime);
-    #endif
-    
-    if((diff >> 0) & 0xff)
-    {
-        u8 = (sysLifeTime >> 0)& 0xff;
+#ifdef _DEBUG_LIFETIME
+    debugf("\r\nsysLifeTime:%ld", sysLifeTime);
+#endif
+
+    if ((diff >> 0) & 0xff) {
+        u8 = (sysLifeTime >> 0) & 0xff;
         I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_LIFETIME_0, u8);
     }
 
-    if((diff >> 8) & 0xff)
-    {
+    if ((diff >> 8) & 0xff) {
         u8 = (sysLifeTime >> 8) & 0xff;
         I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_LIFETIME_1, u8);
     }
 
-    if((diff >> 16) & 0xff)
-    {
+    if ((diff >> 16) & 0xff) {
         u8 = (sysLifeTime >> 16) & 0xff;
         I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_LIFETIME_2, u8);
     }
 
-    if((diff >> 24) & 0xff)
-    {
+    if ((diff >> 24) & 0xff) {
         u8 = (sysLifeTime >> 24) & 0xff;
         I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_LIFETIME_3, u8);
     }
 
     sysLifeTime_last = sysLifeTime;
-
 }
 
-void ParseLifeTime(unsigned char *hourString, unsigned char *minuteString)
-{
+void ParseLifeTime(unsigned char *hourString, unsigned char *minuteString) {
     uint32_t minute;
     uint32_t hour;
 
-    hour = sysLifeTime/360;
-    hourString[0] = '0' + (hour%10000)/1000;
-    hourString[1] = '0' + (hour%1000)/100;
-    hourString[2] = '0' + (hour%100)/10;
-    hourString[3] = '0' + (hour%10);
+    hour = sysLifeTime / 360;
+    hourString[0] = '0' + (hour % 10000) / 1000;
+    hourString[1] = '0' + (hour % 1000) / 100;
+    hourString[2] = '0' + (hour % 100) / 10;
+    hourString[3] = '0' + (hour % 10);
 
-    if(hourString[0] == '0')
-    {
+    if (hourString[0] == '0') {
         hourString[0] = ' ';
-        if(hourString[1] == '0')
-        {
+        if (hourString[1] == '0') {
             hourString[1] = ' ';
-            if(hourString[2] == '0')
-            {
+            if (hourString[2] == '0') {
                 hourString[2] = ' ';
             }
         }
     }
-    
-    minute= (sysLifeTime%360)/6;
-    minuteString[0] = '0' + (minute%60)/10;
-    minuteString[1] = '0' + (minute%10);
+
+    minute = (sysLifeTime % 360) / 6;
+    minuteString[0] = '0' + (minute % 60) / 10;
+    minuteString[1] = '0' + (minute % 10);
 }

--- a/src/lifetime.h
+++ b/src/lifetime.h
@@ -2,10 +2,10 @@
 #define __LIFETIME_H_
 
 #include "common.h"
-#include "i2c.h"
-#include "hardware.h"
-#include "isr.h"
 #include "global.h"
+#include "hardware.h"
+#include "i2c.h"
+#include "isr.h"
 
 void Get_EEP_LifeTime(void);
 void Update_EEP_LifeTime(void);

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -1,33 +1,32 @@
-#include "common.h"
-#include "sfr_ext.h"
-#include "uart.h"
-#include "print.h"
-#include "global.h"
 #include "monitor.h"
+
+#include "camera.h"
+#include "common.h"
+#include "dm6300.h"
+#include "global.h"
 #include "hardware.h"
 #include "i2c.h"
 #include "i2c_device.h"
+#include "print.h"
+#include "sfr_ext.h"
 #include "spi.h"
-#include "dm6300.h"
-#include "camera.h"
+#include "uart.h"
 
 ///////////////////////////////////////////////
 // Global variables for this module only.
 // DO NOT TRY to use it outside the scope
-XDATA_SEG uint8_t 			incnt = 0;		// in char count
-XDATA_SEG uint8_t 			monstr[MAX_CMD_LEN];		// buffer for input string
-XDATA_SEG uint8_t    *argv[7];		// command line arguments
-XDATA_SEG uint8_t 			argc  = 0;		// command line cnt
-XDATA_SEG uint8_t 			last_argc = 0;
+XDATA_SEG uint8_t incnt = 0;           // in char count
+XDATA_SEG uint8_t monstr[MAX_CMD_LEN]; // buffer for input string
+XDATA_SEG uint8_t *argv[7];            // command line arguments
+XDATA_SEG uint8_t argc = 0;            // command line cnt
+XDATA_SEG uint8_t last_argc = 0;
 
-XDATA_SEG uint8_t 			comment=0;
-BIT_TYPE			    echo  = 1;
-BIT_TYPE                verbose = 1;
-
+XDATA_SEG uint8_t comment = 0;
+BIT_TYPE echo = 1;
+BIT_TYPE verbose = 1;
 
 #ifdef _DEBUG_MODE
-void MonHelp(void)
-{
+void MonHelp(void) {
     debugf("\r\nUsage: ");
     debugf("\r\n   w   addr  wdat   : Write reg_map register");
     debugf("\r\n   r   addr         : Read  reg_map register");
@@ -51,268 +50,254 @@ void MonHelp(void)
 #endif
 
 #ifdef _DEBUG_MODE
-uint8_t MonGetCommand(void)
-{
-	uint8_t i, ch;
-	uint8_t ret=0;
+uint8_t MonGetCommand(void) {
+    uint8_t i, ch;
+    uint8_t ret = 0;
 
-	if( !Mon_ready() ) return 0;
-	ch = Mon_rx();
+    if (!Mon_ready())
+        return 0;
+    ch = Mon_rx();
 
-	//----- if comment, echo back and ignore -----
-	if( comment ) {
-		if( ch=='\r' || ch==0x1b ) comment = 0;  //0x1b = esc
-		else { 
-			Mon_tx(ch);
-			return 0;
-		}
-	}
-	else if( ch==';' ) {
-		comment = 1;
-		Mon_tx(ch);
-		return 0;
-	}
+    //----- if comment, echo back and ignore -----
+    if (comment) {
+        if (ch == '\r' || ch == 0x1b)
+            comment = 0; // 0x1b = esc
+        else {
+            Mon_tx(ch);
+            return 0;
+        }
+    } else if (ch == ';') {
+        comment = 1;
+        Mon_tx(ch);
+        return 0;
+    }
 
-	//=====================================
-	switch( ch ) {
+    //=====================================
+    switch (ch) {
 
-	case 0x1b:  //ESC
-		argc = 0;
-		incnt = 0;
-		comment = 0;
-		Prompt();
-		return 0;
+    case 0x1b: // ESC
+        argc = 0;
+        incnt = 0;
+        comment = 0;
+        Prompt();
+        return 0;
 
-	//--- end of string
-	case '\r':
+    //--- end of string
+    case '\r':
 
-		if( incnt==0 ) {
-			Prompt();
-			break;
-		}
-		
-		monstr[incnt++] = '\0';
-		argc=0;
-		for(i=0; i<incnt; i++) if( monstr[i]!=' ' ) break;
+        if (incnt == 0) {
+            Prompt();
+            break;
+        }
 
-		if( !monstr[i] ) {
-			incnt = 0;
-			comment = 0;
-			Prompt();
-			return 0;
-		}
-		
-		
-		argv[0] = &monstr[i];
-		for(; i<incnt; i++) {
-			if( monstr[i]==' ' || monstr[i]=='\0' ) {
-				monstr[i]='\0';
-     			// debugf("(%s) ",  argv[argc]);
-				i++;
-				while( monstr[i]==' ' ) i++;
-				argc++;
-				if( monstr[i] ){
-     			 argv[argc] = &monstr[i];
-				}
-			}
-		}
+        monstr[incnt++] = '\0';
+        argc = 0;
+        for (i = 0; i < incnt; i++)
+            if (monstr[i] != ' ')
+                break;
 
-		ret = 1;
-		last_argc = argc;
-		incnt = 0;
-		
-		break;
+        if (!monstr[i]) {
+            incnt = 0;
+            comment = 0;
+            Prompt();
+            return 0;
+        }
 
-	//--- back space
-	case 0x08:
-		if( incnt ) {
-			incnt--;
-			Mon_tx(ch);
-			Mon_tx(' ');
-			Mon_tx(ch);
-		}
-		break;
+        argv[0] = &monstr[i];
+        for (; i < incnt; i++) {
+            if (monstr[i] == ' ' || monstr[i] == '\0') {
+                monstr[i] = '\0';
+                // debugf("(%s) ",  argv[argc]);
+                i++;
+                while (monstr[i] == ' ')
+                    i++;
+                argc++;
+                if (monstr[i]) {
+                    argv[argc] = &monstr[i];
+                }
+            }
+        }
 
-	//--- repeat command
-	case '/':
-		argc = last_argc;
-		ret = 1;
-		break;
+        ret = 1;
+        last_argc = argc;
+        incnt = 0;
 
+        break;
 
-	default:
-		if(incnt < MAX_CMD_LEN) {
-			Mon_tx(ch);
-			monstr[incnt++] = ch;
-		}
-		break;
-	}
+    //--- back space
+    case 0x08:
+        if (incnt) {
+            incnt--;
+            Mon_tx(ch);
+            Mon_tx(' ');
+            Mon_tx(ch);
+        }
+        break;
 
-	if( ret ) {
-		comment = 0;
-		last_argc = argc;
-		return ret;
-	}
-	else {
-		return ret;
-	}
+    //--- repeat command
+    case '/':
+        argc = last_argc;
+        ret = 1;
+        break;
+
+    default:
+        if (incnt < MAX_CMD_LEN) {
+            Mon_tx(ch);
+            monstr[incnt++] = ch;
+        }
+        break;
+    }
+
+    if (ret) {
+        comment = 0;
+        last_argc = argc;
+        return ret;
+    } else {
+        return ret;
+    }
 }
 #endif
 
-
 #ifdef _DEBUG_MODE
-void MonEE(uint8_t op, uint8_t d)
-{
+void MonEE(uint8_t op, uint8_t d) {
     uint8_t val;
     uint8_t addr;
-    
-    addr = RF_FREQ * (POWER_MAX+1) + RF_POWER;
+
+    addr = RF_FREQ * (POWER_MAX + 1) + RF_POWER;
     val = I2C_Read8(ADDR_EEPROM, addr);
-    
-    switch(op){
-        case 0: // ew
-            I2C_Write8_Wait(10, ADDR_EEPROM, addr, d);
-            break;
-        
-        case 1: // er
-            break;
-        
-        case 2: // ea
-            if(val != 0xFF)
-                val++;
-            I2C_Write8_Wait(10, ADDR_EEPROM, addr, val);
-            break;
-        
-        case 3: // es
-            if(val != 0)
-                val--;
-            I2C_Write8_Wait(10, ADDR_EEPROM, addr, val);
-            break;
+
+    switch (op) {
+    case 0: // ew
+        I2C_Write8_Wait(10, ADDR_EEPROM, addr, d);
+        break;
+
+    case 1: // er
+        break;
+
+    case 2: // ea
+        if (val != 0xFF)
+            val++;
+        I2C_Write8_Wait(10, ADDR_EEPROM, addr, val);
+        break;
+
+    case 3: // es
+        if (val != 0)
+            val--;
+        I2C_Write8_Wait(10, ADDR_EEPROM, addr, val);
+        break;
     }
-    
+
     val = I2C_Read8_Wait(10, ADDR_EEPROM, addr);
     table_power[RF_FREQ][RF_POWER] = val;
     debugf("\r\nRF TAB[%d][%d] = %x", (uint16_t)RF_FREQ, (uint16_t)RF_POWER, val);
-    
+
     DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
 }
 #endif
 
-
-void Monitor(void)
-{
+void Monitor(void) {
 #ifdef _DEBUG_MODE
-	if( !MonGetCommand() ) return;
+    if (!MonGetCommand())
+        return;
 
-	if( !stricmp( argv[0], "w" ) )
-		MonWrite(0);
-	else if ( !stricmp( argv[0], "r" ) )
-		MonRead(0);
-    else if( !stricmp( argv[0], "w2" ) )
-		MonWrite(1);
-	else if ( !stricmp( argv[0], "r2" ) )
-		MonRead(1);
-    else if( !stricmp( argv[0], "ww" ) )
-		MonWrite(2);
-	else if ( !stricmp( argv[0], "rr" ) )
-		MonRead(2);
-    else if ( !stricmp( argv[0], "pat" ) )
-                chg_vtx();
-    else if ( !stricmp( argv[0], "c" ) )
-		Init_6300RF(RF_FREQ, RF_POWER);
-    else if ( !stricmp( argv[0], "rfrst" ) ){
+    if (!stricmp(argv[0], "w"))
+        MonWrite(0);
+    else if (!stricmp(argv[0], "r"))
+        MonRead(0);
+    else if (!stricmp(argv[0], "w2"))
+        MonWrite(1);
+    else if (!stricmp(argv[0], "r2"))
+        MonRead(1);
+    else if (!stricmp(argv[0], "ww"))
+        MonWrite(2);
+    else if (!stricmp(argv[0], "rr"))
+        MonRead(2);
+    else if (!stricmp(argv[0], "pat"))
+        chg_vtx();
+    else if (!stricmp(argv[0], "c"))
+        Init_6300RF(RF_FREQ, RF_POWER);
+    else if (!stricmp(argv[0], "rfrst")) {
         WriteReg(0, 0x8F, 0x00);
         WriteReg(0, 0x8F, 0x11);
-    }
-    else if ( !stricmp( argv[0], "rf1" ) ){
-        //WriteReg(0, 0x8F, 0x00);
-        //WriteReg(0, 0x8F, 0x11);
-		DM6300_init1();
-    }
-    else if ( !stricmp( argv[0], "rf2" ) )
-		DM6300_init2(0);
-    else if ( !stricmp( argv[0], "rf3" ) )
-		DM6300_init3(RF_FREQ);
-    else if ( !stricmp( argv[0], "rf4" ) )
-		DM6300_init4();
-    else if ( !stricmp( argv[0], "rf5" ) )
-		DM6300_init5();
-    else if ( !stricmp( argv[0], "rf6" ) )
-		DM6300_init6(0);
-    else if ( !stricmp( argv[0], "rf7" ) )
-		DM6300_init7(0);
-    else if ( !stricmp( argv[0], "efuse1" ) ){
-		DM6300_EFUSE1();
+    } else if (!stricmp(argv[0], "rf1")) {
+        // WriteReg(0, 0x8F, 0x00);
+        // WriteReg(0, 0x8F, 0x11);
+        DM6300_init1();
+    } else if (!stricmp(argv[0], "rf2"))
+        DM6300_init2(0);
+    else if (!stricmp(argv[0], "rf3"))
+        DM6300_init3(RF_FREQ);
+    else if (!stricmp(argv[0], "rf4"))
+        DM6300_init4();
+    else if (!stricmp(argv[0], "rf5"))
+        DM6300_init5();
+    else if (!stricmp(argv[0], "rf6"))
+        DM6300_init6(0);
+    else if (!stricmp(argv[0], "rf7"))
+        DM6300_init7(0);
+    else if (!stricmp(argv[0], "efuse1")) {
+        DM6300_EFUSE1();
         SPI_Write(0x6, 0xFF0, 0x00000018);
-    }
-    else if ( !stricmp( argv[0], "efuse2" ) ){
-		DM6300_EFUSE2();
+    } else if (!stricmp(argv[0], "efuse2")) {
+        DM6300_EFUSE2();
         SPI_Write(0x6, 0xFF0, 0x00000018);
-    }
-    else if ( !stricmp( argv[0], "rftest" ) )
-		DM6300_RFTest();
-    else if ( !stricmp( argv[0], "bbon" ) )
-		WriteReg(0, 0x8F, 0x11);
-    else if ( !stricmp( argv[0], "bboff" ) )
-		WriteReg(0, 0x8F, 0x01);
-    //else if ( !stricmp( argv[0], "m0" ) )
-		//DM6300_M0();
-    else if ( !stricmp( argv[0], "ch" ) ){
-        if(argc == 3 && Asc2Bin(argv[1]) <= FREQ_MAX && Asc2Bin(argv[2]) <= POWER_MAX){
+    } else if (!stricmp(argv[0], "rftest"))
+        DM6300_RFTest();
+    else if (!stricmp(argv[0], "bbon"))
+        WriteReg(0, 0x8F, 0x11);
+    else if (!stricmp(argv[0], "bboff"))
+        WriteReg(0, 0x8F, 0x01);
+    // else if ( !stricmp( argv[0], "m0" ) )
+    // DM6300_M0();
+    else if (!stricmp(argv[0], "ch")) {
+        if (argc == 3 && Asc2Bin(argv[1]) <= FREQ_MAX && Asc2Bin(argv[2]) <= POWER_MAX) {
             RF_FREQ = Asc2Bin(argv[1]);
             RF_POWER = Asc2Bin(argv[2]);
             DM6300_SetChannel(RF_FREQ);
             DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
         }
-    }
-    else if ( !stricmp( argv[0], "ew" ) )
-		MonEE(0, Asc2Bin(argv[1]));
-    else if ( !stricmp( argv[0], "er" ) )
-		MonEE(1, 0);
-    else if ( !stricmp( argv[0], "ea" ) )
-		MonEE(2, 0);
-    else if ( !stricmp( argv[0], "es" ) )
-		MonEE(3, 0);
-    else if ( !stricmp( argv[0], "dc" ) ){
-        if(argc == 5){
+    } else if (!stricmp(argv[0], "ew"))
+        MonEE(0, Asc2Bin(argv[1]));
+    else if (!stricmp(argv[0], "er"))
+        MonEE(1, 0);
+    else if (!stricmp(argv[0], "ea"))
+        MonEE(2, 0);
+    else if (!stricmp(argv[0], "es"))
+        MonEE(3, 0);
+    else if (!stricmp(argv[0], "dc")) {
+        if (argc == 5) {
             I2C_Write8_Wait(10, ADDR_EEPROM, 0x88, Asc2Bin(argv[1]));
             I2C_Write8_Wait(10, ADDR_EEPROM, 0x89, Asc2Bin(argv[2]));
             I2C_Write8_Wait(10, ADDR_EEPROM, 0x8a, Asc2Bin(argv[3]));
             I2C_Write8_Wait(10, ADDR_EEPROM, 0x8b, Asc2Bin(argv[4]));
-            //debugf("\r\nWrite in eeprom, 0x88=%x,0x89=%x,0x8a=%x,0x8b=%x", 
-                   //Asc2Bin(argv[1]),Asc2Bin(argv[2]),Asc2Bin(argv[3]),Asc2Bin(argv[4]));
-        }
-        else 
+            // debugf("\r\nWrite in eeprom, 0x88=%x,0x89=%x,0x8a=%x,0x8b=%x",
+            // Asc2Bin(argv[1]),Asc2Bin(argv[2]),Asc2Bin(argv[3]),Asc2Bin(argv[4]));
+        } else
             debugf("   --> missing parameter!");
-    }
-    else if ( !stricmp( argv[0], "iq" ) ){
-        if(argc == 5){
+    } else if (!stricmp(argv[0], "iq")) {
+        if (argc == 5) {
             I2C_Write8_Wait(10, ADDR_EEPROM, 0x8c, Asc2Bin(argv[1]));
             I2C_Write8_Wait(10, ADDR_EEPROM, 0x8d, Asc2Bin(argv[2]));
             I2C_Write8_Wait(10, ADDR_EEPROM, 0x8e, Asc2Bin(argv[3]));
             I2C_Write8_Wait(10, ADDR_EEPROM, 0x8f, Asc2Bin(argv[4]));
-            debugf("\r\nWrite in eeprom, 0x88=%x,0x89=%x,0x8a=%x,0x8b=%x", 
-                   (uint16_t)Asc2Bin(argv[1]),(uint16_t)Asc2Bin(argv[2]),(uint16_t)Asc2Bin(argv[3]),(uint16_t)Asc2Bin(argv[4]));
-        }
-        else 
+            debugf("\r\nWrite in eeprom, 0x88=%x,0x89=%x,0x8a=%x,0x8b=%x",
+                   (uint16_t)Asc2Bin(argv[1]), (uint16_t)Asc2Bin(argv[2]), (uint16_t)Asc2Bin(argv[3]), (uint16_t)Asc2Bin(argv[4]));
+        } else
             debugf("   --> missing parameter!");
-    }
-    else if ( !stricmp( argv[0], "v" ) ) {
-		verbose = !verbose;
-        if(verbose)
+    } else if (!stricmp(argv[0], "v")) {
+        verbose = !verbose;
+        if (verbose)
             debugf("\r\nVerbose on");
         else
             debugf("\r\nVerbose off");
-    }
-	else if ( !stricmp( argv[0], "h" ) )
-		MonHelp();
-	else
-		debugf("\r\nInvalid Command...");
+    } else if (!stricmp(argv[0], "h"))
+        MonHelp();
+    else
+        debugf("\r\nInvalid Command...");
 
-	Prompt();
+    Prompt();
 #endif
 }
-
 
 #ifdef _DEBUG_MODE
 void MonWrite(uint8_t mode) {
@@ -328,42 +313,40 @@ void MonWrite(uint8_t mode) {
     uint16_t spi_data_L_h = 0;
     uint16_t spi_data_L_l = 0;
 
-    if(mode<2){
-        if( argc<3 ) {
+    if (mode < 2) {
+        if (argc < 3) {
             debugf("   --> missing parameter!");
             return;
         }
-        addr  = Asc4Bin( argv[1] );
-        value = Asc2Bin( argv[2] );
-        
+        addr = Asc4Bin(argv[1]);
+        value = Asc2Bin(argv[2]);
+
         WriteReg(mode, (uint8_t)addr, value);
-    }
-    else {
-        if( argc<4 ) {
+    } else {
+        if (argc < 4) {
             debugf("   --> missing parameter!");
             return;
         }
-        spi_trans  = Asc2Bin( argv[1] );
-        spi_addr   = Asc4Bin( argv[2] );
-        //spi_data_H = Asc8Bin( argv[3] );
-        spi_data_L = Asc8Bin( argv[3] );
+        spi_trans = Asc2Bin(argv[1]);
+        spi_addr = Asc4Bin(argv[2]);
+        // spi_data_H = Asc8Bin( argv[3] );
+        spi_data_L = Asc8Bin(argv[3]);
         SPI_Write(spi_trans, spi_addr, spi_data_L);
     }
 
-    if(echo){
-        if(mode<2){
+    if (echo) {
+        if (mode < 2) {
             value = ReadReg(mode, (uint8_t)addr);
-            debugf("\r\nRead %2xh: %2xh ",(uint16_t)addr,(uint16_t)value);
-        }
-        else{
+            debugf("\r\nRead %2xh: %2xh ", (uint16_t)addr, (uint16_t)value);
+        } else {
             spi_data_L = 0;
             SPI_Read(spi_trans, spi_addr, &spi_data_L);
-            
+
             spi_data_L_l = spi_data_L & 0xffff;
             spi_data_L_h = (spi_data_L >> 16) & 0xffff;
-            
-            debugf("\r\nRead %x: %x%x",(uint16_t)spi_addr,
-                                       (uint16_t)spi_data_L_h,(uint16_t)spi_data_L_l);
+
+            debugf("\r\nRead %x: %x%x", (uint16_t)spi_addr,
+                   (uint16_t)spi_data_L_h, (uint16_t)spi_data_L_l);
         }
     }
 }
@@ -382,63 +365,58 @@ void MonRead(uint8_t mode) {
     uint16_t spi_data_L_h = 0;
     uint16_t spi_data_L_l = 0;
 
-    if(mode<2){
-        if( argc<2 ) {
+    if (mode < 2) {
+        if (argc < 2) {
             debugf("   --> missing parameter!");
             return;
         }
-        addr  = Asc4Bin( argv[1] );
+        addr = Asc4Bin(argv[1]);
         value = ReadReg(mode, (uint8_t)addr);
-        debugf("\r\nRead %3xh: %2xh ",(uint16_t)addr,(uint16_t)value);
-    }
-    else {
-        if( argc<3 ) {
+        debugf("\r\nRead %3xh: %2xh ", (uint16_t)addr, (uint16_t)value);
+    } else {
+        if (argc < 3) {
             debugf("   --> missing parameter!");
             return;
         }
-        spi_trans  = Asc2Bin( argv[1] );
-        spi_addr   = Asc4Bin( argv[2] );
+        spi_trans = Asc2Bin(argv[1]);
+        spi_addr = Asc4Bin(argv[2]);
         SPI_Read(spi_trans, spi_addr, &spi_data_L);
-        
+
         spi_data_L_l = spi_data_L & 0xffff;
         spi_data_L_h = (spi_data_L >> 16) & 0xffff;
-        
-        debugf("\r\nRead %x: %x%x",(uint16_t)spi_addr,
-                                   (uint16_t)spi_data_L_h,(uint16_t)spi_data_L_l);
-        
+
+        debugf("\r\nRead %x: %x%x", (uint16_t)spi_addr,
+               (uint16_t)spi_data_L_h, (uint16_t)spi_data_L_l);
     }
 }
 
-void chg_vtx(void)
-{
-    uint8_t chan, pwr;            
-    uint8_t t0=0,t1=1,t2=2;
-    
-    if(argc<2){
-		debugf("   --> missing parameter!");
-		return;
-	}
-    
-    chan = Asc2Bin( argv[1] );
-    pwr  = Asc2Bin( argv[2] );    
-    
-    if(!stricmp( argv[1], "-1" )){  //Camera
+void chg_vtx(void) {
+    uint8_t chan, pwr;
+    uint8_t t0 = 0, t1 = 1, t2 = 2;
+
+    if (argc < 2) {
+        debugf("   --> missing parameter!");
+        return;
+    }
+
+    chan = Asc2Bin(argv[1]);
+    pwr = Asc2Bin(argv[2]);
+
+    if (!stricmp(argv[1], "-1")) { // Camera
         WriteReg(0, 0x50, 0x00);
         DM6300_SetChannel(RF_FREQ);
         DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
-        debugf("\r\nVTX Cam, channel = %d,power = %d,FPS = %d",(uint16_t)RF_FREQ,(uint16_t)RF_POWER,(uint16_t)CAM_MODE);
-    }
-    else { //pattern
+        debugf("\r\nVTX Cam, channel = %d,power = %d,FPS = %d", (uint16_t)RF_FREQ, (uint16_t)RF_POWER, (uint16_t)CAM_MODE);
+    } else { // pattern
         Set_720P60(0);
         CAM_MODE = CAM_720P60;
         WriteReg(0, 0x50, 0x01);
 
         RF_POWER = pwr;
-        RF_FREQ  = chan;
+        RF_FREQ = chan;
         DM6300_SetChannel(RF_FREQ);
         DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
-        debugf("\r\nVTX Pattern, channel = %d,power = %d,FPS = 1",(uint16_t)RF_FREQ, (uint16_t)RF_POWER);
+        debugf("\r\nVTX Pattern, channel = %d,power = %d,FPS = 1", (uint16_t)RF_FREQ, (uint16_t)RF_POWER);
     }
 }
 #endif
-

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -1,6 +1,9 @@
 #ifndef __MONITOR_H_
 #define __MONITOR_H_
 
+#include "stdint.h"
+#include "toolchain.h"
+
 #define MAX_CMD_LEN 30
 #define Prompt()    debugf("\r\nDM568X>")
 

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -2,7 +2,7 @@
 #define __MONITOR_H_
 
 #define MAX_CMD_LEN 30
-#define Prompt() debugf("\r\nDM568X>")
+#define Prompt()    debugf("\r\nDM568X>")
 
 // void MonHelp(void);
 uint8_t MonGetCommand(void);
@@ -10,6 +10,7 @@ void Monitor(void);
 void MonWrite(uint8_t mode);
 void MonRead(uint8_t mode);
 void chg_vtx(void);
+
 extern XDATA_SEG uint8_t *argv[7];
 
 #endif /* __MONITOR_H_ */

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -1,27 +1,28 @@
-#include "common.h"
-#include "global.h"
-#include "uart.h"
-#include "print.h"
 #include "msp_displayport.h"
-#include "isr.h"
-#include "hardware.h"
-#include "smartaudio_protocol.h"
-#include "dm6300.h"
+
 #include "camera.h"
-#include "spi.h"
+#include "common.h"
+#include "dm6300.h"
+#include "global.h"
+#include "hardware.h"
+#include "isr.h"
 #include "lifetime.h"
+#include "print.h"
+#include "smartaudio_protocol.h"
+#include "spi.h"
+#include "uart.h"
 
 uint8_t osd_buf[HD_VMAX][HD_HMAX];
 uint8_t loc_buf[HD_VMAX][7];
 uint8_t page_extend_buf[HD_VMAX][7];
-uint8_t tx_buf[TXBUF_SIZE];  //buffer for sending data to VRX
+uint8_t tx_buf[TXBUF_SIZE]; // buffer for sending data to VRX
 uint8_t dptxbuf[256];
-uint8_t dptx_rptr,dptx_wptr;
+uint8_t dptx_rptr, dptx_wptr;
 
 uint8_t fc_lock = 0;
-//BIT_TYPE[0] msp_displayport
-//BIT_TYPE[1] VTX_serial
-uint8_t disp_mode;  //DISPLAY_OSD | DISPLAY_CMS;
+// BIT_TYPE[0] msp_displayport
+// BIT_TYPE[1] VTX_serial
+uint8_t disp_mode; // DISPLAY_OSD | DISPLAY_CMS;
 uint8_t osd_ready;
 
 uint8_t fc_variant[4] = {'B', 'T', 'F', 'L'};
@@ -29,7 +30,7 @@ uint8_t fontType = 0x00;
 uint8_t resolution = SD_3016;
 uint8_t resolution_last = HD_5018;
 
-uint8_t msp_rx_buf[64]; //from FC responding status|variant|rc commands
+uint8_t msp_rx_buf[64]; // from FC responding status|variant|rc commands
 uint8_t disarmed = 1;
 
 uint8_t vtx_channel;
@@ -40,11 +41,11 @@ uint8_t vtx_pit_save = PIT_OFF;
 uint8_t vtx_offset = 0;
 uint8_t first_arm = 0;
 
-uint8_t fc_band_rx      = 0;
-uint8_t fc_channel_rx   = 0;
-uint8_t fc_pwr_rx       = 0;
-uint8_t fc_pit_rx       = 0;
-uint8_t fc_lp_rx        = 0;
+uint8_t fc_band_rx = 0;
+uint8_t fc_channel_rx = 0;
+uint8_t fc_pwr_rx = 0;
+uint8_t fc_pit_rx = 0;
+uint8_t fc_lp_rx = 0;
 
 uint8_t pit_mode_cfg_done = 0;
 uint8_t lp_mode_cfg_done = 0;
@@ -54,7 +55,7 @@ uint8_t lq_cnt = 0;
 
 uint8_t cms_state = CMS_OSD;
 
-uint8_t  msp_tx_cnt = 0xff;
+uint8_t msp_tx_cnt = 0xff;
 
 uint8_t msp_rcv = 0;
 uint16_t tick_8hz = 0;
@@ -80,70 +81,69 @@ uint8_t crc8tab[256] = {
     0x72, 0xA7, 0x0D, 0xD8, 0x8C, 0x59, 0xF3, 0x26, 0x5B, 0x8E, 0x24, 0xF1, 0xA5, 0x70, 0xDA, 0x0F,
     0x20, 0xF5, 0x5F, 0x8A, 0xDE, 0x0B, 0xA1, 0x74, 0x09, 0xDC, 0x76, 0xA3, 0xF7, 0x22, 0x88, 0x5D,
     0xD6, 0x03, 0xA9, 0x7C, 0x28, 0xFD, 0x57, 0x82, 0xFF, 0x2A, 0x80, 0x55, 0x01, 0xD4, 0x7E, 0xAB,
-    0x84, 0x51, 0xFB, 0x2E, 0x7A, 0xAF, 0x05, 0xD0, 0xAD, 0x78, 0xD2, 0x07, 0x53, 0x86, 0x2C, 0xF9
-};
+    0x84, 0x51, 0xFB, 0x2E, 0x7A, 0xAF, 0x05, 0xD0, 0xAD, 0x78, 0xD2, 0x07, 0x53, 0x86, 0x2C, 0xF9};
 
 uint8_t osd_menu_offset = 0;
 
 #ifdef USE_MSP
 
-void msp_task(){
+void msp_task() {
     uint8_t len;
     static uint8_t tx_row = 0;
     static uint8_t t1 = 0;
     static uint8_t vmax = SD_VMAX;
-    
-    #ifdef _DEBUG_DISPLAYPORT
-    if(RS0_ERR){
+
+#ifdef _DEBUG_DISPLAYPORT
+    if (RS0_ERR) {
         RS0_ERR = 0;
-        _outchar('$'); //RS0 buffer full
+        _outchar('$'); // RS0 buffer full
     }
-    #endif
+#endif
     DP_tx_task();
-    
-    //decide by osd_frame size/rate and dptx rate
-    if(msp_read_one_frame()){
-        if(resolution == HD_5018){
-            tx_row = HD_VMAX>>1;
+
+    // decide by osd_frame size/rate and dptx rate
+    if (msp_read_one_frame()) {
+        if (resolution == HD_5018) {
+            tx_row = HD_VMAX >> 1;
             vmax = HD_VMAX;
-        }else{
+        } else {
             tx_row = SD_VMAX;
             vmax = SD_VMAX;
         }
     }
-    
-    if(osd_ready){
-        //send osd
+
+    if (osd_ready) {
+        // send osd
         len = get_tx_data_osd(t1);
-        #ifdef _DEBUG_DISPLAYPORT
-        //debugf("\n\r%x ", (uint16_t)t1);
-        #endif
+#ifdef _DEBUG_DISPLAYPORT
+// debugf("\n\r%x ", (uint16_t)t1);
+#endif
         insert_tx_buf(len);
 
         t1++;
-        if(t1 >= vmax)
+        if (t1 >= vmax)
             t1 = 0;
     }
-    
-    if(timer_4hz)
+
+    if (timer_4hz)
         timer_4hz = 0;
 
-    //send param to FC -- 8HZ
-    //send param to VRX -- 8HZ
-    if(timer_8hz) {
+    // send param to FC -- 8HZ
+    // send param to VRX -- 8HZ
+    if (timer_8hz) {
         timer_8hz = 0;
         len = get_tx_data_5680();
         insert_tx_buf(len);
-        if(dispF_cnt < DISPF_TIME)
-            dispF_cnt ++;
-        
-        if(msp_tx_cnt <= 8)
+        if (dispF_cnt < DISPF_TIME)
+            dispF_cnt++;
+
+        if (msp_tx_cnt <= 8)
             msp_tx_cnt++;
         else
             msp_cmd_tx();
     }
 
-    //set_vtx
+    // set_vtx
     set_vtx_param();
 }
 
@@ -151,292 +151,292 @@ uint8_t msp_read_one_frame() {
     static uint8_t state = MSP_HEADER_START;
     static uint8_t cur_cmd = CUR_OTHERS;
     static uint8_t length, osd_len;
-    static uint8_t ptr = 0; //write ptr of msp_rx_buf
+    static uint8_t ptr = 0; // write ptr of msp_rx_buf
     static uint8_t crc = 0;
     static uint16_t cmd_u16 = 0;
     static uint16_t len_u16 = 0;
-    
-    uint8_t i,ret,full_frame,rx;
+
+    uint8_t i, ret, full_frame, rx;
 
     ret = 0;
     full_frame = 0;
-    for(i=0;i<16;i++) {
-        if((!CMS_ready()) || full_frame) return ret;
+    for (i = 0; i < 16; i++) {
+        if ((!CMS_ready()) || full_frame)
+            return ret;
         rx = CMS_rx();
 
-        switch(state) {
-            case MSP_HEADER_START:
-                if(rx == MSP_HEADER_START_BYTE) {
-                    ptr = 0;
-                    state = MSP_HEADER_M;
+        switch (state) {
+        case MSP_HEADER_START:
+            if (rx == MSP_HEADER_START_BYTE) {
+                ptr = 0;
+                state = MSP_HEADER_M;
+            }
+#ifdef _DEBUG_DISPLAYPORT
+            else
+                _outchar('&');
+#endif
+            break;
+
+        case MSP_HEADER_M:
+            if (rx == MSP_HEADER_M_BYTE) {
+                state = MSP_PACKAGE_REPLAY1;
+            } else if (rx == MSP_HEADER_M2_BYTE) {
+                state = MSP_PACKAGE_REPLAY2;
+            } else {
+                state = MSP_HEADER_START;
+            }
+            break;
+
+        case MSP_PACKAGE_REPLAY1: // 0x3E
+            if (rx == MSP_PACKAGE_REPLAY_BYTE) {
+                state = MSP_LENGTH;
+            } else {
+                state = MSP_HEADER_START;
+            }
+            break;
+
+        case MSP_LENGTH:
+            crc = rx;
+            state = MSP_CMD;
+            length = rx;
+            osd_len = rx - 4;
+            break;
+
+        case MSP_CMD:
+            crc ^= rx;
+            if (length == 0) {
+                cur_cmd = CUR_OTHERS;
+                state = MSP_CRC1;
+            } else {
+                if (rx == MSP_CMD_DISPLAYPORT_BYTE) {
+                    cur_cmd = CUR_DISPLAYPORT;
+                } else if (rx == MSP_CMD_RC_BYTE) {
+                    cur_cmd = CUR_RC;
+                } else if (rx == MSP_CMD_STATUS_BYTE) {
+                    cur_cmd = CUR_STATUS;
+                } else if (rx == MSP_CMD_FC_VARIANT) {
+                    cur_cmd = CUR_FC_VARIANT;
+                } else if (rx == MSP_CMD_VTX_CONFIG) {
+                    cur_cmd = CUR_VTX_CONFIG;
                 }
-                #ifdef _DEBUG_DISPLAYPORT
-                else 
-                    _outchar('&');
-                #endif
-                break;
+                state = MSP_RX1;
+            }
+            // debugf("\r\n%x ",(uint16_t)rx);
+            break;
 
-            case MSP_HEADER_M:
-                if(rx == MSP_HEADER_M_BYTE){
-                    state = MSP_PACKAGE_REPLAY1;
-                }else if(rx == MSP_HEADER_M2_BYTE){
-                    state = MSP_PACKAGE_REPLAY2;
-                }else{
-                    state = MSP_HEADER_START;
-                }
-                break;
+        case MSP_RX1:
+            crc ^= rx;
+            msp_rx_buf[ptr++] = rx;
+            ptr &= 63;
+            length--;
+            if (length == 0)
+                state = MSP_CRC1;
+            break;
 
-            case MSP_PACKAGE_REPLAY1: //0x3E
-                if(rx == MSP_PACKAGE_REPLAY_BYTE){
-                    state = MSP_LENGTH;
-                }else {
-                    state = MSP_HEADER_START;
-                }
-                break;
-
-            case MSP_LENGTH:
-                crc = rx;
-                state = MSP_CMD;
-                length = rx;
-                osd_len = rx - 4;
-                break;
-
-            case MSP_CMD:
-                crc ^= rx;
-                if(length == 0){
-                    cur_cmd = CUR_OTHERS;
-                    state = MSP_CRC1;
-                }else{
-                    if(rx == MSP_CMD_DISPLAYPORT_BYTE) {
-                        cur_cmd = CUR_DISPLAYPORT;
-                    }else if(rx == MSP_CMD_RC_BYTE) {
-                        cur_cmd = CUR_RC;
-                    }else if(rx == MSP_CMD_STATUS_BYTE) {
-                        cur_cmd = CUR_STATUS;
-                    }else if(rx == MSP_CMD_FC_VARIANT) {
-                        cur_cmd = CUR_FC_VARIANT;
-                    }else if(rx == MSP_CMD_VTX_CONFIG){
-                        cur_cmd = CUR_VTX_CONFIG;
-                    }
-                    state = MSP_RX1;
-                }
-                //debugf("\r\n%x ",(uint16_t)rx);
-                break;
-            
-            case MSP_RX1:
-                crc ^= rx;
-                msp_rx_buf[ptr++] = rx; ptr &= 63;
-                length--;
-                if(length == 0)
-                    state = MSP_CRC1;
-                break;
-
-            case MSP_CRC1:
-                if(rx == crc){
-                    if(cur_cmd == CUR_STATUS)
-                        parse_status();
-                    else if(cur_cmd == CUR_RC)
-                        parse_rc();
-                    else if(cur_cmd == CUR_FC_VARIANT)
-                        parse_variant();
-                    else if(cur_cmd == CUR_VTX_CONFIG)
-                        parse_vtx_config();
-                    else if(cur_cmd == CUR_DISPLAYPORT)
-                        ret = parse_displayport(osd_len);
-                    full_frame = 1;
-                    if(fc_lock & FC_VTX_CONFIG_LOCK){
-                        if(!(fc_lock & FC_INIT_VTX_TABLE_LOCK)) {
-                            if(fc_lock & FC_VARIANT_LOCK){
-                                fc_lock |= FC_INIT_VTX_TABLE_LOCK;
-                                if(fc_variant[0] == 'B' && fc_variant[1] == 'T' && fc_variant[2] == 'F' && fc_variant[3] == 'L'){
-                                    #ifdef INIT_VTX_TABLE
-                                    InitVtxTable();
-                                    #endif
-                                }
+        case MSP_CRC1:
+            if (rx == crc) {
+                if (cur_cmd == CUR_STATUS)
+                    parse_status();
+                else if (cur_cmd == CUR_RC)
+                    parse_rc();
+                else if (cur_cmd == CUR_FC_VARIANT)
+                    parse_variant();
+                else if (cur_cmd == CUR_VTX_CONFIG)
+                    parse_vtx_config();
+                else if (cur_cmd == CUR_DISPLAYPORT)
+                    ret = parse_displayport(osd_len);
+                full_frame = 1;
+                if (fc_lock & FC_VTX_CONFIG_LOCK) {
+                    if (!(fc_lock & FC_INIT_VTX_TABLE_LOCK)) {
+                        if (fc_lock & FC_VARIANT_LOCK) {
+                            fc_lock |= FC_INIT_VTX_TABLE_LOCK;
+                            if (fc_variant[0] == 'B' && fc_variant[1] == 'T' && fc_variant[2] == 'F' && fc_variant[3] == 'L') {
+#ifdef INIT_VTX_TABLE
+                                InitVtxTable();
+#endif
                             }
                         }
                     }
                 }
-                #ifdef _DEBUG_DISPLAYPORT
-                else
-                    _outchar('^');
-                #endif
-                    state = MSP_HEADER_START;
-                break;
+            }
+#ifdef _DEBUG_DISPLAYPORT
+            else
+                _outchar('^');
+#endif
+            state = MSP_HEADER_START;
+            break;
 
-            case MSP_PACKAGE_REPLAY2: //0x3E
-                if(rx == MSP_PACKAGE_REPLAY_BYTE){
-                    state = MSP_ZERO;
-                }else{
-                    state = MSP_HEADER_START;
-                }
-                break;
-
-            case MSP_ZERO: //0x00
-                crc = crc8tab[rx]; // 0 ^ rx = rx
-                if(rx == 0x00){
-                    state = MSP_CMD_L;
-                }else{
-                    state = MSP_HEADER_START;
-                }
-                break;
-
-            case MSP_CMD_L:
-                crc = crc8tab[crc ^ rx];
-                cmd_u16 = rx;
-                state = MSP_CMD_H;
-                break;
-
-            case MSP_CMD_H:
-                crc = crc8tab[crc ^ rx];
-                cmd_u16 += ((uint16_t)rx << 8);
-                state = MSP_LEN_L;
-                break;
-
-            case MSP_LEN_L:
-                crc = crc8tab[crc ^ rx];
-                len_u16 = rx;
-                state = MSP_LEN_H;
-                break;
-
-            case MSP_LEN_H:
-                crc = crc8tab[crc ^ rx];
-                len_u16 += ((uint16_t)rx << 8);
-                ptr = 0;
-                state = MSP_RX2;
-                break;
-
-            case MSP_RX2:
-                crc = crc8tab[crc ^ rx];
-                msp_rx_buf[ptr++] = rx; ptr &= 63;
-                len_u16--;
-                if(len_u16 == 0)
-                    state = MSP_CRC2;
-                break;
-
-            case MSP_CRC2:
-                if(crc == rx)
-                    parseMspVtx_V2(cmd_u16);
+        case MSP_PACKAGE_REPLAY2: // 0x3E
+            if (rx == MSP_PACKAGE_REPLAY_BYTE) {
+                state = MSP_ZERO;
+            } else {
                 state = MSP_HEADER_START;
-                break;
+            }
+            break;
 
-            default:
+        case MSP_ZERO:         // 0x00
+            crc = crc8tab[rx]; // 0 ^ rx = rx
+            if (rx == 0x00) {
+                state = MSP_CMD_L;
+            } else {
                 state = MSP_HEADER_START;
-                break;
-          }//switch(state)
-        } //i
-        return ret;
+            }
+            break;
+
+        case MSP_CMD_L:
+            crc = crc8tab[crc ^ rx];
+            cmd_u16 = rx;
+            state = MSP_CMD_H;
+            break;
+
+        case MSP_CMD_H:
+            crc = crc8tab[crc ^ rx];
+            cmd_u16 += ((uint16_t)rx << 8);
+            state = MSP_LEN_L;
+            break;
+
+        case MSP_LEN_L:
+            crc = crc8tab[crc ^ rx];
+            len_u16 = rx;
+            state = MSP_LEN_H;
+            break;
+
+        case MSP_LEN_H:
+            crc = crc8tab[crc ^ rx];
+            len_u16 += ((uint16_t)rx << 8);
+            ptr = 0;
+            state = MSP_RX2;
+            break;
+
+        case MSP_RX2:
+            crc = crc8tab[crc ^ rx];
+            msp_rx_buf[ptr++] = rx;
+            ptr &= 63;
+            len_u16--;
+            if (len_u16 == 0)
+                state = MSP_CRC2;
+            break;
+
+        case MSP_CRC2:
+            if (crc == rx)
+                parseMspVtx_V2(cmd_u16);
+            state = MSP_HEADER_START;
+            break;
+
+        default:
+            state = MSP_HEADER_START;
+            break;
+        } // switch(state)
+    }     // i
+    return ret;
 }
 
-void clear_screen(){
-    memset(osd_buf,0x20,sizeof(osd_buf));
-    memset(loc_buf,0x00,sizeof(loc_buf));
-    memset(page_extend_buf,0x00,sizeof(page_extend_buf));
+void clear_screen() {
+    memset(osd_buf, 0x20, sizeof(osd_buf));
+    memset(loc_buf, 0x00, sizeof(loc_buf));
+    memset(page_extend_buf, 0x00, sizeof(page_extend_buf));
 }
 
 void write_string(uint8_t rx, uint8_t row, uint8_t col, uint8_t page_extend) {
-    if(disp_mode == DISPLAY_OSD){
-        if(resolution == HD_5018){
-            if(row < HD_VMAX && col < HD_HMAX){
+    if (disp_mode == DISPLAY_OSD) {
+        if (resolution == HD_5018) {
+            if (row < HD_VMAX && col < HD_HMAX) {
                 osd_buf[row][col] = rx;
-                if(page_extend)
-                    page_extend_buf[row][col>>3] |= (1 << (col & 0x07));
+                if (page_extend)
+                    page_extend_buf[row][col >> 3] |= (1 << (col & 0x07));
                 else
-                    page_extend_buf[row][col>>3] &= (0xff - (1 << (col & 0x07)));
+                    page_extend_buf[row][col >> 3] &= (0xff - (1 << (col & 0x07)));
             }
-        }else if(resolution == SD_3016 || resolution == HD_3016){
-            if(row < SD_VMAX && col < SD_HMAX){
+        } else if (resolution == SD_3016 || resolution == HD_3016) {
+            if (row < SD_VMAX && col < SD_HMAX) {
                 osd_buf[row][col] = rx;
-                if(page_extend)
-                    page_extend_buf[row][col>>3] |= (1 << (col & 0x07));
+                if (page_extend)
+                    page_extend_buf[row][col >> 3] |= (1 << (col & 0x07));
                 else
-                    page_extend_buf[row][col>>3] &= (0xff - (1 << (col & 0x07)));
+                    page_extend_buf[row][col >> 3] &= (0xff - (1 << (col & 0x07)));
             }
         }
     }
 }
 
-void mark_loc(uint8_t row, uint8_t col)
-{
-    loc_buf[row][col>>3] |= (1 << (col & 0x07));
+void mark_loc(uint8_t row, uint8_t col) {
+    loc_buf[row][col >> 3] |= (1 << (col & 0x07));
 }
 
-void init_tx_buf()
-{
+void init_tx_buf() {
     uint8_t i;
-    for(i=0;i<TXBUF_SIZE;i++)
+    for (i = 0; i < TXBUF_SIZE; i++)
         tx_buf[i] = 0;
 }
 
-void fc_init()
-{
+void fc_init() {
     disp_mode = DISPLAY_OSD;
     dptx_wptr = dptx_rptr = 0;
 
     osd_ready = 0;
     clear_screen();
     init_tx_buf();
-    //vtx_menu_init();
+    // vtx_menu_init();
 
-    if(resolution == HD_5018)
+    if (resolution == HD_5018)
         osd_menu_offset = 8;
     else
         osd_menu_offset = 0;
 }
 
-uint8_t get_tx_data_5680() //prepare data to VRX
+uint8_t get_tx_data_5680() // prepare data to VRX
 {
     uint8_t temp;
-    
+
     tx_buf[0] = DP_HEADER0;
     tx_buf[1] = DP_HEADER1;
     tx_buf[2] = 0xff;
-    //len
+    // len
     tx_buf[3] = 12;
-    
-    //camType
-    if(CAM_MODE == CAM_720P50)
+
+    // camType
+    if (CAM_MODE == CAM_720P50)
         tx_buf[4] = 0x66;
-    else if(CAM_MODE == CAM_720P60)
+    else if (CAM_MODE == CAM_720P60)
         tx_buf[4] = 0x99;
-    else if(CAM_MODE == CAM_720P60_NEW)
+    else if (CAM_MODE == CAM_720P60_NEW)
         tx_buf[4] = 0xAA;
-    else if(CAM_MODE == CAM_720P30)
+    else if (CAM_MODE == CAM_720P30)
         tx_buf[4] = 0xCC;
-    
-    //fcType
+
+    // fcType
     tx_buf[5] = fc_variant[0];
     tx_buf[6] = fc_variant[1];
     tx_buf[7] = fc_variant[2];
     tx_buf[8] = fc_variant[3];
-    
-    //counter for link quality
-    tx_buf[9]  = lq_cnt++;
-    
-    //VTX temp and overhot
+
+    // counter for link quality
+    tx_buf[9] = lq_cnt++;
+
+    // VTX temp and overhot
     temp = pwr_offset >> 1;
-    if(temp > 8)
+    if (temp > 8)
         temp = 8;
-    tx_buf[10]  = (heat_protect << 7) | temp;
-    
-    tx_buf[11] = fontType; //fontType
+    tx_buf[10] = (heat_protect << 7) | temp;
+
+    tx_buf[11] = fontType; // fontType
 
     tx_buf[12] = VERSION;
-    
+
     tx_buf[13] = VTX_ID;
-    
+
     tx_buf[14] = fc_lock & 0x03;
-    
+
     tx_buf[15] = cam_4_3 ? 0xaa : 0x55;
-    
-    tx_buf[16] = 0x40;//crc
+
+    tx_buf[16] = 0x40; // crc
 
     return 17;
 }
 
-uint8_t get_tx_data_osd(uint8_t index) //prepare osd+data to VTX
+uint8_t get_tx_data_osd(uint8_t index) // prepare osd+data to VTX
 {
-    //package struct:
+    // package struct:
     /*
     {
         uint8_t header0;
@@ -449,45 +449,45 @@ uint8_t get_tx_data_osd(uint8_t index) //prepare osd+data to VTX
         uint8_t *page;          // length decide by len(string)
         uint8_t crc0;
         uint8_t crc1;
-    
+
     }
     */
     uint8_t mask[7] = {0};
-    uint8_t i,t1;
+    uint8_t i, t1;
     uint8_t ptr;
     uint8_t hmax;
     uint8_t len_mask;
     uint8_t page[7] = {0};
     uint8_t page_byte = 0;
     uint8_t num = 0;
-    
-    if(resolution == HD_5018){
+
+    if (resolution == HD_5018) {
         hmax = HD_HMAX;
         len_mask = 7;
         ptr = 11;
-    }else{
+    } else {
         ptr = 12;
         len_mask = 4;
         hmax = SD_HMAX;
     }
-    
-    //string
-    for(i=0;i<hmax;i++){
+
+    // string
+    for (i = 0; i < hmax; i++) {
         t1 = osd_buf[index][i];
-        if(t1 != ' ') {
-            mask[i>>3] |= (1<<(i&0x07));
+        if (t1 != ' ') {
+            mask[i >> 3] |= (1 << (i & 0x07));
             tx_buf[ptr] = t1;
 
-            page[num>>3] |= ((page_extend_buf[index][i>>3] >> (i&0x07)) & 0x01) << (num&0x07);
+            page[num >> 3] |= ((page_extend_buf[index][i >> 3] >> (i & 0x07)) & 0x01) << (num & 0x07);
             ptr++;
             num++;
         }
     }
 
-    //page
+    // page
     page_byte = (num >> 3) + ((num & 0x07) != 0);
-    for(i=0;i<page_byte;i++){
-        if(disp_mode == DISPLAY_OSD)
+    for (i = 0; i < page_byte; i++) {
+        if (disp_mode == DISPLAY_OSD)
             tx_buf[ptr++] = page[i];
         else
             tx_buf[ptr++] = 0;
@@ -496,37 +496,35 @@ uint8_t get_tx_data_osd(uint8_t index) //prepare osd+data to VTX
     tx_buf[0] = DP_HEADER0;
     tx_buf[1] = DP_HEADER1;
     tx_buf[2] = (resolution << 5) | index;
-    tx_buf[3] = ptr-4;  //len
-    
-    //0x20 flag
-    for(i=0;i<len_mask;i++){
-        tx_buf[4+i] = mask[i];
+    tx_buf[3] = ptr - 4; // len
+
+    // 0x20 flag
+    for (i = 0; i < len_mask; i++) {
+        tx_buf[4 + i] = mask[i];
     }
-    
-    //location_flag
-    if(resolution == SD_3016){
-        if(disp_mode == DISPLAY_OSD){
-            tx_buf[8]  = loc_buf[index][0];
-            tx_buf[9]  = loc_buf[index][1];
+
+    // location_flag
+    if (resolution == SD_3016) {
+        if (disp_mode == DISPLAY_OSD) {
+            tx_buf[8] = loc_buf[index][0];
+            tx_buf[9] = loc_buf[index][1];
             tx_buf[10] = loc_buf[index][2];
             tx_buf[11] = loc_buf[index][3];
-        }else{
-            tx_buf[8]  = 0x00;//0x04;
-            tx_buf[9]  = 0x00;
-            tx_buf[10] = 0x00;//0x04;
+        } else {
+            tx_buf[8] = 0x00; // 0x04;
+            tx_buf[9] = 0x00;
+            tx_buf[10] = 0x00; // 0x04;
             tx_buf[11] = 0x00;
         }
     }
-    
-    
+
     return (uint8_t)(ptr + 1);
 }
 
-void insert_tx_byte(uint8_t c)
-{
+void insert_tx_byte(uint8_t c) {
     dptxbuf[dptx_wptr++] = c;
 #ifdef _DEBUG_DISPLAYPORT
-    if(dptx_wptr == dptx_rptr) //dptxbuf full
+    if (dptx_wptr == dptx_rptr) // dptxbuf full
         _outchar('*');
 #endif
 }
@@ -539,7 +537,7 @@ void DP_SEND_27M(uint8_t c) {
     do {
         __ticks--;
     } while (__ticks);
-    
+
     DP_tx(c);
 }
 void DP_SEND_20M(uint8_t c) {
@@ -571,33 +569,31 @@ void DP_SEND_20M(uint8_t c) {
     }
 #endif
 
-void DP_tx_task()
-{
+void DP_tx_task() {
     uint8_t i;
-    for(i=0;i<32;i++) {
-        if(dptx_wptr != dptx_rptr) {
-            #if(1)
-            if(RF_BW == BW_20M) {
+    for (i = 0; i < 32; i++) {
+        if (dptx_wptr != dptx_rptr) {
+#if (1)
+            if (RF_BW == BW_20M) {
                 DP_SEND_20M(dptxbuf[dptx_rptr++]);
             } else {
                 DP_SEND_27M(dptxbuf[dptx_rptr++]);
             }
-            #else
+#else
             _outchar(dptxbuf[dptx_rptr++]);
-            #endif
-        }
-        else break;
+#endif
+        } else
+            break;
     }
 }
 
-void insert_tx_buf(uint8_t len)
-{
+void insert_tx_buf(uint8_t len) {
     uint8_t i;
-    uint8_t crc0,crc1;
+    uint8_t crc0, crc1;
 
     crc0 = 0;
     crc1 = 0;
-    for(i=0;i<len-1;i++) {
+    for (i = 0; i < len - 1; i++) {
         crc0 ^= tx_buf[i];
         crc1 = crc8tab[crc1 ^ tx_buf[i]];
         insert_tx_byte(tx_buf[i]);
@@ -606,32 +602,31 @@ void insert_tx_buf(uint8_t len)
     insert_tx_byte(crc1);
 }
 
-void msp_send_header(uint8_t dl)
-{
-    if(dl)
+void msp_send_header(uint8_t dl) {
+    if (dl)
         WAIT(20);
-    
+
     CMS_tx(0x24);
     CMS_tx(0x4d);
     CMS_tx(0x3c);
 }
 
-void msp_cmd_tx() //send 3 commands to FC
+void msp_cmd_tx() // send 3 commands to FC
 {
-    uint8_t i,j;
+    uint8_t i, j;
     uint8_t msp_cmd[4] = {
-        0x02,//msp_fc_variant
-        0x65,//msp_status
-        0x69,//msp_rc
-        0x58//msp_vtx_config
+        0x02, // msp_fc_variant
+        0x65, // msp_status
+        0x69, // msp_rc
+        0x58  // msp_vtx_config
     };
-    
-    if(fc_lock & FC_VTX_CONFIG_LOCK)
+
+    if (fc_lock & FC_VTX_CONFIG_LOCK)
         j = 3;
     else
         j = 4;
 
-    for(i=0;i<j;i++) {
+    for (i = 0; i < j; i++) {
         msp_send_header(0);
         CMS_tx(0x00);
         CMS_tx(msp_cmd[i]);
@@ -639,103 +634,115 @@ void msp_cmd_tx() //send 3 commands to FC
     }
 }
 
-void msp_eeprom_write()
-{
+void msp_eeprom_write() {
     msp_send_header(1);
     CMS_tx(0x00);
     CMS_tx(250);
     CMS_tx(250);
 }
-void msp_set_vtx_config(uint8_t power, uint8_t save)
-{
+void msp_set_vtx_config(uint8_t power, uint8_t save) {
     uint8_t crc = 0;
     uint8_t channel = 0;
     uint8_t band;
-    
-    if(RF_FREQ <8){
+
+    if (RF_FREQ < 8) {
         band = 5;
         channel = RF_FREQ;
-    }else{
+    } else {
         band = 4;
-        if(RF_FREQ == 8)
+        if (RF_FREQ == 8)
             channel = 1;
-        else if(RF_FREQ == 9)
+        else if (RF_FREQ == 9)
             channel = 3;
     }
     msp_send_header(0);
-    CMS_tx(0x0f);       crc ^= 0x0f;            //len
-    CMS_tx(0x59);       crc ^= 0x59;            //cmd
-    CMS_tx(0x00);       crc ^= 0x00;            //freq_h
-    CMS_tx(0x00);       crc ^= 0x00;            //freq_l
-    CMS_tx(power+1);    crc ^= (power+1);       //power_level
-    CMS_tx((PIT_MODE&1)); crc ^= (PIT_MODE&1);  //pitmode
-    CMS_tx(LP_MODE);    crc ^= LP_MODE;        // lp_mode
-    CMS_tx(0x00);       crc ^= 0x00;            //pit_freq_h
-    CMS_tx(0x00);       crc ^= 0x00;            //pit_freq_l
-    CMS_tx(band);       crc ^= band;            //band
-    CMS_tx(channel+1);  crc ^= (channel+1);     //channel
-    CMS_tx(0x00);       crc ^= 0x00;            //freq_h
-    CMS_tx(0x00);       crc ^= 0x00;            //freq_l
-    CMS_tx(0x06);       crc ^= 0x06;            //band number
-    CMS_tx(0x08);       crc ^= 0x08;            //channel number
-    #ifdef HDZERO_FREESTYLE
-    if(powerLock){
+    CMS_tx(0x0f);
+    crc ^= 0x0f; // len
+    CMS_tx(0x59);
+    crc ^= 0x59; // cmd
+    CMS_tx(0x00);
+    crc ^= 0x00; // freq_h
+    CMS_tx(0x00);
+    crc ^= 0x00; // freq_l
+    CMS_tx(power + 1);
+    crc ^= (power + 1); // power_level
+    CMS_tx((PIT_MODE & 1));
+    crc ^= (PIT_MODE & 1); // pitmode
+    CMS_tx(LP_MODE);
+    crc ^= LP_MODE; // lp_mode
+    CMS_tx(0x00);
+    crc ^= 0x00; // pit_freq_h
+    CMS_tx(0x00);
+    crc ^= 0x00; // pit_freq_l
+    CMS_tx(band);
+    crc ^= band; // band
+    CMS_tx(channel + 1);
+    crc ^= (channel + 1); // channel
+    CMS_tx(0x00);
+    crc ^= 0x00; // freq_h
+    CMS_tx(0x00);
+    crc ^= 0x00; // freq_l
+    CMS_tx(0x06);
+    crc ^= 0x06; // band number
+    CMS_tx(0x08);
+    crc ^= 0x08; // channel number
+#ifdef HDZERO_FREESTYLE
+    if (powerLock) {
         CMS_tx(3);
-        crc ^= (3);      //power number
-    }else{
+        crc ^= (3); // power number
+    } else {
         CMS_tx(5);
-        crc ^= (5);      //power number
+        crc ^= (5); // power number
     }
-    #else
-    CMS_tx(POWER_MAX+2); crc ^= (POWER_MAX+2);      //power number
-    #endif
-    CMS_tx(0x00);       crc ^= 0x00;      //disable table
+#else
+    CMS_tx(POWER_MAX + 2);
+    crc ^= (POWER_MAX + 2); // power number
+#endif
+    CMS_tx(0x00);
+    crc ^= 0x00; // disable table
     CMS_tx(crc);
-    
-    #ifdef _DEBUG_MODE
+
+#ifdef _DEBUG_MODE
     debugf("\r\nmsp_set_vtx_config:F%x,P%x,M:%x", (uint16_t)RF_FREQ, (uint16_t)power, (uint16_t)PIT_MODE);
-    #endif
-    
-    if(save)
+#endif
+
+    if (save)
         msp_eeprom_write();
 }
 
-void parse_status()
-{
-    if(!(fc_lock & FC_STATUS_LOCK))
+void parse_status() {
+    if (!(fc_lock & FC_STATUS_LOCK))
         fc_lock |= FC_STATUS_LOCK;
-    
+
     g_IS_ARMED = (msp_rx_buf[6] & 0x01);
     g_IS_PARALYZE = (msp_rx_buf[9] & 0x80);
     disarmed = !g_IS_ARMED;
-    //debugf("\n\rstatus:%x",msp_rx_buf[6] & 0x01);
+    // debugf("\n\rstatus:%x",msp_rx_buf[6] & 0x01);
 }
 
-void parse_variant()
-{
+void parse_variant() {
     uint8_t i;
-    
-    if(!(fc_lock & FC_VARIANT_LOCK))
+
+    if (!(fc_lock & FC_VARIANT_LOCK))
         fc_lock |= FC_VARIANT_LOCK;
-    
-    for(i=0;i<4;i++)
+
+    for (i = 0; i < 4; i++)
         fc_variant[i] = msp_rx_buf[i];
 }
 
-void parse_rc()
-{
-    uint16_t roll,pitch,yaw,throttle;
-    //static uint16_t roll_d,pitch_d,yaw_d,throttle_d;
-    
-    if(!(fc_lock & FC_RC_LOCK))
-        fc_lock |= FC_RC_LOCK;
-    
-    roll      = (msp_rx_buf[1] << 8) | msp_rx_buf[0];
-    pitch     = (msp_rx_buf[3] << 8) | msp_rx_buf[2];
-    yaw       = (msp_rx_buf[5] << 8) | msp_rx_buf[4];
-    throttle  = (msp_rx_buf[7] << 8) | msp_rx_buf[6];
+void parse_rc() {
+    uint16_t roll, pitch, yaw, throttle;
+    // static uint16_t roll_d,pitch_d,yaw_d,throttle_d;
 
-    update_cms_menu(roll,pitch,yaw,throttle);
+    if (!(fc_lock & FC_RC_LOCK))
+        fc_lock |= FC_RC_LOCK;
+
+    roll = (msp_rx_buf[1] << 8) | msp_rx_buf[0];
+    pitch = (msp_rx_buf[3] << 8) | msp_rx_buf[2];
+    yaw = (msp_rx_buf[5] << 8) | msp_rx_buf[4];
+    throttle = (msp_rx_buf[7] << 8) | msp_rx_buf[6];
+
+    update_cms_menu(roll, pitch, yaw, throttle);
     /*
     roll_d = roll;
     pitch_d = pitch;
@@ -743,30 +750,28 @@ void parse_rc()
     throttle_d = throttle;
     */
 }
-void parse_vtx_config()
-{
+void parse_vtx_config() {
     uint8_t nxt_ch = 0;
     uint8_t nxt_pwr = 0;
     uint8_t pit_update = 0;
     uint8_t needSaveEEP = 0;
-    
-    if(!(fc_lock & FC_VTX_CONFIG_LOCK))
+
+    if (!(fc_lock & FC_VTX_CONFIG_LOCK))
         fc_lock |= FC_VTX_CONFIG_LOCK;
-    
-    if(fc_variant[0] == 'B' && fc_variant[1] == 'T' && fc_variant[2] == 'F' && fc_variant[3] == 'L')
+
+    if (fc_variant[0] == 'B' && fc_variant[1] == 'T' && fc_variant[2] == 'F' && fc_variant[3] == 'L')
         ;
-    else if(fc_variant[0] == 'E' && fc_variant[1] == 'M' && fc_variant[2] == 'U' && fc_variant[3] == 'F')
+    else if (fc_variant[0] == 'E' && fc_variant[1] == 'M' && fc_variant[2] == 'U' && fc_variant[3] == 'F')
         ;
     else
         return;
 
     fc_pwr_rx = msp_rx_buf[3] - 1;
-    if(fc_pwr_rx > POWER_MAX+2)
+    if (fc_pwr_rx > POWER_MAX + 2)
         fc_pwr_rx = 0;
 }
 
-void parseMspVtx_V2(uint16_t cmd_u16)
-{
+void parseMspVtx_V2(uint16_t cmd_u16) {
     uint8_t nxt_ch = 0;
     uint8_t nxt_pwr = 0;
     uint8_t pit_update = 0;
@@ -775,21 +780,21 @@ void parseMspVtx_V2(uint16_t cmd_u16)
     static uint8_t last_lp = 255;
     static uint8_t last_pit = 255;
 
-    if(cmd_u16 != MSP_CMD_VTX_CONFIG)
-        return;
-    
-    if(!(fc_lock & FC_VTX_CONFIG_LOCK))
+    if (cmd_u16 != MSP_CMD_VTX_CONFIG)
         return;
 
-    fc_band_rx      = msp_rx_buf[1];
-    fc_channel_rx   = msp_rx_buf[2];
-    fc_pwr_rx       = msp_rx_buf[3];
-    fc_pit_rx       = msp_rx_buf[4];
-    fc_lp_rx        = msp_rx_buf[8];
-    
+    if (!(fc_lock & FC_VTX_CONFIG_LOCK))
+        return;
+
+    fc_band_rx = msp_rx_buf[1];
+    fc_channel_rx = msp_rx_buf[2];
+    fc_pwr_rx = msp_rx_buf[3];
+    fc_pit_rx = msp_rx_buf[4];
+    fc_lp_rx = msp_rx_buf[8];
+
     pwr_lmt_done = 1;
 
-    #ifdef _DEBUG_MODE
+#ifdef _DEBUG_MODE
     debugf("\r\nparseMspVtx_V2");
     debugf("\r\n    fc_vtx_dev:    %x", (uint16_t)msp_rx_buf[0]);
     debugf("\r\n    fc_band_rx:    %x", (uint16_t)msp_rx_buf[1]);
@@ -801,66 +806,63 @@ void parseMspVtx_V2(uint16_t cmd_u16)
     debugf("\r\n    fc_bands:      %x", (uint16_t)msp_rx_buf[12]);
     debugf("\r\n    fc_channels:   %x", (uint16_t)msp_rx_buf[13]);
     debugf("\r\n    fc_powerLevels %x", (uint16_t)msp_rx_buf[14]);
-    #endif
-    
-    if(SA_lock)
+#endif
+
+    if (SA_lock)
         return;
 
     mspVtxLock |= 1;
-    
-    //update LP_MODE
-    if(fc_lp_rx != last_lp){
+
+    // update LP_MODE
+    if (fc_lp_rx != last_lp) {
         last_lp = fc_lp_rx;
-        if(fc_lp_rx < 2){
+        if (fc_lp_rx < 2) {
             LP_MODE = fc_lp_rx;
         }
         needSaveEEP = 1;
     }
-    //update channel
-    if(fc_band_rx == 5)//race band
-        nxt_ch =  fc_channel_rx - 1;
-    else if(fc_band_rx == 4){ //fatshark band
-        if(fc_channel_rx == 2)
+    // update channel
+    if (fc_band_rx == 5) // race band
+        nxt_ch = fc_channel_rx - 1;
+    else if (fc_band_rx == 4) { // fatshark band
+        if (fc_channel_rx == 2)
             nxt_ch = 8;
-        else if(fc_channel_rx == 4)
+        else if (fc_channel_rx == 4)
             nxt_ch = 9;
     }
-    if(RF_FREQ != nxt_ch){
+    if (RF_FREQ != nxt_ch) {
         vtx_channel = nxt_ch;
         RF_FREQ = nxt_ch;
-        if(dm6300_init_done)
+        if (dm6300_init_done)
             DM6300_SetChannel(RF_FREQ);
         needSaveEEP = 1;
     }
 
-    //update pit
+    // update pit
     nxt_pwr = fc_pwr_rx - 1;
 
-    if((nxt_pwr != POWER_MAX+1) && (!dm6300_init_done))
-    {
+    if ((nxt_pwr != POWER_MAX + 1) && (!dm6300_init_done)) {
         Init_6300RF(RF_FREQ, RF_POWER);
         DM6300_AUXADC_Calib();
     }
 
-    if(fc_pit_rx != last_pit)
-    {
+    if (fc_pit_rx != last_pit) {
         PIT_MODE = fc_pit_rx & 1;
-        #ifdef _DEBUG_MODE
+#ifdef _DEBUG_MODE
         debugf("\r\nPIT_MODE = %x", (uint16_t)PIT_MODE);
-        #endif
-        if(PIT_MODE)
-        {
-            DM6300_SetPower(POWER_MAX+1, RF_FREQ, pwr_offset);
-            cur_pwr = POWER_MAX+1;
-        }else{
-            #ifndef VIDEO_PAT
-            #ifdef HDZERO_FREESTYLE
-            if((RF_POWER == 3) && (!g_IS_ARMED))
+#endif
+        if (PIT_MODE) {
+            DM6300_SetPower(POWER_MAX + 1, RF_FREQ, pwr_offset);
+            cur_pwr = POWER_MAX + 1;
+        } else {
+#ifndef VIDEO_PAT
+#ifdef HDZERO_FREESTYLE
+            if ((RF_POWER == 3) && (!g_IS_ARMED))
                 pwr_lmt_done = 0;
             else
-            #endif
-            #endif
-            if(nxt_pwr == POWER_MAX+1) {
+#endif
+#endif
+                if (nxt_pwr == POWER_MAX + 1) {
                 WriteReg(0, 0x8F, 0x10);
                 dm6300_init_done = 0;
                 cur_pwr = POWER_MAX + 2;
@@ -875,595 +877,582 @@ void parseMspVtx_V2(uint16_t cmd_u16)
         vtx_pit_save = PIT_MODE;
         needSaveEEP = 1;
     }
-    
-    //update power
-    if(last_pwr != nxt_pwr){
-        if(last_pwr == POWER_MAX+1){
-            //Exit 0mW
-            if(cur_pwr == POWER_MAX+2)
-            {
-                if(PIT_MODE)
-                    Init_6300RF(RF_FREQ, POWER_MAX+1);
+
+    // update power
+    if (last_pwr != nxt_pwr) {
+        if (last_pwr == POWER_MAX + 1) {
+            // Exit 0mW
+            if (cur_pwr == POWER_MAX + 2) {
+                if (PIT_MODE)
+                    Init_6300RF(RF_FREQ, POWER_MAX + 1);
                 else
                     Init_6300RF(RF_FREQ, RF_POWER);
                 vtx_pit_save = PIT_MODE;
                 needSaveEEP = 1;
             }
-        }else if(nxt_pwr == POWER_MAX+1){
-            //Enter 0mW
-            if(cur_pwr != POWER_MAX + 2)
-            {
+        } else if (nxt_pwr == POWER_MAX + 1) {
+            // Enter 0mW
+            if (cur_pwr != POWER_MAX + 2) {
                 WriteReg(0, 0x8F, 0x10);
                 dm6300_init_done = 0;
                 cur_pwr = POWER_MAX + 2;
                 vtx_pit_save = PIT_0MW;
                 temp_err = 1;
             }
-        }else if(nxt_pwr <= POWER_MAX){
+        } else if (nxt_pwr <= POWER_MAX) {
             RF_POWER = nxt_pwr;
-            if(PIT_MODE)
+            if (PIT_MODE)
                 RF_POWER = POWER_MAX + 1;
-            
-            if(!dm6300_init_done)
-            {
-                if(cur_pwr != RF_POWER)
-                {
-                    #ifndef VIDEO_PAT
-                    #ifdef HDZERO_FREESTYLE
-                    if((RF_POWER == 3) && (!g_IS_ARMED))
+
+            if (!dm6300_init_done) {
+                if (cur_pwr != RF_POWER) {
+#ifndef VIDEO_PAT
+#ifdef HDZERO_FREESTYLE
+                    if ((RF_POWER == 3) && (!g_IS_ARMED))
                         pwr_lmt_done = 0;
-                    else 
-                    #endif
-                    #endif
+                    else
+#endif
+#endif
                     {
                         DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
                         cur_pwr = RF_POWER;
                     }
                     needSaveEEP = 1;
                 }
-            }
-            else
-            {
+            } else {
                 Init_6300RF(RF_FREQ, RF_POWER);
                 DM6300_AUXADC_Calib();
             }
         }
         last_pwr = nxt_pwr;
     }
-    
-    if(needSaveEEP)
+
+    if (needSaveEEP)
         Setting_Save();
 
-    #ifdef _DEBUG_MODE
+#ifdef _DEBUG_MODE
     debugf("\r\nparseMspVtx_V2 pwr:%x, pit:%x", (uint16_t)nxt_pwr, (uint16_t)fc_pit_rx);
-    #endif
-    
+#endif
 }
 
-uint8_t parse_displayport(uint8_t len)
-{
+uint8_t parse_displayport(uint8_t len) {
     uint8_t row = 0, col = 0;
     uint8_t state_osd = MSP_OSD_SUBCMD;
     uint8_t ptr = 0;
     uint8_t i = 0;
     uint8_t page_extend = 0;
-    
-    while(i != 64){
-        switch(state_osd){
-            case MSP_OSD_SUBCMD:
-                if(msp_rx_buf[0] == SUBCMD_HEARTBEAT)
-                    return 0;
-                else if(msp_rx_buf[0] == SUBCMD_RELEASE)
-                    return 0;
-                else if(msp_rx_buf[0] == SUBCMD_CLEAR){
-                    if(disp_mode == DISPLAY_OSD)
-                        clear_screen();
-                    osd_ready = 0;
-                    #ifdef _DEBUG_DISPLAYPORT
-                    _outchar('\r');_outchar('\n');_outchar('C');
-                    #endif
-                    return 0;
-                }else if(msp_rx_buf[0] == SUBCMD_WRITE){
-                    #ifdef _DEBUG_DISPLAYPORT
-                    _outchar('W');
-                    #endif
-                    osd_ready = 0;
-                    state_osd = MSP_OSD_LOC;
-                }else if(msp_rx_buf[0] == SUBCMD_DRAW){
-                    osd_ready = 1;
-                    #ifdef _DEBUG_DISPLAYPORT
-                    _outchar('D'); _outchar(' ');
-                    #endif
-                    if(!(fc_lock & FC_OSD_LOCK)) {
-                        Flicker_LED( 8 );
-                        fc_lock |= FC_OSD_LOCK;
-                    }
-                    return 1;
-                }else if(msp_rx_buf[0] == SUBCMD_CONFIG){
-                    fontType = msp_rx_buf[1];
-                    resolution = msp_rx_buf[2];
-                    
-                    if(resolution != resolution_last)
-                        fc_init();
-                    resolution_last = resolution;
-                    return 0;
-                }else{
-                    return 0;
-                }
-                break;
-            case MSP_OSD_LOC:
-                row = msp_rx_buf[1];
-                col = msp_rx_buf[2];
-                if(resolution == HD_3016)
-                {
-                    row -= 1;
-                    col -= 10;
-                }
-                mark_loc(row,col);
-                state_osd = MSP_OSD_ATTR;
-                break;
-            case MSP_OSD_ATTR:
-                if(len == 0)
-                    return 0;
-                else{
-                    page_extend = msp_rx_buf[3] & 0x01;
-                    state_osd = MSP_OSD_WRITE;
-                }
-                break;
-            case MSP_OSD_WRITE:
-                for(ptr = 0; ptr<len; ptr++){
-                    write_string(msp_rx_buf[4+ptr],row,col+ptr, page_extend);
-                }
+
+    while (i != 64) {
+        switch (state_osd) {
+        case MSP_OSD_SUBCMD:
+            if (msp_rx_buf[0] == SUBCMD_HEARTBEAT)
                 return 0;
-            default: break;
-        }//switch
+            else if (msp_rx_buf[0] == SUBCMD_RELEASE)
+                return 0;
+            else if (msp_rx_buf[0] == SUBCMD_CLEAR) {
+                if (disp_mode == DISPLAY_OSD)
+                    clear_screen();
+                osd_ready = 0;
+#ifdef _DEBUG_DISPLAYPORT
+                _outchar('\r');
+                _outchar('\n');
+                _outchar('C');
+#endif
+                return 0;
+            } else if (msp_rx_buf[0] == SUBCMD_WRITE) {
+#ifdef _DEBUG_DISPLAYPORT
+                _outchar('W');
+#endif
+                osd_ready = 0;
+                state_osd = MSP_OSD_LOC;
+            } else if (msp_rx_buf[0] == SUBCMD_DRAW) {
+                osd_ready = 1;
+#ifdef _DEBUG_DISPLAYPORT
+                _outchar('D');
+                _outchar(' ');
+#endif
+                if (!(fc_lock & FC_OSD_LOCK)) {
+                    Flicker_LED(8);
+                    fc_lock |= FC_OSD_LOCK;
+                }
+                return 1;
+            } else if (msp_rx_buf[0] == SUBCMD_CONFIG) {
+                fontType = msp_rx_buf[1];
+                resolution = msp_rx_buf[2];
+
+                if (resolution != resolution_last)
+                    fc_init();
+                resolution_last = resolution;
+                return 0;
+            } else {
+                return 0;
+            }
+            break;
+        case MSP_OSD_LOC:
+            row = msp_rx_buf[1];
+            col = msp_rx_buf[2];
+            if (resolution == HD_3016) {
+                row -= 1;
+                col -= 10;
+            }
+            mark_loc(row, col);
+            state_osd = MSP_OSD_ATTR;
+            break;
+        case MSP_OSD_ATTR:
+            if (len == 0)
+                return 0;
+            else {
+                page_extend = msp_rx_buf[3] & 0x01;
+                state_osd = MSP_OSD_WRITE;
+            }
+            break;
+        case MSP_OSD_WRITE:
+            for (ptr = 0; ptr < len; ptr++) {
+                write_string(msp_rx_buf[4 + ptr], row, col + ptr, page_extend);
+            }
+            return 0;
+        default:
+            break;
+        } // switch
         i++;
-    }//while
+    } // while
     return 0;
 }
 
-void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throttle)
-{
-/*
- *                throttle(油门) +                                          pitch(俯仰) +
- *
- *
- *   yaw(方向) -                      yaw(方向) +               roll(横滚) -                    roll(横滚) +
- *
- *
- *                throttle(油门) -                                          pitch(俯仰) -
-*/
+void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throttle) {
+    /*
+     *                throttle(油门) +                                          pitch(俯仰) +
+     *
+     *
+     *   yaw(方向) -                      yaw(方向) +               roll(横滚) -                    roll(横滚) +
+     *
+     *
+     *                throttle(油门) -                                          pitch(俯仰) -
+     */
     static uint8_t vtx_state = 0;
     uint8_t mid = 0;
     static uint8_t last_mid = 1;
     static uint8_t cms_cnt;
-    
+
     uint8_t VirtualBtn = BTN_INVALID;
-    
-    uint8_t IS_HI_yaw  = IS_HI(yaw);
-    uint8_t IS_LO_yaw  = IS_LO(yaw);
+
+    uint8_t IS_HI_yaw = IS_HI(yaw);
+    uint8_t IS_LO_yaw = IS_LO(yaw);
     uint8_t IS_MID_yaw = IS_MID(yaw);
-    
-    uint8_t IS_HI_throttle  = IS_HI(throttle);
-    uint8_t IS_LO_throttle  = IS_LO(throttle);
-    //uint8_t IS_MID_throttle = IS_MID(throttle);
-    
-    uint8_t IS_HI_pitch  = IS_HI(pitch);
-    uint8_t IS_LO_pitch  = IS_LO(pitch);
+
+    uint8_t IS_HI_throttle = IS_HI(throttle);
+    uint8_t IS_LO_throttle = IS_LO(throttle);
+    // uint8_t IS_MID_throttle = IS_MID(throttle);
+
+    uint8_t IS_HI_pitch = IS_HI(pitch);
+    uint8_t IS_LO_pitch = IS_LO(pitch);
     uint8_t IS_MID_pitch = IS_MID(pitch);
 
-    uint8_t IS_HI_roll  = IS_HI(roll);
-    uint8_t IS_LO_roll  = IS_LO(roll);
+    uint8_t IS_HI_roll = IS_HI(roll);
+    uint8_t IS_LO_roll = IS_LO(roll);
     uint8_t IS_MID_roll = IS_MID(roll);
-    
-    if(!disarmed && (cms_state != CMS_OSD)){
+
+    if (!disarmed && (cms_state != CMS_OSD)) {
         fc_init();
         cms_state = CMS_OSD;
     }
-    
-    //btn control
-    if(IS_MID_yaw && IS_MID_roll && IS_MID_pitch) {
+
+    // btn control
+    if (IS_MID_yaw && IS_MID_roll && IS_MID_pitch) {
         mid = 1;
         VirtualBtn = BTN_MID;
-    }else{
+    } else {
         mid = 0;
-        if(IS_HI_yaw && IS_MID_roll && IS_MID_pitch)
+        if (IS_HI_yaw && IS_MID_roll && IS_MID_pitch)
             VirtualBtn = BTN_ENTER;
-        else if(IS_LO_yaw && IS_MID_roll && IS_MID_pitch)
+        else if (IS_LO_yaw && IS_MID_roll && IS_MID_pitch)
             VirtualBtn = BTN_EXIT;
-        else if(IS_MID_yaw && IS_MID_roll && IS_HI_pitch)
+        else if (IS_MID_yaw && IS_MID_roll && IS_HI_pitch)
             VirtualBtn = BTN_UP;
-        else if(IS_MID_yaw && IS_MID_roll && IS_LO_pitch)
+        else if (IS_MID_yaw && IS_MID_roll && IS_LO_pitch)
             VirtualBtn = BTN_DOWN;
-        else if(IS_MID_yaw && IS_LO_roll && IS_MID_pitch)
+        else if (IS_MID_yaw && IS_LO_roll && IS_MID_pitch)
             VirtualBtn = BTN_LEFT;
-        else if(IS_MID_yaw && IS_HI_roll && IS_MID_pitch)
+        else if (IS_MID_yaw && IS_HI_roll && IS_MID_pitch)
             VirtualBtn = BTN_RIGHT;
         else
             VirtualBtn = BTN_INVALID;
     }
 
-    switch(cms_state) {
-        case CMS_OSD:
-            if(disarmed){
-                if(IS_HI_yaw && IS_LO_throttle && IS_LO_roll && IS_LO_pitch) {
-                    if(cur_pwr == POWER_MAX+2) {
-                        cms_state = CMS_EXIT_0MW;
-                        //debugf("\r\ncms_state(%x),cur_pwr(%x)",cms_state, cur_pwr);
-                        cms_cnt = 0;
-                        break;
+    switch (cms_state) {
+    case CMS_OSD:
+        if (disarmed) {
+            if (IS_HI_yaw && IS_LO_throttle && IS_LO_roll && IS_LO_pitch) {
+                if (cur_pwr == POWER_MAX + 2) {
+                    cms_state = CMS_EXIT_0MW;
+                    // debugf("\r\ncms_state(%x),cur_pwr(%x)",cms_state, cur_pwr);
+                    cms_cnt = 0;
+                    break;
+                }
+                /*if(!SA_lock)*/ {
+                    cms_state = CMS_ENTER_VTX_MENU;
+                    // debugf("\r\ncms_state(%x)",cms_state);
+                    vtx_menu_init();
+                    vtx_state = 0;
+                }
+            } else if (IS_LO_yaw && IS_LO_throttle && IS_HI_roll && IS_LO_pitch) {
+                if (cur_pwr != POWER_MAX + 2) {
+                    cms_state = CMS_ENTER_0MW;
+                    // debugf("\r\ncms_state(%x)",cms_state);
+                    cms_cnt = 0;
+                }
+            } else if (VirtualBtn == BTN_ENTER) {
+                cms_state = CMS_ENTER_CAM;
+                // debugf("\r\ncms_state(%x)",cms_state);
+                cms_cnt = 0;
+            } else
+                cms_cnt = 0;
+        }
+        // debugf("\n\r CMS_OSD");
+        break;
+
+    case CMS_ENTER_0MW:
+        if (IS_LO_yaw && IS_LO_throttle && IS_HI_roll && IS_LO_pitch)
+            cms_cnt++;
+        else {
+            cms_state = CMS_OSD;
+        }
+        if (cms_cnt == 3) {
+            vtx_channel = RF_FREQ;
+            vtx_power = RF_POWER;
+            vtx_lp = LP_MODE;
+            PIT_MODE = PIT_0MW;
+            vtx_pit = PIT_0MW;
+            if (!SA_lock) {
+                save_vtx_param();
+            } else {
+                msp_set_vtx_config(POWER_MAX + 1, 0); // enter 0mW for SA
+                WriteReg(0, 0x8F, 0x10);
+                dm6300_init_done = 0;
+                cur_pwr = POWER_MAX + 2;
+                temp_err = 1;
+            }
+        }
+        break;
+
+    case CMS_EXIT_0MW:
+        if (vtx_pit == PIT_0MW) {
+            vtx_channel = RF_FREQ;
+            vtx_power = RF_POWER;
+            vtx_lp = LP_MODE;
+            vtx_pit = PIT_OFF;
+            vtx_offset = OFFSET_25MW;
+            if (SA_lock) {
+                // PIT_MODE = 2;
+                vtx_pit = PIT_P1MW;
+                Init_6300RF(RF_FREQ, POWER_MAX + 1);
+                cur_pwr = POWER_MAX + 1;
+                DM6300_AUXADC_Calib();
+#ifdef _DEBUG_DISPLAYPORT
+                debugf("\r\nExit 0mW\r\n");
+#endif
+                // debugf("\r\n exit0");
+            } else {
+                save_vtx_param();
+                pit_mode_cfg_done = 1; // avoid to config DM6300 again
+                // SPI_Write(0x6, 0xFF0, 0x00000018);
+                // SPI_Write(0x3, 0xd00, 0x00000003);
+                Init_6300RF(RF_FREQ, RF_POWER);
+                DM6300_AUXADC_Calib();
+#ifdef _DEBUG_MODE
+                debugf("\r\nExit 0mW\r\n");
+#endif
+                // debugf("\r\n exit0");
+            }
+        }
+
+        if (!(IS_HI_yaw && IS_LO_throttle && IS_LO_roll && IS_LO_pitch))
+            cms_state = CMS_OSD;
+        break;
+
+    case CMS_ENTER_VTX_MENU: {
+        cms_state = CMS_VTX_MENU;
+        vtx_menu_init();
+        break;
+    }
+
+    case CMS_VTX_MENU: {
+        if (disarmed) {
+            if (last_mid) {
+                switch (vtx_state) {
+                // channel
+                case 0:
+                    if (VirtualBtn == BTN_DOWN)
+                        vtx_state = 1;
+                    else if (VirtualBtn == BTN_UP)
+                        vtx_state = 6;
+                    else if (VirtualBtn == BTN_RIGHT) {
+                        if (SA_lock == 0) {
+                            vtx_channel++;
+                            if (vtx_channel == FREQ_MAX_EXT + 1)
+                                vtx_channel = 0;
+                        }
+                    } else if (VirtualBtn == BTN_LEFT) {
+                        if (SA_lock == 0) {
+                            vtx_channel--;
+                            if (vtx_channel > FREQ_MAX_EXT + 1)
+                                vtx_channel = FREQ_MAX_EXT;
+                        }
                     }
-                    /*if(!SA_lock)*/ {
-                        cms_state = CMS_ENTER_VTX_MENU;
-                        //debugf("\r\ncms_state(%x)",cms_state);
-                        vtx_menu_init();
+                    update_vtx_menu_param(vtx_state);
+                    break;
+
+                // power
+                case 1:
+                    if (VirtualBtn == BTN_DOWN)
+                        vtx_state = 2;
+                    else if (VirtualBtn == BTN_UP)
                         vtx_state = 0;
+                    else if (VirtualBtn == BTN_RIGHT) {
+                        if (SA_lock == 0) {
+                            vtx_power++;
+#ifdef HDZERO_FREESTYLE
+                            if (powerLock)
+                                vtx_power &= 0x01;
+#endif
+                            if (vtx_power > POWER_MAX)
+                                vtx_power = 0;
+                        }
+                    } else if (VirtualBtn == BTN_LEFT) {
+                        if (SA_lock == 0) {
+                            vtx_power--;
+#ifdef HDZERO_FREESTYLE
+                            if (powerLock)
+                                vtx_power &= 0x01;
+#endif
+                            if (vtx_power > POWER_MAX)
+                                vtx_power = POWER_MAX;
+                        }
                     }
-                }else if(IS_LO_yaw && IS_LO_throttle && IS_HI_roll && IS_LO_pitch){
-                    if(cur_pwr != POWER_MAX+2){
-                        cms_state = CMS_ENTER_0MW;
-                        //debugf("\r\ncms_state(%x)",cms_state);
-                        cms_cnt = 0;
+                    update_vtx_menu_param(vtx_state);
+                    break;
+
+                // lp_mode
+                case 2:
+                    if (VirtualBtn == BTN_DOWN)
+                        vtx_state = 3;
+                    else if (VirtualBtn == BTN_UP)
+                        vtx_state = 1;
+                    else if (VirtualBtn == BTN_LEFT) {
+                        if (SA_lock == 0) {
+                            vtx_lp--;
+                            if (vtx_lp > 2)
+                                vtx_lp = 2;
+                        }
+                    } else if (VirtualBtn == BTN_RIGHT) {
+                        if (SA_lock == 0) {
+                            vtx_lp++;
+                            if (vtx_lp > 2)
+                                vtx_lp = 0;
+                        }
                     }
-                }else if(VirtualBtn == BTN_ENTER) {
-                    cms_state = CMS_ENTER_CAM;
-                    //debugf("\r\ncms_state(%x)",cms_state);
-                    cms_cnt = 0;
-                }else
-                    cms_cnt = 0;
-            }
-            //debugf("\n\r CMS_OSD");
-            break;
-        
-        case CMS_ENTER_0MW:
-            if(IS_LO_yaw && IS_LO_throttle && IS_HI_roll && IS_LO_pitch)
-                cms_cnt ++;
-            else{
-                cms_state = CMS_OSD;
-            }
-            if(cms_cnt == 3) {
-                vtx_channel = RF_FREQ;
-                vtx_power = RF_POWER;
-                vtx_lp = LP_MODE;
-                PIT_MODE = PIT_0MW;
-                vtx_pit = PIT_0MW;
-                if(!SA_lock){
-                    save_vtx_param();
-                }else{
-                    msp_set_vtx_config(POWER_MAX+1, 0); //enter 0mW for SA
-                    WriteReg(0, 0x8F, 0x10);
-                    dm6300_init_done = 0;
-                    cur_pwr = POWER_MAX + 2;
-                    temp_err = 1;
-                }
-            }
-            break;
+                    update_vtx_menu_param(vtx_state);
+                    break;
 
-        case CMS_EXIT_0MW:
-            if(vtx_pit == PIT_0MW){
-                vtx_channel = RF_FREQ;
-                vtx_power = RF_POWER;
-                vtx_lp = LP_MODE;
-                vtx_pit = PIT_OFF;
-                vtx_offset = OFFSET_25MW;
-                if(SA_lock){
-                    //PIT_MODE = 2;
-                    vtx_pit = PIT_P1MW;
-                    Init_6300RF(RF_FREQ, POWER_MAX+1);
-                    cur_pwr = POWER_MAX+1;
-                    DM6300_AUXADC_Calib();
-                    #ifdef _DEBUG_DISPLAYPORT
-                    debugf("\r\nExit 0mW\r\n");
-                    #endif
-                    //debugf("\r\n exit0");
-                }else{
-                    save_vtx_param();
-                    pit_mode_cfg_done = 1; //avoid to config DM6300 again
-                    //SPI_Write(0x6, 0xFF0, 0x00000018);
-                    //SPI_Write(0x3, 0xd00, 0x00000003);
-                    Init_6300RF(RF_FREQ, RF_POWER);
-                    DM6300_AUXADC_Calib();
-                    #ifdef _DEBUG_MODE
-                    debugf("\r\nExit 0mW\r\n");
-                    #endif
-                    //debugf("\r\n exit0");
-                }
-            }
-            
-            if(!(IS_HI_yaw && IS_LO_throttle && IS_LO_roll && IS_LO_pitch))
-                cms_state = CMS_OSD;
-            break;
-        
-            
-        case CMS_ENTER_VTX_MENU: {
-            cms_state = CMS_VTX_MENU;
-            vtx_menu_init();
-            break;
-        }
-        
-        case CMS_VTX_MENU: {
-            if(disarmed) {
-                if(last_mid){
-                    switch(vtx_state) {
-                        //channel
-                        case 0:
-                            if(VirtualBtn == BTN_DOWN) 
-                                vtx_state = 1;
-                            else if(VirtualBtn == BTN_UP)
-                                vtx_state = 6;
-                            else if(VirtualBtn == BTN_RIGHT){
-                                if(SA_lock == 0){
-                                    vtx_channel++;
-                                    if(vtx_channel==FREQ_MAX_EXT+1)
-                                        vtx_channel=0;
-                                }
-                            }else if(VirtualBtn == BTN_LEFT){
-                                if(SA_lock == 0){
-                                    vtx_channel--;
-                                    if(vtx_channel>FREQ_MAX_EXT+1)
-                                        vtx_channel=FREQ_MAX_EXT;
-                                }
-                            }
-                            update_vtx_menu_param(vtx_state);
-                            break;
+                // pit_mode
+                case 3:
+                    if (VirtualBtn == BTN_DOWN)
+                        vtx_state = 4;
+                    else if (VirtualBtn == BTN_UP)
+                        vtx_state = 2;
+                    else if (VirtualBtn == BTN_RIGHT) {
+                        if (SA_lock == 0) {
+                            if (vtx_pit == PIT_0MW)
+                                vtx_pit = PIT_OFF;
+                            else
+                                vtx_pit++;
+                        }
+                    } else if (VirtualBtn == BTN_LEFT) {
+                        if (SA_lock == 0) {
+                            if (vtx_pit == PIT_OFF)
+                                vtx_pit = PIT_0MW;
+                            else
+                                vtx_pit--;
+                        }
+                    }
+                    update_vtx_menu_param(vtx_state);
+                    break;
 
-                        //power
-                        case 1:
-                            if(VirtualBtn == BTN_DOWN)
-                                vtx_state = 2;
-                            else if(VirtualBtn == BTN_UP)
-                                vtx_state = 0;
-                            else if(VirtualBtn == BTN_RIGHT){
-                                if(SA_lock == 0){
-                                    vtx_power++;
-                                    #ifdef HDZERO_FREESTYLE
-                                    if(powerLock)
-                                        vtx_power &= 0x01;
-                                    #endif
-                                    if(vtx_power>POWER_MAX)
-                                        vtx_power=0;
-                                }
-                            }else if(VirtualBtn == BTN_LEFT){
-                                if(SA_lock==0){
-                                    vtx_power--;
-                                    #ifdef HDZERO_FREESTYLE
-                                    if(powerLock)
-                                        vtx_power &= 0x01;
-                                    #endif
-                                    if(vtx_power>POWER_MAX)
-                                        vtx_power=POWER_MAX;
-                                }
-                            }
-                            update_vtx_menu_param(vtx_state);
-                            break;
+                // offset_25mw
+                case 4:
+                    if (VirtualBtn == BTN_DOWN)
+                        vtx_state = 5;
+                    else if (VirtualBtn == BTN_UP)
+                        vtx_state = 3;
+                    else if (VirtualBtn == BTN_RIGHT) {
+                        if (vtx_offset == 10)
+                            vtx_offset = vtx_offset;
+                        else if (vtx_offset == 11)
+                            vtx_offset = 0;
+                        else if (vtx_offset < 10)
+                            vtx_offset++;
+                        else
+                            vtx_offset--;
+                    } else if (VirtualBtn == BTN_LEFT) {
+                        if (vtx_offset == 20)
+                            vtx_offset = vtx_offset;
+                        else if (vtx_offset == 0)
+                            vtx_offset = 11;
+                        else if (vtx_offset > 10)
+                            vtx_offset++;
+                        else
+                            vtx_offset--;
+                    }
+                    update_vtx_menu_param(vtx_state);
+                    break;
 
-                        //lp_mode
-                        case 2:
-                            if(VirtualBtn == BTN_DOWN)
-                                vtx_state = 3;
-                            else if(VirtualBtn == BTN_UP)
-                                vtx_state = 1;
-                            else if(VirtualBtn == BTN_LEFT)
-                            {
-                                if(SA_lock == 0)
-                                {
-                                    vtx_lp --;
-                                    if(vtx_lp > 2)
-                                        vtx_lp = 2;
-                                }
-                            }
-                            else if(VirtualBtn == BTN_RIGHT)
-                            {
-                                if(SA_lock == 0)
-                                {
-                                    vtx_lp ++;
-                                    if(vtx_lp > 2)
-                                        vtx_lp = 0;
-                                }
-                            }
-                            update_vtx_menu_param(vtx_state);
-                            break;
+                // exit
+                case 5:
+                    if (VirtualBtn == BTN_DOWN) {
+                        vtx_state = 6;
+                        update_vtx_menu_param(vtx_state);
+                    } else if (VirtualBtn == BTN_UP) {
+                        vtx_state = 4;
+                        update_vtx_menu_param(vtx_state);
+                    } else if (VirtualBtn == BTN_RIGHT) {
+                        vtx_state = 0;
+                        cms_state = CMS_OSD;
+                        fc_init();
+                        msp_tx_cnt = 0;
+                    }
+                    break;
 
-                        //pit_mode
-                        case 3: 
-                            if(VirtualBtn == BTN_DOWN)
-                                vtx_state = 4;
-                            else if(VirtualBtn == BTN_UP)
-                                vtx_state = 2;
-                            else if(VirtualBtn == BTN_RIGHT){
-                                if(SA_lock == 0){
-                                    if(vtx_pit == PIT_0MW)
-                                        vtx_pit = PIT_OFF;
-                                    else
-                                        vtx_pit ++;
-                                }
-                            }else if(VirtualBtn == BTN_LEFT){
-                                if(SA_lock == 0){
-                                    if(vtx_pit == PIT_OFF)
-                                        vtx_pit = PIT_0MW;
-                                    else
-                                        vtx_pit --;
-                                }
-                            }
-                            update_vtx_menu_param(vtx_state);
-                            break;
-
-                        //offset_25mw
-                        case 4:
-                            if(VirtualBtn == BTN_DOWN)
-                                vtx_state = 5;
-                            else if(VirtualBtn == BTN_UP)
-                                vtx_state = 3;
-                            else if(VirtualBtn == BTN_RIGHT){
-                                if(vtx_offset == 10)
-                                    vtx_offset = vtx_offset;
-                                else if(vtx_offset == 11)
-                                    vtx_offset = 0;
-                                else if(vtx_offset < 10)
-                                    vtx_offset ++;
-                                else
-                                    vtx_offset --;
-                            }else if(VirtualBtn == BTN_LEFT){
-                                if(vtx_offset == 20)
-                                    vtx_offset = vtx_offset;
-                                else if(vtx_offset == 0)
-                                    vtx_offset = 11;
-                                else if(vtx_offset > 10)
-                                    vtx_offset ++;
-                                else
-                                    vtx_offset --;
-                            }
-                            update_vtx_menu_param(vtx_state);
-                            break;
-
-                        //exit
-                        case 5:
-                            if(VirtualBtn == BTN_DOWN) {
-                                vtx_state = 6;
-                                update_vtx_menu_param(vtx_state);
-                            }else if(VirtualBtn == BTN_UP) {
-                                vtx_state = 4;
-                                update_vtx_menu_param(vtx_state);
-                            }else if(VirtualBtn == BTN_RIGHT){
-                                vtx_state = 0;
-                                cms_state = CMS_OSD;
-                                fc_init();
-                                msp_tx_cnt = 0;
-                            }
-                            break;
-
-                        //save&exit
-                        case 6:
-                            if(VirtualBtn == BTN_DOWN){
-                                vtx_state = 0;
-                                update_vtx_menu_param(vtx_state);
-                            }else if(VirtualBtn == BTN_UP){
-                                vtx_state = 5;
-                                update_vtx_menu_param(vtx_state);
-                            }else if(VirtualBtn == BTN_RIGHT){
-                                vtx_state = 0;
-                                cms_state = CMS_OSD;
-                                if(SA_lock){
-                                    RF_FREQ = vtx_channel;
-                                    RF_POWER = vtx_power;
-                                    LP_MODE = vtx_lp;
-                                    PIT_MODE = vtx_pit;
-                                    vtx_pit_save = vtx_pit;
-                                    OFFSET_25MW = vtx_offset;
-                                    CFG_Back();
-                                    Setting_Save();
-                                }else{
-                                    save_vtx_param();
-                                }
-                                fc_init();
-                                msp_tx_cnt = 0;
-                            }
-                            break;
-                        default:
-                            cms_state = CMS_OSD;
-                            fc_init();
-                            break;
-                    }//switch
-                }//if(last_mid)
-                //last_mid = mid;
-            }else{
-                cms_state = CMS_OSD;
-                fc_init();
-            }
-            break;
-        }
-
-        case CMS_ENTER_CAM: {
-            if(VirtualBtn == BTN_ENTER)
-                cms_cnt ++;
-            else
-                cms_state = CMS_OSD;
-
-            if(cms_cnt==5) {
-                cms_cnt = 0;
-                disp_mode = DISPLAY_CMS;
-                clear_screen();
-                camMenuInit();
-                cms_state = CMS_CAM;
-            }
-            break;
-        }
-
-        case CMS_CAM: {
-            //detect to exit
-            if(VirtualBtn == BTN_EXIT)
-                cms_cnt ++;
-            else
-                cms_cnt = 0;
-            
-            if(camStatusUpdate(VirtualBtn) || (cms_cnt==10)){
-                disp_mode = DISPLAY_OSD;
-                cms_state = CMS_OSD;
-                fc_init();
-                msp_tx_cnt = 0;
-            }
-                
-            break;
-        }
-        
-        default: {
+                // save&exit
+                case 6:
+                    if (VirtualBtn == BTN_DOWN) {
+                        vtx_state = 0;
+                        update_vtx_menu_param(vtx_state);
+                    } else if (VirtualBtn == BTN_UP) {
+                        vtx_state = 5;
+                        update_vtx_menu_param(vtx_state);
+                    } else if (VirtualBtn == BTN_RIGHT) {
+                        vtx_state = 0;
+                        cms_state = CMS_OSD;
+                        if (SA_lock) {
+                            RF_FREQ = vtx_channel;
+                            RF_POWER = vtx_power;
+                            LP_MODE = vtx_lp;
+                            PIT_MODE = vtx_pit;
+                            vtx_pit_save = vtx_pit;
+                            OFFSET_25MW = vtx_offset;
+                            CFG_Back();
+                            Setting_Save();
+                        } else {
+                            save_vtx_param();
+                        }
+                        fc_init();
+                        msp_tx_cnt = 0;
+                    }
+                    break;
+                default:
+                    cms_state = CMS_OSD;
+                    fc_init();
+                    break;
+                } // switch
+            }     // if(last_mid)
+            // last_mid = mid;
+        } else {
             cms_state = CMS_OSD;
             fc_init();
-            break;
         }
-    }//switch
+        break;
+    }
+
+    case CMS_ENTER_CAM: {
+        if (VirtualBtn == BTN_ENTER)
+            cms_cnt++;
+        else
+            cms_state = CMS_OSD;
+
+        if (cms_cnt == 5) {
+            cms_cnt = 0;
+            disp_mode = DISPLAY_CMS;
+            clear_screen();
+            camMenuInit();
+            cms_state = CMS_CAM;
+        }
+        break;
+    }
+
+    case CMS_CAM: {
+        // detect to exit
+        if (VirtualBtn == BTN_EXIT)
+            cms_cnt++;
+        else
+            cms_cnt = 0;
+
+        if (camStatusUpdate(VirtualBtn) || (cms_cnt == 10)) {
+            disp_mode = DISPLAY_OSD;
+            cms_state = CMS_OSD;
+            fc_init();
+            msp_tx_cnt = 0;
+        }
+
+        break;
+    }
+
+    default: {
+        cms_state = CMS_OSD;
+        fc_init();
+        break;
+    }
+    } // switch
     last_mid = mid;
 }
 
-void vtx_menu_init()
-{
+void vtx_menu_init() {
     uint8_t i;
     uint8_t hourString[4];
     uint8_t minuteString[2];
-    
+
     disp_mode = DISPLAY_CMS;
     clear_screen();
-    
-    strcpy(osd_buf[0]+osd_menu_offset+2,"----VTX_MENU----");
-    strcpy(osd_buf[2]+osd_menu_offset+2,">CHANNEL");
-    strcpy(osd_buf[3]+osd_menu_offset+3,"POWER");
-    strcpy(osd_buf[4]+osd_menu_offset+3,"LP_MODE");
-    strcpy(osd_buf[5]+osd_menu_offset+3,"PIT_MODE");
-    strcpy(osd_buf[6]+osd_menu_offset+3,"OFFSET_25MW");
-    strcpy(osd_buf[7]+osd_menu_offset+3,"EXIT");
-    strcpy(osd_buf[8]+osd_menu_offset+3,"SAVE&EXIT");
-    strcpy(osd_buf[9]+osd_menu_offset+2,"------INFO------");
-    strcpy(osd_buf[10]+osd_menu_offset+3,"VTX");
-    strcpy(osd_buf[11]+osd_menu_offset+3,"VER");
-    strcpy(osd_buf[12]+osd_menu_offset+3,"LIFETIME");
 
-    for(i=0;i<5;i++){
-        osd_buf[2+i][osd_menu_offset+19] = '<';
-        osd_buf[2+i][osd_menu_offset+26] = '>';
+    strcpy(osd_buf[0] + osd_menu_offset + 2, "----VTX_MENU----");
+    strcpy(osd_buf[2] + osd_menu_offset + 2, ">CHANNEL");
+    strcpy(osd_buf[3] + osd_menu_offset + 3, "POWER");
+    strcpy(osd_buf[4] + osd_menu_offset + 3, "LP_MODE");
+    strcpy(osd_buf[5] + osd_menu_offset + 3, "PIT_MODE");
+    strcpy(osd_buf[6] + osd_menu_offset + 3, "OFFSET_25MW");
+    strcpy(osd_buf[7] + osd_menu_offset + 3, "EXIT");
+    strcpy(osd_buf[8] + osd_menu_offset + 3, "SAVE&EXIT");
+    strcpy(osd_buf[9] + osd_menu_offset + 2, "------INFO------");
+    strcpy(osd_buf[10] + osd_menu_offset + 3, "VTX");
+    strcpy(osd_buf[11] + osd_menu_offset + 3, "VER");
+    strcpy(osd_buf[12] + osd_menu_offset + 3, "LIFETIME");
+
+    for (i = 0; i < 5; i++) {
+        osd_buf[2 + i][osd_menu_offset + 19] = '<';
+        osd_buf[2 + i][osd_menu_offset + 26] = '>';
     }
 
-    //draw variant
-    strcpy(osd_buf[10]+osd_menu_offset+10, VTX_NAME);
+    // draw variant
+    strcpy(osd_buf[10] + osd_menu_offset + 10, VTX_NAME);
 
-    //draw version
-    osd_buf[11][osd_menu_offset+22] = (uint8_t)((VERSION >> 4) & 0x0f) + '0';
-    osd_buf[11][osd_menu_offset+23] = (uint8_t)(VERSION & 0x0f) + '0';
-    #ifdef BETA
-    osd_buf[11][osd_menu_offset+25] = 'B';
-    osd_buf[11][osd_menu_offset+26] = (uint8_t)((BETA >> 4) & 0x0f) + '0';
-    osd_buf[11][osd_menu_offset+27] = (uint8_t)(BETA & 0x0f) + '0';
-    #endif
+    // draw version
+    osd_buf[11][osd_menu_offset + 22] = (uint8_t)((VERSION >> 4) & 0x0f) + '0';
+    osd_buf[11][osd_menu_offset + 23] = (uint8_t)(VERSION & 0x0f) + '0';
+#ifdef BETA
+    osd_buf[11][osd_menu_offset + 25] = 'B';
+    osd_buf[11][osd_menu_offset + 26] = (uint8_t)((BETA >> 4) & 0x0f) + '0';
+    osd_buf[11][osd_menu_offset + 27] = (uint8_t)(BETA & 0x0f) + '0';
+#endif
 
-    ParseLifeTime(hourString,minuteString);
-    osd_buf[12][osd_menu_offset+16] = hourString[0];
-    osd_buf[12][osd_menu_offset+17] = hourString[1];
-    osd_buf[12][osd_menu_offset+18] = hourString[2];
-    osd_buf[12][osd_menu_offset+19] = hourString[3];
-    osd_buf[12][osd_menu_offset+20] = 'H';
-    osd_buf[12][osd_menu_offset+21] = minuteString[0];
-    osd_buf[12][osd_menu_offset+22] = minuteString[1];
-    osd_buf[12][osd_menu_offset+23] = 'M';
-    
+    ParseLifeTime(hourString, minuteString);
+    osd_buf[12][osd_menu_offset + 16] = hourString[0];
+    osd_buf[12][osd_menu_offset + 17] = hourString[1];
+    osd_buf[12][osd_menu_offset + 18] = hourString[2];
+    osd_buf[12][osd_menu_offset + 19] = hourString[3];
+    osd_buf[12][osd_menu_offset + 20] = 'H';
+    osd_buf[12][osd_menu_offset + 21] = minuteString[0];
+    osd_buf[12][osd_menu_offset + 22] = minuteString[1];
+    osd_buf[12][osd_menu_offset + 23] = 'M';
+
     vtx_channel = RF_FREQ;
     vtx_power = RF_POWER;
     vtx_lp = LP_MODE;
@@ -1472,90 +1461,87 @@ void vtx_menu_init()
     update_vtx_menu_param(0);
 }
 
-void update_vtx_menu_param(uint8_t vtx_state)
-{
+void update_vtx_menu_param(uint8_t vtx_state) {
     uint8_t i;
     uint8_t hourString[4];
     uint8_t minuteString[2];
 
-    //state
-    for(i=0;i<7;i++){
-        if( i == vtx_state)
-            osd_buf[i+2][osd_menu_offset+2] = '>';
+    // state
+    for (i = 0; i < 7; i++) {
+        if (i == vtx_state)
+            osd_buf[i + 2][osd_menu_offset + 2] = '>';
         else
-            osd_buf[i+2][osd_menu_offset+2] = ' ';
+            osd_buf[i + 2][osd_menu_offset + 2] = ' ';
     }
 
-    //channel display
-    if(vtx_channel < 8){
-        osd_buf[2][osd_menu_offset+23] = 'R';
-        osd_buf[2][osd_menu_offset+24] = vtx_channel + '1';
-    }else{
-        osd_buf[2][osd_menu_offset+23] = 'F';
-        if(vtx_channel == 8)
-            osd_buf[2][osd_menu_offset+24] = '2';
-        else if(vtx_channel == 9)
-            osd_buf[2][osd_menu_offset+24] = '4';
-    }
- 
-    //power display
-    switch(vtx_power){
-        case 0:
-            strcpy(osd_buf[3]+osd_menu_offset+20,"   25");
-            break;
-        case 1:
-            strcpy(osd_buf[3]+osd_menu_offset+20,"  200");
-            break;
-        case 2:
-            strcpy(osd_buf[3]+osd_menu_offset+20,"  500");
-            break;
-        case 3:
-            strcpy(osd_buf[3]+osd_menu_offset+20,"  MAX");
-            break;
-        default:
-            strcpy(osd_buf[3]+osd_menu_offset+20,"     ");
-            break;
+    // channel display
+    if (vtx_channel < 8) {
+        osd_buf[2][osd_menu_offset + 23] = 'R';
+        osd_buf[2][osd_menu_offset + 24] = vtx_channel + '1';
+    } else {
+        osd_buf[2][osd_menu_offset + 23] = 'F';
+        if (vtx_channel == 8)
+            osd_buf[2][osd_menu_offset + 24] = '2';
+        else if (vtx_channel == 9)
+            osd_buf[2][osd_menu_offset + 24] = '4';
     }
 
-    if(vtx_lp == 0)
-        strcpy(osd_buf[4]+osd_menu_offset+20,"  OFF");
-    else if(vtx_lp == 1)
-        strcpy(osd_buf[4]+osd_menu_offset+20,"   ON");
-    else if(vtx_lp == 2)
-        strcpy(osd_buf[4]+osd_menu_offset+20,"  1ST");
-    
-    if(vtx_pit==PIT_P1MW)
-        strcpy(osd_buf[5]+osd_menu_offset+20," P1MW");
-    else if(vtx_pit == PIT_0MW)
-        strcpy(osd_buf[5]+osd_menu_offset+20,"  0MW");
-    else if(vtx_pit == PIT_OFF)
-        strcpy(osd_buf[5]+osd_menu_offset+20,"  OFF");
-    
-    if(vtx_offset < 10){
-        strcpy(osd_buf[6]+osd_menu_offset+20,"     ");
-        osd_buf[6][osd_menu_offset+23] = '0' + vtx_offset;
-    }else if(vtx_offset == 10)
-        strcpy(osd_buf[6]+osd_menu_offset+20,"   10");
-    else if(vtx_offset < 20){
-        strcpy(osd_buf[6]+osd_menu_offset+20,"   -");
-        osd_buf[6][osd_menu_offset+24] = '0' + (vtx_offset - 10);
+    // power display
+    switch (vtx_power) {
+    case 0:
+        strcpy(osd_buf[3] + osd_menu_offset + 20, "   25");
+        break;
+    case 1:
+        strcpy(osd_buf[3] + osd_menu_offset + 20, "  200");
+        break;
+    case 2:
+        strcpy(osd_buf[3] + osd_menu_offset + 20, "  500");
+        break;
+    case 3:
+        strcpy(osd_buf[3] + osd_menu_offset + 20, "  MAX");
+        break;
+    default:
+        strcpy(osd_buf[3] + osd_menu_offset + 20, "     ");
+        break;
     }
-    else if(vtx_offset == 20)
-        strcpy(osd_buf[6]+osd_menu_offset+20,"  -10");
-    
-    ParseLifeTime(hourString,minuteString);
-    osd_buf[12][osd_menu_offset+16] = hourString[0];
-    osd_buf[12][osd_menu_offset+17] = hourString[1];
-    osd_buf[12][osd_menu_offset+18] = hourString[2];
-    osd_buf[12][osd_menu_offset+19] = hourString[3];
-    osd_buf[12][osd_menu_offset+20] = 'H';
-    osd_buf[12][osd_menu_offset+21] = minuteString[0];
-    osd_buf[12][osd_menu_offset+22] = minuteString[1];
-    osd_buf[12][osd_menu_offset+23] = 'M';
+
+    if (vtx_lp == 0)
+        strcpy(osd_buf[4] + osd_menu_offset + 20, "  OFF");
+    else if (vtx_lp == 1)
+        strcpy(osd_buf[4] + osd_menu_offset + 20, "   ON");
+    else if (vtx_lp == 2)
+        strcpy(osd_buf[4] + osd_menu_offset + 20, "  1ST");
+
+    if (vtx_pit == PIT_P1MW)
+        strcpy(osd_buf[5] + osd_menu_offset + 20, " P1MW");
+    else if (vtx_pit == PIT_0MW)
+        strcpy(osd_buf[5] + osd_menu_offset + 20, "  0MW");
+    else if (vtx_pit == PIT_OFF)
+        strcpy(osd_buf[5] + osd_menu_offset + 20, "  OFF");
+
+    if (vtx_offset < 10) {
+        strcpy(osd_buf[6] + osd_menu_offset + 20, "     ");
+        osd_buf[6][osd_menu_offset + 23] = '0' + vtx_offset;
+    } else if (vtx_offset == 10)
+        strcpy(osd_buf[6] + osd_menu_offset + 20, "   10");
+    else if (vtx_offset < 20) {
+        strcpy(osd_buf[6] + osd_menu_offset + 20, "   -");
+        osd_buf[6][osd_menu_offset + 24] = '0' + (vtx_offset - 10);
+    } else if (vtx_offset == 20)
+        strcpy(osd_buf[6] + osd_menu_offset + 20, "  -10");
+
+    ParseLifeTime(hourString, minuteString);
+    osd_buf[12][osd_menu_offset + 16] = hourString[0];
+    osd_buf[12][osd_menu_offset + 17] = hourString[1];
+    osd_buf[12][osd_menu_offset + 18] = hourString[2];
+    osd_buf[12][osd_menu_offset + 19] = hourString[3];
+    osd_buf[12][osd_menu_offset + 20] = 'H';
+    osd_buf[12][osd_menu_offset + 21] = minuteString[0];
+    osd_buf[12][osd_menu_offset + 22] = minuteString[1];
+    osd_buf[12][osd_menu_offset + 23] = 'M';
 }
 
-void save_vtx_param()
-{
+void save_vtx_param() {
     RF_FREQ = vtx_channel;
     RF_POWER = vtx_power;
     LP_MODE = vtx_lp;
@@ -1566,141 +1552,134 @@ void save_vtx_param()
     Setting_Save();
     Imp_RF_Param();
 
-    //init pitmode status and first_arm after setting_save
+    // init pitmode status and first_arm after setting_save
     pit_mode_cfg_done = 0;
     lp_mode_cfg_done = 0;
     first_arm = 0;
-    
-    if(!SA_lock){
-        if(vtx_pit == PIT_0MW)
-            msp_set_vtx_config(POWER_MAX+1, 0);
+
+    if (!SA_lock) {
+        if (vtx_pit == PIT_0MW)
+            msp_set_vtx_config(POWER_MAX + 1, 0);
         else
             msp_set_vtx_config(RF_POWER, 1);
     }
 }
 
-void set_vtx_param()
-{
-    //If fc is lost, auto armed
+void set_vtx_param() {
+    // If fc is lost, auto armed
     /*
     if(seconds >= PWR_LMT_SEC){
         if(!fc_lock)
             g_IS_ARMED = 1;
     }
     */
-    if(SA_lock)
+    if (SA_lock)
         return;
 
-    if(!g_IS_ARMED){
-        //configurate pitmode when power-up or setting_vtx
-        if(PIT_MODE){
-            if(!pit_mode_cfg_done){
-                if(vtx_pit_save == PIT_0MW)
-                {
+    if (!g_IS_ARMED) {
+        // configurate pitmode when power-up or setting_vtx
+        if (PIT_MODE) {
+            if (!pit_mode_cfg_done) {
+                if (vtx_pit_save == PIT_0MW) {
                     WriteReg(0, 0x8F, 0x10);
                     dm6300_init_done = 0;
-                    //SPI_Write(0x6, 0xFF0, 0x00000018);
-                    //SPI_Write(0x3, 0xd00, 0x00000000);
-                    #ifdef _DEBUG_MODE
+// SPI_Write(0x6, 0xFF0, 0x00000018);
+// SPI_Write(0x3, 0xd00, 0x00000000);
+#ifdef _DEBUG_MODE
                     debugf("\r\nDM6300 0mW");
-                    #endif
+#endif
                     cur_pwr = POWER_MAX + 2;
                     temp_err = 1;
-                }
-                else //if(vtx_pit_save == PIT_P1MW)
+                } else // if(vtx_pit_save == PIT_P1MW)
                 {
                     DM6300_SetPower(POWER_MAX + 1, RF_FREQ, 0);
-                    #ifdef _DEBUG_MODE
+#ifdef _DEBUG_MODE
                     debugf("\r\nDM6300 P1mW");
-                    #endif
+#endif
                     cur_pwr = POWER_MAX + 1;
                 }
                 pit_mode_cfg_done = 1;
             }
-        }
-        else if(LP_MODE){
-            if(!lp_mode_cfg_done){
+        } else if (LP_MODE) {
+            if (!lp_mode_cfg_done) {
                 DM6300_SetPower(0, RF_FREQ, 0); // limit power to 25mW
                 cur_pwr = 0;
-                #ifdef _DEBUG_MODE
+#ifdef _DEBUG_MODE
                 debugf("\n\rEnter LP_MODE");
-                #endif
+#endif
                 lp_mode_cfg_done = 1;
             }
         }
     }
 
-    if(g_IS_ARMED && !g_IS_ARMED_last){
+    if (g_IS_ARMED && !g_IS_ARMED_last) {
         // Power_Auto
-        if(vtx_pit_save == PIT_0MW){
-            //exit 0mW
+        if (vtx_pit_save == PIT_0MW) {
+            // exit 0mW
             Init_6300RF(RF_FREQ, RF_POWER);
             DM6300_AUXADC_Calib();
             cur_pwr = RF_POWER;
             vtx_pit = PIT_OFF;
             vtx_pit_save = PIT_OFF;
-        }
-        else if(PIT_MODE || LP_MODE)
-        {
-            //exit pitmode or lp_mode
-            #ifdef _DEBUG_MDOE
+        } else if (PIT_MODE || LP_MODE) {
+// exit pitmode or lp_mode
+#ifdef _DEBUG_MDOE
             debugf("\n\rExit PIT or LP");
-            #endif
-        #ifndef VIDEO_PAT
-        #ifdef HDZERO_FREESTYLE
-            if(RF_POWER == 3 && !g_IS_ARMED)
+#endif
+#ifndef VIDEO_PAT
+#ifdef HDZERO_FREESTYLE
+            if (RF_POWER == 3 && !g_IS_ARMED)
                 pwr_lmt_done = 0;
             else
-        #endif
-        #endif
+#endif
+#endif
             {
-            DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
-            cur_pwr = RF_POWER;
-        	}
+                DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
+                cur_pwr = RF_POWER;
+            }
         }
-        
+
         first_arm = 1;
         PIT_MODE = PIT_OFF;
         Setting_Save();
         msp_set_vtx_config(RF_POWER, 1);
-    }
-    else if(!g_IS_ARMED && g_IS_ARMED_last){
-        if(LP_MODE == 1){
+    } else if (!g_IS_ARMED && g_IS_ARMED_last) {
+        if (LP_MODE == 1) {
             DM6300_SetPower(0, RF_FREQ, 0); // limit power to 25mW during disarmed
             cur_pwr = 0;
-            #ifdef _DEBUG_MDOE
+#ifdef _DEBUG_MDOE
             debugf("\n\rEnter LP_MODE");
-            #endif
+#endif
         }
     }
-    
+
     g_IS_ARMED_last = g_IS_ARMED;
 }
 
 #ifdef INIT_VTX_TABLE
- const uint8_t bf_vtx_band_table[6][31] = {
+const uint8_t bf_vtx_band_table[6][31] = {
     /*BOSCAM_A*/
-    {/*0x24,0x4d,0x3c,*/0x1d,0xe3,0x01,0x08,'B','O','S','C','A','M','_','A','A',0x01,0x08,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,},
+    {/*0x24,0x4d,0x3c,*/ 0x1d, 0xe3, 0x01, 0x08, 'B', 'O', 'S', 'C', 'A', 'M', '_', 'A', 'A', 0x01, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
     /*BOSCAM_B*/
-    {/*0x24,0x4d,0x3c,*/0x1d,0xe3,0x02,0x08,'B','O','S','C','A','M','_','B','B',0x01,0x08,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,},
+    {/*0x24,0x4d,0x3c,*/ 0x1d, 0xe3, 0x02, 0x08, 'B', 'O', 'S', 'C', 'A', 'M', '_', 'B', 'B', 0x01, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
     /*BOSCAM_R*/
-    {/*0x24,0x4d,0x3c,*/0x1d,0xe3,0x03,0x08,'B','O','S','C','A','M','_','E','E',0x01,0x08,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,},
+    {/*0x24,0x4d,0x3c,*/ 0x1d, 0xe3, 0x03, 0x08, 'B', 'O', 'S', 'C', 'A', 'M', '_', 'E', 'E', 0x01, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
     /*FATSHARK*/
-    {/*0x24,0x4d,0x3c,*/0x1d,0xe3,0x04,0x08,'F','A','T','S','H','A','R','K','F',0x01,0x08,0x00,0x00,0x80,0x16,0x00,0x00,0xa8,0x16,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,},
+    {/*0x24,0x4d,0x3c,*/ 0x1d, 0xe3, 0x04, 0x08, 'F', 'A', 'T', 'S', 'H', 'A', 'R', 'K', 'F', 0x01, 0x08, 0x00, 0x00, 0x80, 0x16, 0x00, 0x00, 0xa8, 0x16, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
     /*RACEBAND*/
-    {/*0x24,0x4d,0x3c,*/0x1d,0xe3,0x05,0x08,'R','A','C','E','B','A','N','D','R',0x01,0x08,0x1a,0x16,0x3f,0x16,0x64,0x16,0x89,0x16,0xae,0x16,0xd3,0x16,0xf8,0x16,0x1d,0x17,},
+    {/*0x24,0x4d,0x3c,*/ 0x1d, 0xe3, 0x05, 0x08, 'R', 'A', 'C', 'E', 'B', 'A', 'N', 'D', 'R', 0x01, 0x08, 0x1a, 0x16, 0x3f, 0x16, 0x64, 0x16, 0x89, 0x16, 0xae, 0x16, 0xd3, 0x16, 0xf8, 0x16, 0x1d, 0x17},
     /*IMD6*/
-    {/*0x24,0x4d,0x3c,*/0x1d,0xe3,0x06,0x08,'I','M','D','6',' ',' ',' ',' ','I',0x01,0x08,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,},
+    {/*0x24,0x4d,0x3c,*/ 0x1d, 0xe3, 0x06, 0x08, 'I', 'M', 'D', '6', ' ', ' ', ' ', ' ', 'I', 0x01, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 };
- const uint8_t bf_vtx_power_table[5][9] = {
-    {/*0x24,0x4d,0x3c,*/0x07,0xe4,0x01,0x0e,0x00,0x03,'2','5',' '},//25mW
-    {/*0x24,0x4d,0x3c,*/0x07,0xe4,0x02,0x17,0x00,0x03,'2','0','0'},//200mW
-    {/*0x24,0x4d,0x3c,*/0x07,0xe4,0x03,0x00,0x00,0x03,'0',' ',' '},//0mW
-    {/*0x24,0x4d,0x3c,*/0x07,0xe4,0x04,0x00,0x00,0x03,'0',' ',' '},//0mW
-    {/*0x24,0x4d,0x3c,*/0x07,0xe4,0x05,0x00,0x00,0x03,'0',' ',' '},//0mW
+const uint8_t bf_vtx_power_table[5][9] = {
+    {/*0x24,0x4d,0x3c,*/ 0x07, 0xe4, 0x01, 0x0e, 0x00, 0x03, '2', '5', ' '}, // 25mW
+    {/*0x24,0x4d,0x3c,*/ 0x07, 0xe4, 0x02, 0x17, 0x00, 0x03, '2', '0', '0'}, // 200mW
+    {/*0x24,0x4d,0x3c,*/ 0x07, 0xe4, 0x03, 0x00, 0x00, 0x03, '0', ' ', ' '}, // 0mW
+    {/*0x24,0x4d,0x3c,*/ 0x07, 0xe4, 0x04, 0x00, 0x00, 0x03, '0', ' ', ' '}, // 0mW
+    {/*0x24,0x4d,0x3c,*/ 0x07, 0xe4, 0x05, 0x00, 0x00, 0x03, '0', ' ', ' '}, // 0mW
 };
- const uint8_t bf_vtx_power_500mW[9] = {0x07,0xe4,0x03,0x1b,0x00,0x03,'5','0','0'}; //500mW
- const uint8_t bf_vtx_power_1W[9]    = {0x07,0xe4,0x04,0x1e,0x00,0x03,'M','A','X'}; //MAX
+const uint8_t bf_vtx_power_500mW[9] = {0x07, 0xe4, 0x03, 0x1b, 0x00, 0x03, '5', '0', '0'}; // 500mW
+const uint8_t bf_vtx_power_1W[9] = {0x07, 0xe4, 0x04, 0x1e, 0x00, 0x03, 'M', 'A', 'X'};    // MAX
 
 void InitVtxTable() {
     uint8_t i, j;

--- a/src/msp_displayport.h
+++ b/src/msp_displayport.h
@@ -5,37 +5,37 @@
 
 #define IS_HI(x)  ((x) > 1750)
 #define IS_LO(x)  ((x) < 1250)
-#define IS_MID(x) ((!IS_HI(x))  && (!IS_LO(x)))
+#define IS_MID(x) ((!IS_HI(x)) && (!IS_LO(x)))
 
-#define SD_HMAX     				30
-#define SD_VMAX                     16
-#define HD_HMAX                     50
-#define HD_VMAX                     18
+#define SD_HMAX 30
+#define SD_VMAX 16
+#define HD_HMAX 50
+#define HD_VMAX 18
 
-#define TXBUF_SIZE  				69
+#define TXBUF_SIZE 69
 
-#define MSP_HEADER_START_BYTE       0x24
-#define MSP_HEADER_M_BYTE           0x4D
-#define MSP_HEADER_M2_BYTE          0x58
-#define MSP_PACKAGE_REPLAY_BYTE     0x3E
+#define MSP_HEADER_START_BYTE   0x24
+#define MSP_HEADER_M_BYTE       0x4D
+#define MSP_HEADER_M2_BYTE      0x58
+#define MSP_PACKAGE_REPLAY_BYTE 0x3E
 
-#define MSP_CMD_FC_VARIANT          0x02
-#define MSP_CMD_VTX_CONFIG          0x58
-#define MSP_CMD_STATUS_BYTE         0x65
-#define MSP_CMD_RC_BYTE             0x69
-#define MSP_CMD_DISPLAYPORT_BYTE    0xB6
+#define MSP_CMD_FC_VARIANT       0x02
+#define MSP_CMD_VTX_CONFIG       0x58
+#define MSP_CMD_STATUS_BYTE      0x65
+#define MSP_CMD_RC_BYTE          0x69
+#define MSP_CMD_DISPLAYPORT_BYTE 0xB6
 
-#define DP_HEADER0                  0x56
-#define DP_HEADER1                  0x80
+#define DP_HEADER0 0x56
+#define DP_HEADER1 0x80
 
-#define FC_OSD_LOCK             0x01
-#define FC_VARIANT_LOCK         0x02
-#define FC_RC_LOCK              0x04
-#define FC_VTX_CONFIG_LOCK      0x08
-#define FC_STATUS_LOCK          0x10
-#define FC_INIT_VTX_TABLE_LOCK  0x80
+#define FC_OSD_LOCK            0x01
+#define FC_VARIANT_LOCK        0x02
+#define FC_RC_LOCK             0x04
+#define FC_VTX_CONFIG_LOCK     0x08
+#define FC_STATUS_LOCK         0x10
+#define FC_INIT_VTX_TABLE_LOCK 0x80
 
-typedef enum{
+typedef enum {
     BTN_UP,
     BTN_DOWN,
     BTN_LEFT,
@@ -44,21 +44,21 @@ typedef enum{
     BTN_ENTER,
     BTN_EXIT,
     BTN_INVALID
-}ButtonEvent_e;
+} ButtonEvent_e;
 
-typedef enum{
+typedef enum {
     BTFL,
     INAV,
     ARDU
 } fc_variant_e;
 
-typedef enum{
+typedef enum {
     PIT_OFF,
     PIT_P1MW,
     PIT_0MW
-}vtxPtiType_e;
+} vtxPtiType_e;
 
-typedef enum{
+typedef enum {
     MSP_HEADER_START,
     MSP_HEADER_M,
     MSP_PACKAGE_REPLAY1,
@@ -78,16 +78,16 @@ typedef enum{
 
 } msp_rx_status_e;
 
-typedef enum{
-    //msp_displayport
+typedef enum {
+    // msp_displayport
     MSP_OSD_SUBCMD,
     MSP_OSD_LOC,
     MSP_OSD_ATTR,
     MSP_OSD_WRITE,
     MSP_OSD_CONFIG,
-}msp_osd_status_e;
+} msp_osd_status_e;
 
-typedef enum{
+typedef enum {
     CUR_DISPLAYPORT,
     CUR_RC,
     CUR_STATUS,
@@ -96,7 +96,7 @@ typedef enum{
     CUR_OTHERS
 } cur_cmd_e;
 
-typedef enum{
+typedef enum {
     SUBCMD_HEARTBEAT,
     SUBCMD_RELEASE,
     SUBCMD_CLEAR,
@@ -105,13 +105,13 @@ typedef enum{
     SUBCMD_CONFIG,
 } displayport_subcmd_e;
 
-typedef enum{
+typedef enum {
     SD_3016,
     HD_5018,
     HD_3016,
 } resolutionType_e;
 
-typedef enum{
+typedef enum {
     CMS_OSD,
     CMS_ENTER_0MW,
     CMS_EXIT_0MW,
@@ -122,10 +122,10 @@ typedef enum{
     CMS_CAM
 } cms_state_e;
 
-typedef enum{
+typedef enum {
     DISPLAY_OSD,
     DISPLAY_CMS,
-}disp_mode_e;
+} disp_mode_e;
 
 void msp_task();
 uint8_t msp_read_one_frame();

--- a/src/print.c
+++ b/src/print.c
@@ -1,4 +1,5 @@
 #include "print.h"
+
 #include "common.h"
 #include "uart.h"
 
@@ -30,7 +31,7 @@ void _verbosef(const char *fmt, ...) {
     va_list ap;
 
     if (!verbose) {
-      return;
+        return;
     }
 
     va_start(ap, fmt);

--- a/src/print.h
+++ b/src/print.h
@@ -7,7 +7,7 @@ void _debugf(const char *fmt, ...);
 void _verbosef(const char *fmt, ...);
 
 #ifdef _DEBUG_MODE
-#define debugf _debugf
+#define debugf   _debugf
 #define verbosef _verbosef
 #else
 
@@ -17,7 +17,7 @@ void _verbosef(const char *fmt, ...);
 #else
 // workaround keils warning C275: expression with possibly no effect
 static void _nopf(const char *fmt, ...) { fmt = fmt; }
-#define debugf _nopf
+#define debugf   _nopf
 #define verbosef _nopf
 #endif
 

--- a/src/print.h
+++ b/src/print.h
@@ -1,5 +1,5 @@
-#ifndef __PRINT_H__
-#define __PRINT_H__
+#ifndef __PRINT_H_
+#define __PRINT_H_
 
 #include <stdarg.h>
 
@@ -7,20 +7,20 @@ void _debugf(const char *fmt, ...);
 void _verbosef(const char *fmt, ...);
 
 #ifdef _DEBUG_MODE
-#define debugf(args...) _debugf(args)
-#define verbosef(args...) _verbosef(args)
+#define debugf _debugf
+#define verbosef _verbosef
 #else
 
 #ifdef SDCC
-#define debugf 
+#define debugf
 #define verbosef
 #else
 // workaround keils warning C275: expression with possibly no effect
 static void _nopf(const char *fmt, ...) { fmt = fmt; }
 #define debugf _nopf
-#define verbosef  _nopf
+#define verbosef _nopf
 #endif
 
 #endif
 
-#endif
+#endif /* __PRINT_H_ */

--- a/src/rom.c
+++ b/src/rom.c
@@ -1,131 +1,130 @@
-#include "common.h"
 #include "rom.h"
-#include "uart.h"
-#include "hardware.h"
+
+#include "common.h"
 #include "dm6300.h"
 #include "global.h"
+#include "hardware.h"
 #include "i2c.h"
 #include "i2c_device.h"
 #include "spi.h"
+#include "uart.h"
 
 #ifdef _RF_CALIB
 #define CAL_BUF_MAX 8
 
-void CalibProc()
-{
+void CalibProc() {
     static uint8_t rxbuf[CAL_BUF_MAX];
     static int cnt = 0;
     uint8_t rx;
     uint32_t dcoc;
-    
-    if(Rom_ready()){
+
+    if (Rom_ready()) {
         rx = Rom_rx();
-        
-        if(rx != 0xFF){
+
+        if (rx != 0xFF) {
             rxbuf[cnt++] = rx;
-            if(cnt == CAL_BUF_MAX)
+            if (cnt == CAL_BUF_MAX)
                 cnt = 0;
-        }
-        else {
-            switch(rxbuf[0]){
-                case 'r':
-                    for(cnt = 0; cnt < (FREQ_MAX+1) * (POWER_MAX+1); cnt++){
-                        Rom_tx(table_power[cnt/(POWER_MAX+1)][cnt%(POWER_MAX+1)]);
-                    }
-                    break;
-                
-                case 'w':
-                    table_power[RF_FREQ][RF_POWER] = rxbuf[1];
+        } else {
+            switch (rxbuf[0]) {
+            case 'r':
+                for (cnt = 0; cnt < (FREQ_MAX + 1) * (POWER_MAX + 1); cnt++) {
+                    Rom_tx(table_power[cnt / (POWER_MAX + 1)][cnt % (POWER_MAX + 1)]);
+                }
+                break;
 
+            case 'w':
+                table_power[RF_FREQ][RF_POWER] = rxbuf[1];
+
+                DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
+
+                I2C_Write8_Wait(10, ADDR_EEPROM, RF_FREQ * (POWER_MAX + 1) + RF_POWER, table_power[RF_FREQ][RF_POWER]);
+                break;
+
+            case 'c':
+                if (rxbuf[1] <= FREQ_MAX && rxbuf[2] <= POWER_MAX) {
+                    RF_FREQ = rxbuf[1];
+                    RF_POWER = rxbuf[2];
+                    DM6300_SetChannel(RF_FREQ);
                     DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
+                }
+                break;
 
-                    I2C_Write8_Wait(10, ADDR_EEPROM, RF_FREQ * (POWER_MAX+1) + RF_POWER, table_power[RF_FREQ][RF_POWER]);
+            case 'f':
+                WriteReg(0, 0x8F, 0x01);
+                break;
+
+            case 'o':
+                WriteReg(0, 0x8F, 0x11);
+                break;
+
+            case 'D':
+                switch (rxbuf[1]) {
+                case '1':
+                    SPI_Write(0x6, 0xFF0, 0x00000018);
+                    dcoc = dcoc_ih | 0x8080;
+                    SPI_Write(0x3, 0x380, dcoc);
+                    dcoc = dcoc_qh | 0x8080;
+                    SPI_Write(0x3, 0x388, dcoc);
                     break;
-                
-                case 'c':
-                    if(rxbuf[1] <= FREQ_MAX && rxbuf[2] <= POWER_MAX){
-                        RF_FREQ = rxbuf[1];
-                        RF_POWER = rxbuf[2];
-                        DM6300_SetChannel(RF_FREQ);
-                        DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
-                    }
+
+                case '2':
+                    SPI_Write(0x6, 0xFF0, 0x00000018);
+                    dcoc = dcoc_ih | 0x80C0;
+                    SPI_Write(0x3, 0x380, dcoc);
+                    dcoc = dcoc_qh | 0x8080;
+                    SPI_Write(0x3, 0x388, dcoc);
                     break;
-                    
-                case 'f':
-                    WriteReg(0, 0x8F, 0x01);
+
+                case '3':
+                    SPI_Write(0x6, 0xFF0, 0x00000018);
+                    dcoc = dcoc_ih | 0xC080;
+                    SPI_Write(0x3, 0x380, dcoc);
+                    dcoc = dcoc_qh | 0x8080;
+                    SPI_Write(0x3, 0x388, dcoc);
                     break;
-                
-                case 'o':
-                    WriteReg(0, 0x8F, 0x11);
+
+                case '4':
+                    SPI_Write(0x6, 0xFF0, 0x00000018);
+                    dcoc = dcoc_ih | 0x8080;
+                    SPI_Write(0x3, 0x380, dcoc);
+                    dcoc = dcoc_qh | 0x80C0;
+                    SPI_Write(0x3, 0x388, dcoc);
                     break;
-                
-                case 'D':
-                    switch(rxbuf[1]){
-                        case '1':
-                            SPI_Write(0x6, 0xFF0, 0x00000018);
-                            dcoc = dcoc_ih | 0x8080;
-                            SPI_Write(0x3, 0x380, dcoc);
-                            dcoc = dcoc_qh | 0x8080;
-                            SPI_Write(0x3, 0x388, dcoc);
-                            break;
-                        
-                        case '2':
-                            SPI_Write(0x6, 0xFF0, 0x00000018);
-                            dcoc = dcoc_ih | 0x80C0;
-                            SPI_Write(0x3, 0x380, dcoc);
-                            dcoc = dcoc_qh | 0x8080;
-                            SPI_Write(0x3, 0x388, dcoc);
-                            break;
-                        
-                        case '3':
-                            SPI_Write(0x6, 0xFF0, 0x00000018);
-                            dcoc = dcoc_ih | 0xC080;
-                            SPI_Write(0x3, 0x380, dcoc);
-                            dcoc = dcoc_qh | 0x8080;
-                            SPI_Write(0x3, 0x388, dcoc);
-                            break;
-                        
-                        case '4':
-                            SPI_Write(0x6, 0xFF0, 0x00000018);
-                            dcoc = dcoc_ih | 0x8080;
-                            SPI_Write(0x3, 0x380, dcoc);
-                            dcoc = dcoc_qh | 0x80C0;
-                            SPI_Write(0x3, 0x388, dcoc);
-                            break;
-                        
-                        case '5':
-                            SPI_Write(0x6, 0xFF0, 0x00000018);
-                            dcoc = dcoc_ih | 0x8080;
-                            SPI_Write(0x3, 0x380, dcoc);
-                            dcoc = dcoc_qh | 0xC080;
-                            SPI_Write(0x3, 0x388, dcoc);
-                            break;
-                        
-                        case 'S':
-                            // dcoc cfg
-                            SPI_Write(0x6, 0xFF0, 0x00000018);
-                            dcoc = rxbuf[2];
-                            dcoc <<= 8;
-                            dcoc |= rxbuf[3];
-                            dcoc |= dcoc_ih;
-                            SPI_Write(0x3, 0x380, dcoc);
-                            dcoc = rxbuf[4];
-                            dcoc <<= 8;
-                            dcoc |= rxbuf[5];
-                            dcoc |= dcoc_qh;
-                            SPI_Write(0x3, 0x388, dcoc);
-                        
-                            // write to eeprom
-                            I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_DCOC_EN, 0x00);
-                            I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_DCOC_IH, rxbuf[2]);
-                            I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_DCOC_IL, rxbuf[3]);
-                            I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_DCOC_QH, rxbuf[4]);
-                            I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_DCOC_QL, rxbuf[5]);
-                            break;
-                    }
+
+                case '5':
+                    SPI_Write(0x6, 0xFF0, 0x00000018);
+                    dcoc = dcoc_ih | 0x8080;
+                    SPI_Write(0x3, 0x380, dcoc);
+                    dcoc = dcoc_qh | 0xC080;
+                    SPI_Write(0x3, 0x388, dcoc);
                     break;
+
+                case 'S':
+                    // dcoc cfg
+                    SPI_Write(0x6, 0xFF0, 0x00000018);
+                    dcoc = rxbuf[2];
+                    dcoc <<= 8;
+                    dcoc |= rxbuf[3];
+                    dcoc |= dcoc_ih;
+                    SPI_Write(0x3, 0x380, dcoc);
+                    dcoc = rxbuf[4];
+                    dcoc <<= 8;
+                    dcoc |= rxbuf[5];
+                    dcoc |= dcoc_qh;
+                    SPI_Write(0x3, 0x388, dcoc);
+
+                    // write to eeprom
+                    I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_DCOC_EN, 0x00);
+                    I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_DCOC_IH, rxbuf[2]);
+                    I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_DCOC_IL, rxbuf[3]);
+                    I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_DCOC_QH, rxbuf[4]);
+                    I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_DCOC_QL, rxbuf[5]);
+                    break;
+                }
+                break;
             }
-            
+
             cnt = 0;
         }
     }

--- a/src/rom.h
+++ b/src/rom.h
@@ -1,6 +1,6 @@
-#ifndef __ROM_H__
-#define __ROM_H__
+#ifndef __ROM_H_
+#define __ROM_H_
 
 void CalibProc();
 
-#endif
+#endif /* __ROM_H_ */

--- a/src/sfr_def.h
+++ b/src/sfr_def.h
@@ -3,13 +3,13 @@
 
 #include "toolchain.h"
 
-#define REG_P0 0x80
-#define REG_P1 0x90
-#define REG_P2 0xA0
-#define REG_P3 0xB0
-#define REG_TCON 0x88
-#define REG_IE 0xA8
-#define REG_IP 0xB8
+#define REG_P0    0x80
+#define REG_P1    0x90
+#define REG_P2    0xA0
+#define REG_P3    0xB0
+#define REG_TCON  0x88
+#define REG_IE    0xA8
+#define REG_IP    0xB8
 #define REG_SCON0 0x98
 #define REG_SCON1 0xC0
 
@@ -175,4 +175,4 @@ SBIT_DEF(RI1, REG_SCON1 ^ 0);
 // SBIT_DEF(INT3F,    EIF^1);
 // SBIT_DEF(INT2F,    EIF^0);
 
-#endif
+#endif /* __SFR_DEF_H_ */

--- a/src/sfr_ext.c
+++ b/src/sfr_ext.c
@@ -1,66 +1,62 @@
-#include "common.h"
 #include "sfr_ext.h"
+
+#include "common.h"
 
 /////////////////////////////////////////////////////////////////
 // reg w/r
-void WriteReg(uint8_t page, uint8_t addr, uint8_t dat)
-{
-    SFR_DATA  = dat;
+void WriteReg(uint8_t page, uint8_t addr, uint8_t dat) {
+    SFR_DATA = dat;
     SFR_ADDRL = addr;
-    SFR_CMD   = page ? 0x02 : 0x00;
+    SFR_CMD = page ? 0x02 : 0x00;
 }
 
-uint8_t ReadReg(uint8_t page, uint8_t addr)
-{
+uint8_t ReadReg(uint8_t page, uint8_t addr) {
     uint8_t busy = 1;
-    
+
     SFR_ADDRL = addr;
-    SFR_CMD   = page ? 0x03 : 0x01;
-    
-    while(busy != 0){
+    SFR_CMD = page ? 0x03 : 0x01;
+
+    while (busy != 0) {
         busy = SFR_BUSY & 0x02;
     }
-    
+
     return SFR_DATA;
 }
 
 /////////////////////////////////////////////////////////////////
 // AD936X w/r
-void Write936x(uint16_t addr, uint8_t dat)
-{
+void Write936x(uint16_t addr, uint8_t dat) {
     uint8_t busy = 1;
-    
-    SFR_DATA  = dat;
+
+    SFR_DATA = dat;
     SFR_ADDRL = addr & 0xFF;
-    SFR_ADDRH = (addr>>8) & 0xFF;
-    SFR_CMD   = 0x10;
-    
-    while(busy != 0){
+    SFR_ADDRH = (addr >> 8) & 0xFF;
+    SFR_CMD = 0x10;
+
+    while (busy != 0) {
         busy = SFR_BUSY & 0x01;
     }
 }
 
-uint8_t Read936x(uint16_t addr)
-{
+uint8_t Read936x(uint16_t addr) {
     uint8_t busy = 1;
 
     SFR_ADDRL = addr & 0xFF;
-    SFR_ADDRH = (addr>>8) & 0xFF;
-    SFR_CMD   = 0x11;
-    
-    while(busy != 0){
+    SFR_ADDRH = (addr >> 8) & 0xFF;
+    SFR_CMD = 0x11;
+
+    while (busy != 0) {
         busy = SFR_BUSY & 0x01;
     }
-    
+
     return SFR_DATA;
 }
 
 /////////////////////////////////////////////////////////////////
 // flight control
-void DP_tx(uint8_t dat)
-{
-    SFR_DATA  = dat;
-    SFR_CMD   = 0x20;
+void DP_tx(uint8_t dat) {
+    SFR_DATA = dat;
+    SFR_CMD = 0x20;
 }
 /*
 // OSD

--- a/src/sfr_ext.h
+++ b/src/sfr_ext.h
@@ -3,12 +3,12 @@
 
 #include "toolchain.h"
 
-SFR_DEF(SFR_CMD,     0xB9);
-SFR_DEF(SFR_DATA,    0xBA);
-SFR_DEF(SFR_ADDRL,   0xBB);
-SFR_DEF(SFR_ADDRH,   0xBC);
-SFR_DEF(SFR_BUSY,    0xBD);
-SFR_DEF(DBG_PIN0,    0xFB);
+SFR_DEF(SFR_CMD, 0xB9);
+SFR_DEF(SFR_DATA, 0xBA);
+SFR_DEF(SFR_ADDRL, 0xBB);
+SFR_DEF(SFR_ADDRH, 0xBC);
+SFR_DEF(SFR_BUSY, 0xBD);
+SFR_DEF(DBG_PIN0, 0xFB);
 
 void WriteReg(uint8_t page, uint8_t addr, uint8_t dat);
 uint8_t ReadReg(uint8_t page, uint8_t addr);
@@ -23,4 +23,4 @@ void OSD_CH_wr(uint16_t addr, uint8_t dat);
 */
 void DP_tx(uint8_t dat);
 
-#endif
+#endif /* __SFR_EXT_H_ */

--- a/src/sfr_ext.h
+++ b/src/sfr_ext.h
@@ -1,6 +1,7 @@
 #ifndef __SFR_EXT_H_
 #define __SFR_EXT_H_
 
+#include "stdint.h"
 #include "toolchain.h"
 
 SFR_DEF(SFR_CMD, 0xB9);

--- a/src/smartaudio_protocol.c
+++ b/src/smartaudio_protocol.c
@@ -1,23 +1,24 @@
+#include "smartaudio_protocol.h"
+
 #include "common.h"
-#include "isr.h"
+#include "dm6300.h"
 #include "global.h"
-#include "uart.h"
-#include "print.h"
-#include "monitor.h"
-#include "sfr_ext.h"
 #include "hardware.h"
 #include "i2c_device.h"
-#include "rom.h"
-#include "smartaudio_protocol.h"
+#include "isr.h"
+#include "monitor.h"
 #include "msp_displayport.h"
-#include "dm6300.h"
+#include "print.h"
+#include "rom.h"
+#include "sfr_ext.h"
+#include "uart.h"
 
 uint8_t SA_lock = 0;
 uint8_t SA_config = 0;
-uint8_t SA_is_0 = 1;  // detect pre hreder 0x00
+uint8_t SA_is_0 = 1; // detect pre hreder 0x00
 
-uint8_t pwr_init = 0; //0:POWER_MAX+2
-uint8_t ch_init = 0;//0~9
+uint8_t pwr_init = 0; // 0:POWER_MAX+2
+uint8_t ch_init = 0;  // 0~9
 uint8_t ch_bf = 0;
 
 #ifdef USE_SMARTAUDIO
@@ -26,92 +27,88 @@ uint8_t sa_rbuf[8];
 uint8_t SA_dbm = 14;
 uint8_t SA_dbm_last;
 uint8_t ch = 0;
-uint8_t mode_o = 0x04; 
-    // Bit0: 1=set freq 0=set ch    0
-    // Bit1: pitmode active         0
-    // Bit2: PIR active             1
-    // Bit3: POR active             0
-    // Bit4: 1 = Unclocked VTX      1
-    
+uint8_t mode_o = 0x04;
+// Bit0: 1=set freq 0=set ch    0
+// Bit1: pitmode active         0
+// Bit2: PIR active             1
+// Bit3: POR active             0
+// Bit4: 1 = Unclocked VTX      1
+
 uint8_t mode_p = 0x05;
-    // Bit0: PIR active             1
-    // Bit1: POR active             0
-    // Bit2: pitmode active         0
-    // Bit3: 1 = Unclocked VTX      1
-    
+// Bit0: PIR active             1
+// Bit1: POR active             0
+// Bit2: pitmode active         0
+// Bit3: 1 = Unclocked VTX      1
+
 uint8_t freq_new_h = 0x16;
 uint8_t freq_new_l = 0x1a;
 uint16_t freq = 0x161a;
 
-uint8_t dbm_to_pwr(uint8_t dbm)
-{
-    if(dbm == 0)
-        return POWER_MAX+2;
-    else if(dbm == 14)      //25mw
+uint8_t dbm_to_pwr(uint8_t dbm) {
+    if (dbm == 0)
+        return POWER_MAX + 2;
+    else if (dbm == 14) // 25mw
         return 0;
-    else if(dbm == 23)      //200mw
+    else if (dbm == 23) // 200mw
         return 1;
-    #if (POWER_MAX > 1)
-    else if(dbm == 27)      //500mw
+#if (POWER_MAX > 1)
+    else if (dbm == 27) // 500mw
         return 2;
-    #endif
-    #if (POWER_MAX > 2)
-    else if(dbm == 30)      //1W
+#endif
+#if (POWER_MAX > 2)
+    else if (dbm == 30) // 1W
         return 3;
-    #endif
+#endif
     else
         return 0;
 }
 
-uint8_t pwr_to_dbm(uint8_t pwr)
-{
-    if(pwr == 0)                //25mw
+uint8_t pwr_to_dbm(uint8_t pwr) {
+    if (pwr == 0) // 25mw
         return 14;
-    else if(pwr == 1)           //200mw
+    else if (pwr == 1) // 200mw
         return 23;
-    #if (POWER_MAX > 1)
-    else if(pwr == 2)           //500mw
+#if (POWER_MAX > 1)
+    else if (pwr == 2) // 500mw
         return 27;
-    #endif
-    #if (POWER_MAX > 2)
-    else if(pwr == 3)           //1W
+#endif
+#if (POWER_MAX > 2)
+    else if (pwr == 3) // 1W
         return 30;
-    #endif
-    else if(pwr == POWER_MAX+2)
+#endif
+    else if (pwr == POWER_MAX + 2)
         return 0;
     else
         return 14;
 }
-void SA_Response(uint8_t cmd)
-{
-    uint8_t i,crc,tx_len;
+void SA_Response(uint8_t cmd) {
+    uint8_t i, crc, tx_len;
     uint8_t tbuf[20];
-    switch (cmd)
-    {
+    switch (cmd) {
     case SA_GET_SETTINGS:
         tbuf[0] = 0xAA;
         tbuf[1] = 0x55;
-        tbuf[2] = 0x11;                 // version V2.1
-        tbuf[3] = 0x0A+POWER_MAX;       // length
-        tbuf[4] = ch_bf;                // channel
-        tbuf[5] = dbm_to_pwr(SA_dbm);   // power level
-        tbuf[6] = mode_o;               // operation mode
-        tbuf[7] = freq_new_h;           // cur_freq_h
-        tbuf[8] = freq_new_l;           // cur_freq_l
-        tbuf[9] = SA_dbm;               // power dbm
-        #ifdef HDZERO_FREESTYLE
-        if(powerLock){
-            tbuf[10] = 1 + 1;       // amount of power level
-            for(i=0;i<=1;i++)
-                tbuf[11+i] = pwr_to_dbm(i);
-            tbuf[12+1] = 0;
-        }else
-        #endif
-        tbuf[10] = POWER_MAX + 1;       // amount of power level
-        for(i=0;i<=POWER_MAX;i++)
-            tbuf[11+i] = pwr_to_dbm(i);
-        tbuf[12+POWER_MAX] = 0;
-    
+        tbuf[2] = 0x11;               // version V2.1
+        tbuf[3] = 0x0A + POWER_MAX;   // length
+        tbuf[4] = ch_bf;              // channel
+        tbuf[5] = dbm_to_pwr(SA_dbm); // power level
+        tbuf[6] = mode_o;             // operation mode
+        tbuf[7] = freq_new_h;         // cur_freq_h
+        tbuf[8] = freq_new_l;         // cur_freq_l
+        tbuf[9] = SA_dbm;             // power dbm
+#ifdef HDZERO_FREESTYLE
+        if (powerLock) {
+            tbuf[10] = 1 + 1; // amount of power level
+            for (i = 0; i <= 1; i++)
+                tbuf[11 + i] = pwr_to_dbm(i);
+            tbuf[12 + 1] = 0;
+        } else
+#endif
+            tbuf[10] = POWER_MAX + 1; // amount of power level
+        for (i = 0; i <= POWER_MAX; i++)
+            tbuf[11 + i] = pwr_to_dbm(i);
+        tbuf[12 + POWER_MAX] = 0;
+
         tx_len = tbuf[3] + 4;
         break;
 
@@ -121,8 +118,8 @@ void SA_Response(uint8_t cmd)
         tbuf[2] = 2;
         tbuf[3] = 3;
         tbuf[4] = SA_dbm;
-        tbuf[5] = 1; //reserved
-        tx_len  = 7;
+        tbuf[5] = 1; // reserved
+        tx_len = 7;
         break;
 
     case SA_SET_CH:
@@ -131,8 +128,8 @@ void SA_Response(uint8_t cmd)
         tbuf[2] = 3;
         tbuf[3] = 3;
         tbuf[4] = ch_bf;
-        tbuf[5] = 1; //reserved
-        tx_len  = 7;
+        tbuf[5] = 1; // reserved
+        tx_len = 7;
         break;
 
     case SA_SET_FREQ:
@@ -142,7 +139,7 @@ void SA_Response(uint8_t cmd)
         tbuf[3] = 4;
         tbuf[4] = freq_new_h;
         tbuf[5] = freq_new_l;
-        tbuf[6] = 0x01; //reserved
+        tbuf[6] = 0x01; // reserved
         tx_len = 8;
         break;
 
@@ -152,100 +149,99 @@ void SA_Response(uint8_t cmd)
         tbuf[2] = 5;
         tbuf[3] = 3;
         tbuf[4] = mode_p;
-        tbuf[5] = 0x01; //reserved
+        tbuf[5] = 0x01; // reserved
         tx_len = 7;
         break;
-        
-    default: return;
-    }//switch(cmd)
-   
-    //calculate CRC
+
+    default:
+        return;
+    } // switch(cmd)
+
+    // calculate CRC
     crc = 0;
-    for(i=2;i<tx_len-1;i++)
+    for (i = 2; i < tx_len - 1; i++)
         crc = crc8tab[crc ^ tbuf[i]];
 
-    tbuf[tx_len-1] = crc;
-    SUART_tx(tbuf,tx_len);
+    tbuf[tx_len - 1] = crc;
+    SUART_tx(tbuf, tx_len);
 }
 
-
-void SA_Update(uint8_t cmd)
-{
-    #ifdef DBG_SMARTAUDIO
-    if(SUART_ready()){
+void SA_Update(uint8_t cmd) {
+#ifdef DBG_SMARTAUDIO
+    if (SUART_ready()) {
         _outchar('^');
         return;
     }
-    #endif
+#endif
     switch (cmd) {
     case SA_GET_SETTINGS:
-        #ifdef DBG_SMARTAUDIO
+#ifdef DBG_SMARTAUDIO
         _outchar('G');
-        #endif
+#endif
         break;
 
     case SA_SET_PWR:
-        if(!(sa_rbuf[0] >> 7))
+        if (!(sa_rbuf[0] >> 7))
             return;
         SA_dbm = sa_rbuf[0] & 0x7f;
-        
-        #ifdef DBG_SMARTAUDIO
+
+#ifdef DBG_SMARTAUDIO
         debugf("dbm:%x", (uint16_t)SA_dbm);
-        #endif
-        
-        if(SA_dbm_last != SA_dbm) {  // need to update power
-            if(SA_dbm == 0) {     // Enter 0mW
+#endif
+
+        if (SA_dbm_last != SA_dbm) { // need to update power
+            if (SA_dbm == 0) {       // Enter 0mW
                 cur_pwr = POWER_MAX + 2;
                 PIT_MODE = 0;
                 vtx_pit = PIT_0MW;
-                
-                if(last_SA_lock && seconds < WAIT_SA_CONFIG){
+
+                if (last_SA_lock && seconds < WAIT_SA_CONFIG) {
                     pwr_init = cur_pwr;
-                }else{
-                    #ifdef _DEBUG_SA
+                } else {
+#ifdef _DEBUG_SA
                     debugf("\n\rEnter 0mW");
-                    #endif
+#endif
                     WriteReg(0, 0x8F, 0x10); // reset RF_chip
                     dm6300_init_done = 0;
                     temp_err = 1;
                 }
-            }else if(SA_dbm_last == 0) { // Exit 0mW
+            } else if (SA_dbm_last == 0) { // Exit 0mW
                 cur_pwr = dbm_to_pwr(SA_dbm);
                 PIT_MODE = 0;
                 RF_POWER = cur_pwr;
-                
-                if(last_SA_lock && seconds < WAIT_SA_CONFIG)
+
+                if (last_SA_lock && seconds < WAIT_SA_CONFIG)
                     pwr_init = cur_pwr;
-                else{
-                    #ifdef _DEBUG_MDOE
+                else {
+#ifdef _DEBUG_MDOE
                     debugf("\n\rExit 0mW");
-                    #endif
-                    
+#endif
+
                     Init_6300RF(RF_FREQ, RF_POWER);
                     PIT_MODE = 0;
-                    
+
                     DM6300_AUXADC_Calib();
                 }
-            }else{
+            } else {
                 cur_pwr = dbm_to_pwr(SA_dbm);
-                #ifdef HDZERO_FREESTYLE
-                if(powerLock)
+#ifdef HDZERO_FREESTYLE
+                if (powerLock)
                     cur_pwr &= 0x01;
-                #endif
+#endif
                 RF_POWER = cur_pwr;
-                if(last_SA_lock && seconds < WAIT_SA_CONFIG)
+                if (last_SA_lock && seconds < WAIT_SA_CONFIG)
                     pwr_init = cur_pwr;
-                else{
-            		#ifndef VIDEO_PAT
-            		#ifdef HDZERO_FREESTYLE
-                    if((RF_POWER == 3) && (!g_IS_ARMED))
+                else {
+#ifndef VIDEO_PAT
+#ifdef HDZERO_FREESTYLE
+                    if ((RF_POWER == 3) && (!g_IS_ARMED))
                         pwr_lmt_done = 0;
                     else
-                    #endif
-            		#endif
-                    DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
+#endif
+#endif
+                        DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
                 }
-                
+
                 Setting_Save();
             }
             SA_dbm_last = SA_dbm;
@@ -255,27 +251,27 @@ void SA_Update(uint8_t cmd)
     case SA_SET_CH:
         ch_bf = sa_rbuf[0];
 
-        if(ch_bf == 25)
+        if (ch_bf == 25)
             ch = 8;
-        else if(ch_bf == 27)
-            ch= 9;
-        else if(ch_bf >= 32 && ch_bf < 40)
+        else if (ch_bf == 27)
+            ch = 9;
+        else if (ch_bf >= 32 && ch_bf < 40)
             ch = ch_bf - 32;
-        
-        #ifdef DBG_SMARTAUDIO
+
+#ifdef DBG_SMARTAUDIO
         _outchar('C');
         debugf("%x", (uint16_t)ch);
-        #endif
-        
+#endif
+
         if (ch != RF_FREQ) {
             RF_FREQ = ch;
-            if(last_SA_lock && (seconds < WAIT_SA_CONFIG))
+            if (last_SA_lock && (seconds < WAIT_SA_CONFIG))
                 ch_init = RF_FREQ;
             else
                 DM6300_SetChannel(RF_FREQ);
             Setting_Save();
         }
-        
+
         break;
     case SA_SET_FREQ:
         freq_new_h = sa_rbuf[0];
@@ -283,43 +279,43 @@ void SA_Update(uint8_t cmd)
         freq = freq_new_h;
         freq = freq << 8;
         freq += freq_new_l;
-    
-        if(freq == FREQ_R1)
+
+        if (freq == FREQ_R1)
             ch = 0;
-        else if(freq == FREQ_R2)
+        else if (freq == FREQ_R2)
             ch = 1;
-        else if(freq == FREQ_R3)
+        else if (freq == FREQ_R3)
             ch = 2;
-        else if(freq == FREQ_R4)
+        else if (freq == FREQ_R4)
             ch = 3;
-        else if(freq == FREQ_R5)
+        else if (freq == FREQ_R5)
             ch = 4;
-        else if(freq == FREQ_R6)
+        else if (freq == FREQ_R6)
             ch = 5;
-        else if(freq == FREQ_R7)
+        else if (freq == FREQ_R7)
             ch = 6;
-        else if(freq == FREQ_R8)
+        else if (freq == FREQ_R8)
             ch = 7;
-        else if(freq == FREQ_F2)
+        else if (freq == FREQ_F2)
             ch = 8;
-        else if(freq == FREQ_F4)
+        else if (freq == FREQ_F4)
             ch = 9;
-        
-        if(ch == 8)
+
+        if (ch == 8)
             ch_bf = 25;
-        else if(ch == 9)
+        else if (ch == 9)
             ch_bf = 27;
         else
             ch_bf = ch + 32;
-        
-        #ifdef DBG_SMARTAUDIO
+
+#ifdef DBG_SMARTAUDIO
         _outchar('F');
         debugf("%x", (uint16_t)ch);
-        #endif
-        
+#endif
+
         if (ch != RF_FREQ) {
             RF_FREQ = ch;
-            if(last_SA_lock && (seconds < WAIT_SA_CONFIG))
+            if (last_SA_lock && (seconds < WAIT_SA_CONFIG))
                 ch_init = RF_FREQ;
             else
                 DM6300_SetChannel(RF_FREQ);
@@ -328,118 +324,114 @@ void SA_Update(uint8_t cmd)
         break;
 
     case SA_SET_MODE:
-        if(mode_p != sa_rbuf[0]) {
+        if (mode_p != sa_rbuf[0]) {
             mode_p = sa_rbuf[0] & 0x07;
-            
-            if(mode_p & 0x04) {//deactive pitmode
+
+            if (mode_p & 0x04) { // deactive pitmode
                 PIT_MODE = 0;
                 mode_o &= 0x1d;
-            }
-            else {//active pitmode
+            } else { // active pitmode
                 PIT_MODE = 2;
                 mode_o |= 0x02;
             }
-            if(cur_pwr == (POWER_MAX+2)) return;
+            if (cur_pwr == (POWER_MAX + 2))
+                return;
 
-            if(PIT_MODE){
-                if(last_SA_lock && seconds < WAIT_SA_CONFIG)
+            if (PIT_MODE) {
+                if (last_SA_lock && seconds < WAIT_SA_CONFIG)
                     pwr_init = cur_pwr;
-                else if(dbm_to_pwr(SA_dbm) == (POWER_MAX+2)){
+                else if (dbm_to_pwr(SA_dbm) == (POWER_MAX + 2)) {
                     cur_pwr = POWER_MAX + 2;
                     PIT_MODE = 0;
                     vtx_pit = PIT_0MW;
-                    #ifdef _DEBUG_SA
+#ifdef _DEBUG_SA
                     debugf("\n\rSA:Enter 0mW");
-                    #endif
+#endif
                     WriteReg(0, 0x8F, 0x10); // reset RF_chip
                     dm6300_init_done = 0;
                     temp_err = 1;
-                }else{
-                    DM6300_SetPower(POWER_MAX+1, RF_FREQ, 0);
+                } else {
+                    DM6300_SetPower(POWER_MAX + 1, RF_FREQ, 0);
                     cur_pwr = POWER_MAX + 1;
                 }
-            }else{
-                if(last_SA_lock && seconds < WAIT_SA_CONFIG)
+            } else {
+                if (last_SA_lock && seconds < WAIT_SA_CONFIG)
                     pwr_init = cur_pwr;
-                else if(dbm_to_pwr(SA_dbm) == (POWER_MAX+2)){
+                else if (dbm_to_pwr(SA_dbm) == (POWER_MAX + 2)) {
                     cur_pwr = POWER_MAX + 2;
                     PIT_MODE = 0;
                     vtx_pit = PIT_0MW;
-                    #ifdef _DEBUG_SA
+#ifdef _DEBUG_SA
                     debugf("\n\rSA:Enter 0mW");
-                    #endif
+#endif
                     WriteReg(0, 0x8F, 0x10); // reset RF_chip
                     dm6300_init_done = 0;
                     temp_err = 1;
-                }else{
-            		#ifndef VIDEO_PAT
-            		#ifdef HDZERO_FREESTYLE
-                    if((RF_POWER == 3) && (!g_IS_ARMED)){
+                } else {
+#ifndef VIDEO_PAT
+#ifdef HDZERO_FREESTYLE
+                    if ((RF_POWER == 3) && (!g_IS_ARMED)) {
                         pwr_lmt_done = 0;
                         cur_pwr = 3;
-                        #ifdef _DEBUG_SA
+#ifdef _DEBUG_SA
                         debugf("\r\npwr_lmt_done reset");
-                        #endif
-                    }
-                    else
-                    #endif
-           		 	#endif                    
+#endif
+                    } else
+#endif
+#endif
                     {
-                    DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
-                    cur_pwr = RF_POWER;
-                	}
-            	}
+                        DM6300_SetPower(RF_POWER, RF_FREQ, pwr_offset);
+                        cur_pwr = RF_POWER;
+                    }
+                }
             }
-            
+
             Setting_Save();
         }
-        #ifdef DBG_SMARTAUDIO
+#ifdef DBG_SMARTAUDIO
         debugf("M_P:%x  ", (uint16_t)mode_p);
         debugf("M_O:%x", (uint16_t)mode_o);
-        #endif
+#endif
         break;
 
     default:
-        #ifdef DBG_SMARTAUDIO
+#ifdef DBG_SMARTAUDIO
         _outchar('#');
-        #endif
+#endif
         break;
     }
     //_outchar('_');
 }
 
-uint8_t SA_task()
-{
-	static uint8_t SA_state=0,SA=0xFF; 
+uint8_t SA_task() {
+    static uint8_t SA_state = 0, SA = 0xFF;
 
-	if(SA_state == 0) {  //monitor SA pin
-		SA = (SA<<1) | SUART_PORT;
-		if(SA == 0xfe) {
+    if (SA_state == 0) { // monitor SA pin
+        SA = (SA << 1) | SUART_PORT;
+        if (SA == 0xfe) {
             SA_config = 1;
             SA_is_0 = 1;
-			IE = 0xC2; //UART1 & Timer0 enabled, UART0 disabled
-			SA_state = 1;
-            #ifdef DBG_SMARTAUDIO
+            IE = 0xC2; // UART1 & Timer0 enabled, UART0 disabled
+            SA_state = 1;
+#ifdef DBG_SMARTAUDIO
             _outchar('\n');
             _outchar('\r');
             _outchar('<');
-            #endif
-		}
-	}
-	else {
-		if(SA_Process()) {
+#endif
+        }
+    } else {
+        if (SA_Process()) {
             SA_config = 0;
-			IE =  0xD2; //UART1 & Timer0 enabled, UART0 0 enable
-			SA_state = 0;
+            IE = 0xD2; // UART1 & Timer0 enabled, UART0 0 enable
+            SA_state = 0;
             SA = 0xFF;
-            #ifdef DBG_SMARTAUDIO
+#ifdef DBG_SMARTAUDIO
             _outchar('>');
-            #endif
-		}
-	}
-	return SA_state;
+#endif
+        }
+    }
+    return SA_state;
 }
-
 
 uint8_t SA_Process() {
     static uint8_t rx = 0;
@@ -449,20 +441,19 @@ uint8_t SA_Process() {
     static uint8_t len = 0;
     static uint8_t index = 0;
     uint8_t ret = 0;
-    
-    if(SUART_ready()) {
+
+    if (SUART_ready()) {
         rx = SUART_rx();
-        #ifdef DBG_SMARTAUDIO
-        //debugf("%x ", (uint16_t)rx);
-        #endif
+#ifdef DBG_SMARTAUDIO
+// debugf("%x ", (uint16_t)rx);
+#endif
         switch (sa_status) {
         case SA_HEADER0:
             if (rx == SA_HEADER0_BYTE) {
                 crc = crc8tab[rx]; // 0 ^ rx = rx
                 index = 0;
                 sa_status = SA_HEADER1;
-            }
-            else{
+            } else {
                 ret = 1;
             }
             break;
@@ -471,20 +462,18 @@ uint8_t SA_Process() {
             if (rx == SA_HEADER1_BYTE) {
                 crc = crc8tab[crc ^ rx];
                 sa_status = SA_CMD;
-            }
-            else {
+            } else {
                 sa_status = SA_HEADER0;
                 ret = 1;
             }
             break;
-            
+
         case SA_CMD:
-            if(rx & 1) {
+            if (rx & 1) {
                 cmd = rx >> 1;
                 crc = crc8tab[crc ^ rx];
                 sa_status = SA_LENGTH;
-            }
-            else {
+            } else {
                 sa_status = SA_HEADER0;
                 ret = 1;
             }
@@ -495,8 +484,7 @@ uint8_t SA_Process() {
             if (len > 16) {
                 sa_status = SA_HEADER0;
                 ret = 1;
-            }
-            else {
+            } else {
                 crc = crc8tab[crc ^ rx];
                 if (len == 0)
                     sa_status = SA_CRC;
@@ -511,20 +499,19 @@ uint8_t SA_Process() {
             crc = crc8tab[crc ^ rx];
             sa_rbuf[index++] = rx;
             len--;
-            if(len == 0)
+            if (len == 0)
                 sa_status = SA_CRC;
             break;
 
         case SA_CRC:
-            if(crc == rx) {
+            if (crc == rx) {
                 SA_lock = 1;
                 SA_Update(cmd);
                 SA_Response(cmd);
-            }
-            else {
-                #ifdef DBG_SMARTAUDIO
+            } else {
+#ifdef DBG_SMARTAUDIO
                 _outchar('$');
-                #endif
+#endif
             }
             ret = 1;
             sa_status = SA_HEADER0;
@@ -535,11 +522,10 @@ uint8_t SA_Process() {
             sa_status = SA_HEADER0;
             break;
         }
-    }
-    else{
-        #ifdef DBG_SMARTAUDIO
+    } else {
+#ifdef DBG_SMARTAUDIO
         _outchar('.');
-        #endif
+#endif
     }
     return ret;
 }
@@ -548,27 +534,49 @@ void SA_Init() {
     SA_dbm = pwr_to_dbm(RF_POWER);
     SA_dbm_last = SA_dbm;
     ch = RF_FREQ;
-    if(ch==8)
+    if (ch == 8)
         ch_bf = 25;
-    else if(ch==9)
+    else if (ch == 9)
         ch_bf = 27;
     else
         ch_bf = ch + 32;
     mode_o |= PIT_MODE;
-    mode_p |= (PIT_MODE<<1);
-    
-    switch(ch){
-        case 0: freq = FREQ_R1; break;
-        case 1: freq = FREQ_R2; break;
-        case 2: freq = FREQ_R3; break;
-        case 3: freq = FREQ_R4; break;
-        case 4: freq = FREQ_R5; break;
-        case 5: freq = FREQ_R6; break;
-        case 6: freq = FREQ_R7; break;
-        case 7: freq = FREQ_R8; break;
-        case 8: freq = FREQ_F2; break;
-        case 9: freq = FREQ_F4; break;
-        default: freq = FREQ_R1; break;
+    mode_p |= (PIT_MODE << 1);
+
+    switch (ch) {
+    case 0:
+        freq = FREQ_R1;
+        break;
+    case 1:
+        freq = FREQ_R2;
+        break;
+    case 2:
+        freq = FREQ_R3;
+        break;
+    case 3:
+        freq = FREQ_R4;
+        break;
+    case 4:
+        freq = FREQ_R5;
+        break;
+    case 5:
+        freq = FREQ_R6;
+        break;
+    case 6:
+        freq = FREQ_R7;
+        break;
+    case 7:
+        freq = FREQ_R8;
+        break;
+    case 8:
+        freq = FREQ_F2;
+        break;
+    case 9:
+        freq = FREQ_F4;
+        break;
+    default:
+        freq = FREQ_R1;
+        break;
     }
     freq_new_h = (uint8_t)(freq >> 8);
     freq_new_l = (uint8_t)(freq & 0xff);

--- a/src/smartaudio_protocol.h
+++ b/src/smartaudio_protocol.h
@@ -5,16 +5,16 @@
 
 #ifdef USE_SMARTAUDIO
 
-#define FREQ_R1  (uint16_t)5658
-#define FREQ_R2  (uint16_t)5696
-#define FREQ_R3  (uint16_t)5732
-#define FREQ_R4  (uint16_t)5769
-#define FREQ_R5  (uint16_t)5806
-#define FREQ_R6  (uint16_t)5843
-#define FREQ_R7  (uint16_t)5880
-#define FREQ_R8  (uint16_t)5917
-#define FREQ_F2  (uint16_t)5760
-#define FREQ_F4  (uint16_t)5800
+#define FREQ_R1 (uint16_t)5658
+#define FREQ_R2 (uint16_t)5696
+#define FREQ_R3 (uint16_t)5732
+#define FREQ_R4 (uint16_t)5769
+#define FREQ_R5 (uint16_t)5806
+#define FREQ_R6 (uint16_t)5843
+#define FREQ_R7 (uint16_t)5880
+#define FREQ_R8 (uint16_t)5917
+#define FREQ_F2 (uint16_t)5760
+#define FREQ_F4 (uint16_t)5800
 
 //#define DBG_SMARTAUDIO
 
@@ -22,25 +22,23 @@
 #define SA_HEADER1_BYTE 0x55
 #define SA_VERSION_BYTE 0x09
 #define SA_GET_SETTINGS 0x01
-#define SA_SET_PWR 0x02
-#define SA_SET_CH 0x03
-#define SA_SET_FREQ 0x04
-#define SA_SET_MODE 0x05
+#define SA_SET_PWR      0x02
+#define SA_SET_CH       0x03
+#define SA_SET_FREQ     0x04
+#define SA_SET_MODE     0x05
 
-typedef enum
-{
+typedef enum {
     SA_HEADER0,
     SA_HEADER1,
     SA_CMD,
     SA_LENGTH,
     SA_PAYLOAD,
     SA_CRC
-
 } SA_status_e;
 
 uint8_t SA_task();
 uint8_t SA_Process();
-void    SA_Init();
+void SA_Init();
 
 extern uint8_t SA_dbm;
 extern uint8_t crc8tab[256];

--- a/src/spi.c
+++ b/src/spi.c
@@ -1,17 +1,22 @@
-#include "common.h"
 #include "spi.h"
-#include "print.h"
+
+#include "common.h"
 #include "global.h"
+#include "print.h"
 
-#define SET_CS(n)   SPI_CS=n
-#define SET_CK(n)   SPI_CK=n
-#define SET_DO(n)   SPI_DO=n
-#define SET_DI(n)   SPI_DI=n
+#define SET_CS(n) SPI_CS = n
+#define SET_CK(n) SPI_CK = n
+#define SET_DO(n) SPI_DO = n
+#define SET_DI(n) SPI_DI = n
 
-#define SPI_DLY     {int i=1; while(i--);}
+#define SPI_DLY     \
+    {               \
+        int i = 1;  \
+        while (i--) \
+            ;       \
+    }
 
-void SPI_Init()
-{
+void SPI_Init() {
     SET_CS(1);
     SET_CK(0);
     SET_DO(0);
@@ -22,13 +27,13 @@ void SPI_Write_Byte(uint8_t dat) {
     int8_t i;
     for (i = 7; i >= 0; i--) {
         SPI_DLY;
-        
-        SET_DO( (dat>>i) & 0x01 );
+
+        SET_DO((dat >> i) & 0x01);
         SPI_DLY;
 
         SET_CK(1);
         SPI_DLY;
-        
+
         SET_CK(0);
     }
 }
@@ -39,96 +44,100 @@ uint8_t SPI_Read_Byte() {
 
     for (i = 7; i >= 0; i--) {
         SPI_DLY;
-        
+
         SET_CK(1);
         SPI_DLY;
-        
-        ret = (ret<<1) | SPI_DI;
+
+        ret = (ret << 1) | SPI_DI;
         SET_CK(0);
     }
-    
+
     return ret;
 }
 
-void SPI_Write(uint8_t trans, uint16_t addr, uint32_t dat_l)
-{
-    uint32_t rh=0,rl=0;
-    uint16_t rlh=0,rll=0;
-    
+void SPI_Write(uint8_t trans, uint16_t addr, uint32_t dat_l) {
+    uint32_t rh = 0, rl = 0;
+    uint16_t rlh = 0, rll = 0;
+
     int i, N;
     uint8_t byte;
-    
-    if(trans == 6)
+
+    if (trans == 6)
         N = 2;
     else
         N = trans + 1;
-    
+
     byte = 0x80 | (trans << 4) | (addr >> 8);
-    
+
     // start SPI timing
-    SET_CS(0);SPI_DLY;SPI_DLY; // start
-    
+    SET_CS(0);
+    SPI_DLY;
+    SPI_DLY; // start
+
     SPI_Write_Byte(byte);
     byte = addr & 0xFF;
     SPI_Write_Byte(byte);
-    
-    for(i=N-1; i>=0; i--){
-        if(i >= 4){
+
+    for (i = N - 1; i >= 0; i--) {
+        if (i >= 4) {
             SPI_Write_Byte(0);
-        }
-        else{
-            byte = (dat_l >> (i<<3)) & 0xFF;
+        } else {
+            byte = (dat_l >> (i << 3)) & 0xFF;
             SPI_Write_Byte(byte);
         }
     }
-    
-    SPI_DLY;SPI_DLY;SET_CS(1); // end
+
+    SPI_DLY;
+    SPI_DLY;
+    SET_CS(1); // end
     SET_CK(0);
     SET_DO(0);
-    
+
 #ifdef _DEBUG_DM6300
     SPI_Read(trans, addr, &rl);
-    if(dat_l != rl)
+    if (dat_l != rl)
         debugf("                           --- W or R error !!   wdat=%lx", dat_l);
 #endif
 }
 
-void SPI_Read(uint8_t trans, uint16_t addr, uint32_t* dat_l)
-{
+void SPI_Read(uint8_t trans, uint16_t addr, uint32_t *dat_l) {
     int i, N;
     uint8_t byte;
-    uint16_t rlh=0,rll=0;
-    
-    if(trans == 6)
+    uint16_t rlh = 0, rll = 0;
+
+    if (trans == 6)
         N = 2;
     else
         N = trans + 1;
-    
+
     byte = 0x00 | (trans << 4) | (addr >> 8);
-    
+
     // start SPI timing
-    SET_CS(0);SPI_DLY;SPI_DLY; // start
+    SET_CS(0);
+    SPI_DLY;
+    SPI_DLY; // start
 
     SPI_Write_Byte(byte);
     byte = addr & 0xFF;
     SPI_Write_Byte(byte);
-    
-    //WAIT(100);
-    
-    for(i=N-1; i>=0; i--){
-        if(i >= 4){
+
+    // WAIT(100);
+
+    for (i = N - 1; i >= 0; i--) {
+        if (i >= 4) {
             SPI_Read_Byte();
-        }
-        else{
+        } else {
             *dat_l = (*dat_l) << 8;
             *dat_l |= SPI_Read_Byte();
         }
     }
-    
-    SPI_DLY;SPI_DLY;SET_CS(1); // end
+
+    SPI_DLY;
+    SPI_DLY;
+    SET_CS(1); // end
     SET_CK(0);
     SET_DO(0);
-    
+
 #ifdef _DEBUG_DM6300
     rlh = ((*dat_l) >> 16) & 0xFFFF;
     rll = (*dat_l) & 0xFFFF;

--- a/src/spi.h
+++ b/src/spi.h
@@ -7,4 +7,4 @@ void SPI_Write(uint8_t trans, uint16_t addr, uint32_t dat_l);
 void SPI_Read(uint8_t trans, uint16_t addr, uint32_t *dat_l);
 void SPI_Init();
 
-#endif
+#endif /* __SPI_H_ */

--- a/src/toolchain.h
+++ b/src/toolchain.h
@@ -1,15 +1,15 @@
-#ifndef __TOOLCHAIN__H_
-#define __TOOLCHAIN__H_
+#ifndef __TOOLCHAIN_H_
+#define __TOOLCHAIN_H_
 
 #ifdef SDCC
 
 #define IDATA_SEG __idata
 #define XDATA_SEG __xdata
-#define CODE_SEG __code
+#define CODE_SEG  __code
 
 #define BIT_TYPE __bit
 
-#define SFR_DEF(name, loc) __sfr __at(loc) name
+#define SFR_DEF(name, loc)  __sfr __at(loc) name
 #define SBIT_DEF(name, loc) __sbit __at(loc) name
 
 #define INTERRUPT(num) __interrupt(num)
@@ -22,15 +22,15 @@
 
 #define IDATA_SEG idata
 #define XDATA_SEG xdata
-#define CODE_SEG code
+#define CODE_SEG  code
 
 #define BIT_TYPE bit
 
-#define SFR_DEF(name, loc) sfr name = loc
+#define SFR_DEF(name, loc)  sfr name = loc
 #define SBIT_DEF(name, loc) sbit name = loc
 
 #define INTERRUPT(num) interrupt num
 
 #endif
 
-#endif
+#endif /* __TOOLCHAIN_H_ */

--- a/src/uart.c
+++ b/src/uart.c
@@ -1,5 +1,6 @@
-#include "common.h"
 #include "uart.h"
+
+#include "common.h"
 #include "print.h"
 #include "smartaudio_protocol.h"
 
@@ -25,24 +26,23 @@ XDATA_SEG volatile uint8_t RS_out1 = 0;
 volatile BIT_TYPE RS_Xbusy1 = 0;
 #endif
 
-uint8_t RS_ready(void)
-{
-	if( RS_in == RS_out ) return 0;
-	else return 1;
+uint8_t RS_ready(void) {
+    if (RS_in == RS_out)
+        return 0;
+    else
+        return 1;
 }
 
-uint8_t RS_rx(void)
-{
-	uint8_t ret;
-		
-	ret = RS_buf[RS_out];
-	RS_out++;
-	if(RS_out >= BUF_MAX) 
-		RS_out = 0;
+uint8_t RS_rx(void) {
+    uint8_t ret;
 
-	return ret;
+    ret = RS_buf[RS_out];
+    RS_out++;
+    if (RS_out >= BUF_MAX)
+        RS_out = 0;
+
+    return ret;
 }
-
 
 #ifdef EXTEND_BUF
 uint16_t RS_rx_len(void)
@@ -50,31 +50,28 @@ uint16_t RS_rx_len(void)
 uint8_t RS_rx_len(void)
 #endif
 {
-	 if(RS_out < RS_in)
-		 return RS_out+BUF_MAX - RS_in;
-	 else
-		 return RS_out - RS_in;
+    if (RS_out < RS_in)
+        return RS_out + BUF_MAX - RS_in;
+    else
+        return RS_out - RS_in;
 }
 
-uint8_t RS_ready1(void)
-{
-	if( RS_in1 == RS_out1 ) 
-		return 0;
-	else 
-		return 1;
-	
+uint8_t RS_ready1(void) {
+    if (RS_in1 == RS_out1)
+        return 0;
+    else
+        return 1;
 }
 
-uint8_t RS_rx1(void)
-{
-	uint8_t ret;
-	ret = RS_buf1[RS_out1];
+uint8_t RS_rx1(void) {
+    uint8_t ret;
+    ret = RS_buf1[RS_out1];
 
-	RS_out1++;
-	if(RS_out1 >= BUF1_MAX) 
-		RS_out1 = 0;
+    RS_out1++;
+    if (RS_out1 >= BUF1_MAX)
+        RS_out1 = 0;
 
-	return ret;
+    return ret;
 }
 
 /*
@@ -84,20 +81,19 @@ uint16_t RS_rx1_len(void)
 uint8_t RS_rx1_len(void)
 #endif
 {
-	 if(RS_out1 < RS_in1)
-		 return RS_out1+BUF_MAX - RS_in1;
-	 else
-		 return RS_out1 - RS_in1;
+     if(RS_out1 < RS_in1)
+         return RS_out1+BUF_MAX - RS_in1;
+     else
+         return RS_out1 - RS_in1;
 }*/
 
-
 ////////////////////////////////////////////////////////////////////////////
-//SUART TX
+// SUART TX
 #ifdef USE_SMARTAUDIO
 XDATA_SEG uint8_t SUART_rbuf[SUART_BUF_MAX];
-XDATA_SEG uint8_t SUART_rin=0, SUART_rout=0,SUART_rERR=0;
+XDATA_SEG uint8_t SUART_rin = 0, SUART_rout = 0, SUART_rERR = 0;
 
-void suart_rxint()  //ISR
+void suart_rxint() // ISR
 {
     static uint8_t isSearchingStart = 1;
     static uint8_t si_d = 1;
@@ -105,14 +101,14 @@ void suart_rxint()  //ISR
     static uint8_t rxbyte = 0;
     static uint8_t cnt = 0;
     uint8_t si;
-    
+
     si = SUART_PORT;
 
-    if(si)
+    if (si)
         SA_is_0 = 0;
-    
-    if(isSearchingStart) {
-        if(si_d && !si && !SA_is_0) {
+
+    if (isSearchingStart) {
+        if (si_d && !si && !SA_is_0) {
             isSearchingStart = 0;
             bcnt = 0;
             rxbyte = 0;
@@ -120,93 +116,88 @@ void suart_rxint()  //ISR
         }
         si_d = si;
         return;
-    }
-  else{
+    } else {
         cnt++;
-        if(cnt >= 2){
+        if (cnt >= 2) {
             cnt = 0;
-            if(bcnt < 8) {
+            if (bcnt < 8) {
                 rxbyte >>= 1;
-                if(si)
+                if (si)
                     rxbyte |= 0x80;
                 bcnt++;
-            }
-            else {
+            } else {
                 isSearchingStart = 1;
                 si_d = 1;
 
                 SUART_rbuf[SUART_rin++] = rxbyte;
-                SUART_rin &= (SUART_BUF_MAX-1);
-                #ifdef _DEBUG_SA
-                if(SUART_rin == SUART_rout)
+                SUART_rin &= (SUART_BUF_MAX - 1);
+#ifdef _DEBUG_SA
+                if (SUART_rin == SUART_rout)
                     SUART_rERR = 1;
-                #endif
+#endif
             }
         }
     }
 }
 
-uint8_t SUART_ready()
-{
-	if(SUART_rin == SUART_rout) 
-		return 0;
-	else 
-		return 1;
+uint8_t SUART_ready() {
+    if (SUART_rin == SUART_rout)
+        return 0;
+    else
+        return 1;
 }
 
-uint8_t SUART_rx()
-{
-	uint8_t ret;
-#ifdef _DEBUG_SA   
-    if(SUART_rERR) {
+uint8_t SUART_rx() {
+    uint8_t ret;
+#ifdef _DEBUG_SA
+    if (SUART_rERR) {
         SUART_rERR = 0;
         _outchar('&');
     }
 #endif
 
-	ret = SUART_rbuf[SUART_rout];
-	SUART_rout++;
-	SUART_rout &= (SUART_BUF_MAX-1);
+    ret = SUART_rbuf[SUART_rout];
+    SUART_rout++;
+    SUART_rout &= (SUART_BUF_MAX - 1);
 
-	return ret;
+    return ret;
 }
 
 ////////////////////////////////////////////////////////////////////////////
-//SUART TX
+// SUART TX
 uint8_t suart_tx_en = 0;
 uint8_t suart_txbcnt = 0;
 uint16_t suart_txdat;
 
-void suart_txint() //ISR
+void suart_txint() // ISR
 {
     static uint8_t cnt = 0;
-    
+
     cnt++;
-    if(cnt >= 2){
+    if (cnt >= 2) {
         cnt = 0;
         SUART_PORT = suart_txdat & 1;
         suart_txdat >>= 1;
         suart_txbcnt++;
-        if(suart_txbcnt >= 11) {
+        if (suart_txbcnt >= 11) {
             suart_tx_en = 0;
-					  SUART_PORT = 1;
-				}
+            SUART_PORT = 1;
+        }
     }
 }
 
-void SUART_tx_byte(uint8_t dat)
-{
+void SUART_tx_byte(uint8_t dat) {
     suart_txdat = (dat << 1) | 0xFE00;
     suart_txbcnt = 0;
     suart_tx_en = 1;
 }
 
-void SUART_tx(uint8_t* tbuf, uint8_t len)
-{
+void SUART_tx(uint8_t *tbuf, uint8_t len) {
     uint8_t i;
-    for(i=0;i<len;i++) {
+    for (i = 0; i < len; i++) {
         SUART_tx_byte(tbuf[i]);
-        while(suart_tx_en);
+        while (suart_tx_en)
+            ;
     }
 }
 #endif

--- a/src/uart.h
+++ b/src/uart.h
@@ -4,19 +4,32 @@
 #include "common.h"
 
 #ifdef EXTEND_BUF
-#define  BUF_MAX        2048 //30
+#define BUF_MAX 2048 // 30
 #else
-#define  BUF_MAX        255
+#define BUF_MAX 255
 #endif
 #ifdef EXTEND_BUF1
-#define  BUF1_MAX       2047    //30
+#define BUF1_MAX 2047 // 30
 #else
-#define  BUF1_MAX	    255     //30
+#define BUF1_MAX 255 // 30
 #endif
 
-
-#define RS_tx(c)  while(1) { if( !RS_Xbusy  ) { SBUF0 = c; RS_Xbusy = 1;  break; } }
-#define RS_tx1(c) while(1) { if( !RS_Xbusy1 ) { SBUF1 = c; RS_Xbusy1 = 1; break; } }
+#define RS_tx(c)          \
+    while (1) {           \
+        if (!RS_Xbusy) {  \
+            SBUF0 = c;    \
+            RS_Xbusy = 1; \
+            break;        \
+        }                 \
+    }
+#define RS_tx1(c)          \
+    while (1) {            \
+        if (!RS_Xbusy1) {  \
+            SBUF1 = c;     \
+            RS_Xbusy1 = 1; \
+            break;         \
+        }                  \
+    }
 
 uint8_t RS_ready(void);
 
@@ -62,7 +75,7 @@ extern XDATA_SEG volatile uint8_t RS_out1;
 
 #ifdef USE_SMARTAUDIO
 
-#define SUART_BUF_MAX 32  //has to be power of 2
+#define SUART_BUF_MAX 32 // has to be power of 2
 
 extern uint8_t suart_tx_en;
 void suart_txint();
@@ -71,9 +84,9 @@ void suart_rxint();
 uint8_t SUART_ready();
 uint8_t SUART_rx();
 
-void SUART_tx(uint8_t* tbuf,uint8_t len);
+void SUART_tx(uint8_t *tbuf, uint8_t len);
 extern uint8_t SA_is_0;
 extern uint8_t SA_config;
-#endif //USE_SMARTAUDIO
+#endif // USE_SMARTAUDIO
 
 #endif /* __UART_H_ */


### PR DESCRIPTION
builds on #39
addresses #32

PR enables automatic formatting via vscode according to the clang-format configuration merged in earlier PRs
applies said formatting to all source files. this only touches indentation, no variable and function names.

As for symbol names, with c, i personally prefer `snake_case`, as you usually have functions and variables named `prefix_<something>`, because of this an attempt to use CamelCase quite often ends up leading to weird hybrids like `Prefix_CamelCase` which is in-consistent and not desirable in my humble opinion.
This seems to have already happened to a degree in this codebase and most _variables_ are already in snake_case.
 
 I suggest we convert the whole codebase to `snake_case` and use that moving forward.
 
 I am marking this as a draft, so we can iterate on the clang-format config if necessary and maybe add changes to unify the symbol names across the codebase.