### PR TITLE
change fc_variant initial value to 0xff 0xff 0xff 0xff

### DIFF
--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -26,7 +26,7 @@ uint8_t fc_lock = 0;
 uint8_t disp_mode; // DISPLAY_OSD | DISPLAY_CMS;
 uint8_t osd_ready;
 
-uint8_t fc_variant[4] = {'B', 'T', 'F', 'L'};
+uint8_t fc_variant[4] = {0xff, 0xff, 0xff, 0xff};
 uint8_t fontType = 0x00;
 uint8_t resolution = SD_3016;
 uint8_t resolution_last = HD_5018;


### PR DESCRIPTION
VRX load osd font image only once when it receives fc_variant != 0xffffffff