### PR TITLE
Version control with semvers

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -8,9 +8,6 @@
 #include "sfr_ext.h"
 #include "toolchain.h"
 
-#define VERSION 0x41
-#define BETA    0x04
-
 //#define HDZERO_WHOOP
 //#define HDZERO_WHOOP_LITE
 //#define HDZERO_RACE_V1
@@ -32,17 +29,17 @@
 #endif
 
 #if defined HDZERO_WHOOP
-#define VTX_NAME "     HDZ WHOOP"
+#define VTX_NAME "HDZ WHOOP"
 #elif defined HDZERO_WHOOP_LITE
 #define VTX_NAME "HDZ WHOOP LITE"
 #elif defined HDZERO_RACE_V1
-#define VTX_NAME "   HDZ RACE V1"
+#define VTX_NAME "HDZ RACE V1"
 #elif defined HDZERO_RACE_V2
-#define VTX_NAME "   HDZ RACE V2"
+#define VTX_NAME "HDZ RACE V2"
 #elif defined HDZERO_FREESTYLE
-#define VTX_NAME " HDZ FREESTYLE"
+#define VTX_NAME "HDZ FREESTYLE"
 #else
-#define VTX_NAME "              "
+#define VTX_NAME "  "
 #endif
 
 // system
@@ -60,7 +57,7 @@
 //#define FIX_EEP
 
 #ifndef _RF_CALIB
-//#define _DEBUG_MODE
+#define _DEBUG_MODE
 //#define _DEBUG_DM6300
 //#define _DEBUG_TC3587
 //#define _DEBUG_CAMERA

--- a/src/common.h
+++ b/src/common.h
@@ -57,7 +57,7 @@
 //#define FIX_EEP
 
 #ifndef _RF_CALIB
-#define _DEBUG_MODE
+//#define _DEBUG_MODE
 //#define _DEBUG_DM6300
 //#define _DEBUG_TC3587
 //#define _DEBUG_CAMERA

--- a/src/global.h
+++ b/src/global.h
@@ -22,5 +22,4 @@ void WAIT(uint16_t ms);
 #else
 void WAIT(uint32_t ms);
 #endif
-
 #endif /* __GLOBAL_H_ */

--- a/src/mcu.c
+++ b/src/mcu.c
@@ -92,9 +92,9 @@ void main(void) {
 
 #ifdef _DEBUG_MODE
     debugf("\r\n");
-    debugf("\r\nVtx:%s", VTX_NAME);
-    debugf("\r\nVersion: %s", VTX_VERSION_STRING);
-    debugf("\r\nBuild time: " __DATE__ " " __TIME__);
+    debugf("\r\nVtx        : %s", VTX_NAME);
+    debugf("\r\nVersion    : %s", VTX_VERSION_STRING);
+    debugf("\r\nBuild time : " __DATE__ " " __TIME__);
 #endif
 
     Init_HW(); // init

--- a/src/mcu.c
+++ b/src/mcu.c
@@ -14,6 +14,7 @@
 #include "sfr_ext.h"
 #include "smartaudio_protocol.h"
 #include "uart.h"
+#include "version.h"
 
 uint8_t UNUSED = 0;
 
@@ -90,14 +91,10 @@ void main(void) {
     // WAIT(100);
 
 #ifdef _DEBUG_MODE
-    debugf("\r\n========================================================");
-    debugf("\r\n     >>>             Divimath DM568X            <<<     ");
-    debugf("\r\n========================================================");
-    debugf("\r\nversion:%02X", VERSION);
-#ifdef BETA
-    debugf(".%02X", BETA);
-#endif
     debugf("\r\n");
+    debugf("\r\nVtx:%s", VTX_NAME);
+    debugf("\r\nVersion: %s", VTX_VERSION_STRING);
+    debugf("\r\nBuild time: " __DATE__ " " __TIME__);
 #endif
 
     Init_HW(); // init
@@ -113,7 +110,6 @@ void main(void) {
 
     // main loop
     while (1) {
-
         timer_task();
 
 #ifdef USE_SMARTAUDIO

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -11,6 +11,7 @@
 #include "smartaudio_protocol.h"
 #include "spi.h"
 #include "uart.h"
+#include "version.h"
 
 uint8_t osd_buf[HD_VMAX][HD_HMAX];
 uint8_t loc_buf[HD_VMAX][7];
@@ -392,7 +393,7 @@ uint8_t get_tx_data_5680() // prepare data to VRX
     tx_buf[1] = DP_HEADER1;
     tx_buf[2] = 0xff;
     // len
-    tx_buf[3] = 12;
+    tx_buf[3] = 15;
 
     // camType
     if (CAM_MODE == CAM_720P50)
@@ -421,7 +422,7 @@ uint8_t get_tx_data_5680() // prepare data to VRX
 
     tx_buf[11] = fontType; // fontType
 
-    tx_buf[12] = VERSION;
+    tx_buf[12] = 0x00; // deprecated
 
     tx_buf[13] = VTX_ID;
 
@@ -429,9 +430,13 @@ uint8_t get_tx_data_5680() // prepare data to VRX
 
     tx_buf[15] = cam_4_3 ? 0xaa : 0x55;
 
-    tx_buf[16] = 0x40; // crc
+    tx_buf[16] = VTX_VERSION_MAJOR;
+    tx_buf[17] = VTX_VERSION_MINOR;
+    tx_buf[18] = VTX_VERSION_PATCH_LEVEL;
 
-    return 17;
+    tx_buf[19] = 0x40; // crc
+
+    return 20;
 }
 
 uint8_t get_tx_data_osd(uint8_t index) // prepare osd+data to VTX
@@ -1432,26 +1437,20 @@ void vtx_menu_init() {
     }
 
     // draw variant
-    strcpy(osd_buf[10] + osd_menu_offset + 10, VTX_NAME);
+    strcpy(osd_buf[10] + osd_menu_offset + 13, VTX_NAME);
 
     // draw version
-    osd_buf[11][osd_menu_offset + 22] = (uint8_t)((VERSION >> 4) & 0x0f) + '0';
-    osd_buf[11][osd_menu_offset + 23] = (uint8_t)(VERSION & 0x0f) + '0';
-#ifdef BETA
-    osd_buf[11][osd_menu_offset + 25] = 'B';
-    osd_buf[11][osd_menu_offset + 26] = (uint8_t)((BETA >> 4) & 0x0f) + '0';
-    osd_buf[11][osd_menu_offset + 27] = (uint8_t)(BETA & 0x0f) + '0';
-#endif
+    strcpy(osd_buf[11] + osd_menu_offset + 13, VTX_VERSION_STRING);
 
     ParseLifeTime(hourString, minuteString);
-    osd_buf[12][osd_menu_offset + 16] = hourString[0];
-    osd_buf[12][osd_menu_offset + 17] = hourString[1];
-    osd_buf[12][osd_menu_offset + 18] = hourString[2];
-    osd_buf[12][osd_menu_offset + 19] = hourString[3];
-    osd_buf[12][osd_menu_offset + 20] = 'H';
-    osd_buf[12][osd_menu_offset + 21] = minuteString[0];
-    osd_buf[12][osd_menu_offset + 22] = minuteString[1];
-    osd_buf[12][osd_menu_offset + 23] = 'M';
+    osd_buf[12][osd_menu_offset + 13] = hourString[0];
+    osd_buf[12][osd_menu_offset + 14] = hourString[1];
+    osd_buf[12][osd_menu_offset + 15] = hourString[2];
+    osd_buf[12][osd_menu_offset + 16] = hourString[3];
+    osd_buf[12][osd_menu_offset + 17] = 'H';
+    osd_buf[12][osd_menu_offset + 18] = minuteString[0];
+    osd_buf[12][osd_menu_offset + 19] = minuteString[1];
+    osd_buf[12][osd_menu_offset + 20] = 'M';
 
     vtx_channel = RF_FREQ;
     vtx_power = RF_POWER;

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -393,7 +393,7 @@ uint8_t get_tx_data_5680() // prepare data to VRX
     tx_buf[1] = DP_HEADER1;
     tx_buf[2] = 0xff;
     // len
-    tx_buf[3] = 15;
+    tx_buf[3] = 14;
 
     // camType
     if (CAM_MODE == CAM_720P50)
@@ -434,9 +434,7 @@ uint8_t get_tx_data_5680() // prepare data to VRX
     tx_buf[17] = VTX_VERSION_MINOR;
     tx_buf[18] = VTX_VERSION_PATCH_LEVEL;
 
-    tx_buf[19] = 0x40; // crc
-
-    return 20;
+    return 19;
 }
 
 uint8_t get_tx_data_osd(uint8_t index) // prepare osd+data to VTX

--- a/src/version.h
+++ b/src/version.h
@@ -1,0 +1,11 @@
+#ifndef __VERSION_H_
+#define __VERSION_H_
+
+#define _STR(x)                 #x
+#define STR(x)                  _STR(x)
+#define VTX_VERSION_MAJOR       0 // increment when a major release is made (big new feature, etc)
+#define VTX_VERSION_MINOR       1 // increment when a minor release is made (small new feature, change etc)
+#define VTX_VERSION_PATCH_LEVEL 0 // increment when a bug is fixed
+#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL)
+
+#endif /* __VERSION_H_ */

--- a/src/version.h
+++ b/src/version.h
@@ -1,11 +1,12 @@
 #ifndef __VERSION_H_
 #define __VERSION_H_
 
-#define _STR(x)                 #x
-#define STR(x)                  _STR(x)
 #define VTX_VERSION_MAJOR       0 // increment when a major release is made (big new feature, etc)
 #define VTX_VERSION_MINOR       1 // increment when a minor release is made (small new feature, change etc)
 #define VTX_VERSION_PATCH_LEVEL 0 // increment when a bug is fixed
 #define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL)
+
+#define _STR(x) #x
+#define STR(x)  _STR(x)
 
 #endif /* __VERSION_H_ */


### PR DESCRIPTION
- Use semver.
- VTX_NAME align left.
- Modify debug information when VTX power up.
- Vtx version number transfer to VRX is being verified.