### PR TITLE
reset runcam camera isp if video format is changed

### DIFF
--- a/src/camera.c
+++ b/src/camera.c
@@ -56,10 +56,16 @@ void camera_mode_detect() {
                 Init_TC3587(1);
                 Set_540P90(0);
             } else if (camera_setting_reg_set[11] == 3) {
+#if (0)
                 Set_720P60(IS_RX);
                 Init_TC3587(0);
                 Set_960x720P60(0);
                 video_format = VDO_FMT_960x720P60;
+#else
+                Init_TC3587(1);
+                Set_960x720P60(0);
+                video_format = VDO_FMT_960x720P60;
+#endif
             }
         } else {
             Set_720P60(IS_RX);

--- a/src/camera.c
+++ b/src/camera.c
@@ -36,6 +36,23 @@ void camera_type_detect(void) {
     }
 }
 
+void camera_ratio_detect(void) {
+    if (camera_type == CAMERA_TYPE_RUNCAM_MICRO_V1) {
+        camRatio = 0;
+    } else if (camera_type == CAMERA_TYPE_RUNCAM_MICRO_V2) {
+        if (camera_setting_reg_set[11] == 0)
+            camRatio = 1;
+        else
+            camRatio = 0;
+    } else if (camera_type == CAMERA_TYPE_RUNCAM_NANO_90) {
+        if (camera_setting_reg_set[11] == 1)
+            camRatio = 0;
+        else
+            camRatio = 1;
+    } else
+        camRatio = 0;
+}
+
 void camera_mode_detect() {
     uint8_t cycles = 4;
     uint8_t loss = 0;
@@ -110,7 +127,7 @@ void camera_mode_detect() {
             cycles--;
         }
     }
-
+    camera_ratio_detect();
 #ifdef _DEBUG_MODE
     debugf("\r\ncameraID: %x", (uint16_t)camera_type);
 #endif

--- a/src/camera.c
+++ b/src/camera.c
@@ -64,25 +64,19 @@ void camera_mode_detect() {
 
     if (camera_type) {
         if (camera_type == CAMERA_TYPE_RUNCAM_NANO_90) {
-            if (camera_setting_reg_set[11] == 0 || camera_setting_reg_set[11] == 1) {
+            Init_TC3587(1);
+            if (camera_setting_reg_set[11] == 0) {
+                Set_540P90(0);
                 video_format = VDO_FMT_540P90;
-                Init_TC3587(1);
-                Set_540P90(0);
+            } else if (camera_setting_reg_set[11] == 1) {
+                Set_540P90_crop(0);
+                video_format = VDO_FMT_540P90;
             } else if (camera_setting_reg_set[11] == 2) {
-                video_format = VDO_FMT_540P60;
-                Init_TC3587(1);
-                Set_540P90(0);
+                ; // Set_540P90(0);
+                ; // video_format = VDO_FMT_540P60;
             } else if (camera_setting_reg_set[11] == 3) {
-#if (0)
-                Set_720P60(IS_RX);
-                Init_TC3587(0);
                 Set_960x720P60(0);
                 video_format = VDO_FMT_960x720P60;
-#else
-                Init_TC3587(1);
-                Set_960x720P60(0);
-                video_format = VDO_FMT_960x720P60;
-#endif
             }
         } else {
             Set_720P60(IS_RX);

--- a/src/camera.c
+++ b/src/camera.c
@@ -369,8 +369,8 @@ void camera_menu_draw_value(void) {
                     strcpy(&osd_buf[i][osd_menu_offset + 19], resolution_runcam_micro_v2[camera_setting_reg_menu[i - 1]]);
                 } else if (camera_type == CAMERA_TYPE_RUNCAM_NANO_90) {
                     strcpy(&osd_buf[i][osd_menu_offset + 19], resolution_runcam_nano_90[camera_setting_reg_menu[i - 1]]);
-                    osd_buf[i][osd_menu_offset + 29] = '>';
                 }
+                osd_buf[i][osd_menu_offset + 29] = '>';
                 break;
             default:
                 break;
@@ -637,13 +637,8 @@ uint8_t camera_status_update(uint8_t op) {
             camera_setting_reg_menu_update();
             repower = camera_set(camera_setting_reg_menu, 0);
 
-            if (repower) {
-                camera_menu_show_repower();
-                camMenuStatus = CAM_STATUS_REPOWER;
-            } else {
-                camMenuStatus = CAM_STATUS_IDLE;
-                ret = 1;
-            }
+            camMenuStatus = CAM_STATUS_IDLE;
+            ret = 1;
         }
         break;
     case CAM_STATUS_SAVE_EXIT:
@@ -660,11 +655,12 @@ uint8_t camera_status_update(uint8_t op) {
             camera_setting_profile_write(0xff);
 
             if (repower) {
-                camera_menu_show_repower();
-                camMenuStatus = CAM_STATUS_REPOWER;
-            } else {
-                camMenuStatus = CAM_STATUS_IDLE;
-                ret = 1;
+                if (camera_mfr == CAMERA_MFR_RUNCAM) {
+                    runcam_reset_isp();
+                    camera_init();
+                    camMenuStatus = CAM_STATUS_IDLE;
+                    ret = 1;
+                }
             }
         }
         break;

--- a/src/camera.c
+++ b/src/camera.c
@@ -658,10 +658,10 @@ uint8_t camera_status_update(uint8_t op) {
                 if (camera_mfr == CAMERA_MFR_RUNCAM) {
                     runcam_reset_isp();
                     camera_init();
-                    camMenuStatus = CAM_STATUS_IDLE;
-                    ret = 1;
                 }
             }
+            camMenuStatus = CAM_STATUS_IDLE;
+            ret = 1;
         }
         break;
         // case CAM_STATUS_REPOWER:

--- a/src/camera.c
+++ b/src/camera.c
@@ -446,13 +446,13 @@ void camera_profile_menu_toggle(uint8_t op) {
         if (camera_profile_menu == CAMERA_PROFILE_NUM)
             camera_profile_menu = 0;
         camera_setting_reg_menu_update();
-        camera_set(camera_setting_reg_menu, 0);
+        camera_set(camera_setting_reg_menu, 0); // bug here
     } else if (op == BTN_LEFT) {
         camera_profile_menu--;
         if (camera_profile_menu > CAMERA_PROFILE_NUM)
             camera_profile_menu = CAMERA_PROFILE_NUM - 1;
         camera_setting_reg_menu_update();
-        camera_set(camera_setting_reg_menu, 0);
+        camera_set(camera_setting_reg_menu, 0); // bug here
     }
 }
 

--- a/src/camera.c
+++ b/src/camera.c
@@ -666,6 +666,9 @@ uint8_t camera_status_update(uint8_t op) {
         camera_menu_item_toggle(op);
 
         if (op == BTN_RIGHT) {
+            // 540@60 do not work for now
+            if (camera_mfr == CAMERA_MFR_RUNCAM && camera_type == CAMERA_TYPE_RUNCAM_NANO_90 && camera_setting_reg_menu[11] == 2)
+                break;
             camera_profile_eep = camera_profile_menu;
             camera_profile_write();
             reset_isp_need |= camera_set(camera_setting_reg_menu, 1);

--- a/src/camera.c
+++ b/src/camera.c
@@ -45,10 +45,7 @@ void camera_ratio_detect(void) {
         else
             camRatio = 0;
     } else if (camera_type == CAMERA_TYPE_RUNCAM_NANO_90) {
-        if (camera_setting_reg_set[11] == 1)
-            camRatio = 0;
-        else
-            camRatio = 1;
+        camRatio = 1;
     } else
         camRatio = 0;
 }
@@ -70,7 +67,7 @@ void camera_mode_detect() {
                 video_format = VDO_FMT_540P90;
             } else if (camera_setting_reg_set[11] == 1) {
                 Set_540P90_crop(0);
-                video_format = VDO_FMT_540P90;
+                video_format = VDO_FMT_540P90_CROP;
             } else if (camera_setting_reg_set[11] == 2) {
                 ; // Set_540P90(0);
                 ; // video_format = VDO_FMT_540P60;

--- a/src/camera.h
+++ b/src/camera.h
@@ -40,6 +40,7 @@ typedef enum {
     VDO_FMT_720P60_NEW,
     VDO_FMT_720P30,
     VDO_FMT_540P90,
+    VDO_FMT_540P90_CROP,
     VDO_FMT_540P60,
     VDO_FMT_960x720P60
 } video_format_e;

--- a/src/hardware.c
+++ b/src/hardware.c
@@ -1,5 +1,4 @@
 #include "hardware.h"
-
 #include "camera.h"
 #include "common.h"
 #include "dm6300.h"
@@ -141,7 +140,7 @@ void Set_720P60(uint8_t page) {
 }
 
 void Set_960x720P60(uint8_t page) {
-    WriteReg(page, 0x21, 0x1F);
+    WriteReg(page, 0x21, 0x1C);
 
     WriteReg(page, 0x40, 0xC0);
     WriteReg(page, 0x41, 0x23);
@@ -182,10 +181,34 @@ void Set_720P30(uint8_t page, uint8_t is_43) {
 }
 
 void Set_540P90(uint8_t page) {
+    WriteReg(page, 0x21, 0x21);
+
+    WriteReg(page, 0x40, 0xD0);
+    WriteReg(page, 0x41, 0x22);
+    WriteReg(page, 0x42, 0x18);
+
+    // WriteReg(page, 0x43, 0xD4); //pat
+    // WriteReg(page, 0x44, 0x45);
+
+    WriteReg(page, 0x43, 0x1F); // cam
+    WriteReg(page, 0x44, 0x44);
+
+    WriteReg(page, 0x45, 0x29);
+    WriteReg(page, 0x49, 0x04);
+    WriteReg(page, 0x4c, 0x08);
+    WriteReg(page, 0x4f, 0x00);
+    WriteReg(page, 0x52, 0x04);
+    WriteReg(page, 0x53, 0x02);
+    WriteReg(page, 0x54, 0x3C);
+
+    WriteReg(page, 0x06, 0x01);
+}
+
+void Set_540P90_crop(uint8_t page) {
 #ifdef CAM90_DEMO
     WriteReg(page, 0x21, 0x24);
 #else
-    WriteReg(page, 0x21, 0x21);
+    WriteReg(page, 0x21, 0x1f);
 #endif
 
     WriteReg(page, 0x40, 0xD0);

--- a/src/hardware.c
+++ b/src/hardware.c
@@ -205,11 +205,7 @@ void Set_540P90(uint8_t page) {
 }
 
 void Set_540P90_crop(uint8_t page) {
-#ifdef CAM90_DEMO
-    WriteReg(page, 0x21, 0x24);
-#else
     WriteReg(page, 0x21, 0x1f);
-#endif
 
     WriteReg(page, 0x40, 0xD0);
     WriteReg(page, 0x41, 0x22);

--- a/src/hardware.h
+++ b/src/hardware.h
@@ -78,6 +78,7 @@ void CFG_Back();
 void Set_720P50(uint8_t page);
 void Set_720P60(uint8_t page);
 void Set_540P90(uint8_t page);
+void Set_540P90_crop(uint8_t page);
 void Set_960x720P60(uint8_t page);
 void Set_720P30(uint8_t page, uint8_t is_43);
 

--- a/src/i2c_device.c
+++ b/src/i2c_device.c
@@ -87,6 +87,7 @@ void Init_TC3587(uint8_t fmt) {
 #ifdef _DEBUG_TC3587
     debugf("\r\nDetecte TC3587...");
 #endif
+#if (0) // some vtx cannot pass tc3587 detect, I don't know the reason.
     while (1) {
         val = I2C_Read16(ADDR_TC3587, 0x0000);
         if (val == 0x4401) {
@@ -105,6 +106,10 @@ void Init_TC3587(uint8_t fmt) {
             }
         }
     }
+#else
+    LED_BLUE_ON;
+    led_status = ON;
+#endif
     I2C_Write16(ADDR_TC3587, 0x0002, 0x0001);
     I2C_Write16(ADDR_TC3587, 0x0002, 0x0000); // srst
 

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -412,6 +412,8 @@ uint8_t get_tx_data_5680() // prepare data to VRX
         tx_buf[4] = 0xCC;
     else if (video_format == VDO_FMT_540P90)
         tx_buf[4] = 0xEE;
+    else if (video_format == VDO_FMT_540P90_CROP)
+        tx_buf[4] = 0x44;
     else if (video_format == VDO_FMT_540P60)
         tx_buf[4] = 0x33;
     else if (video_format == VDO_FMT_960x720P60)
@@ -455,7 +457,7 @@ uint8_t get_tx_data_5680() // prepare data to VRX
 
     tx_buf[14] = fc_lock & 0x03;
 
-    tx_buf[15] = (camRatio == 0) ? 0xaa : 0x55;
+    tx_buf[15] = (camRatio == 0) ? 0x55 : 0xaa;
 
     tx_buf[16] = VTX_VERSION_MAJOR;
     tx_buf[17] = VTX_VERSION_MINOR;

--- a/src/runcam.c
+++ b/src/runcam.c
@@ -412,6 +412,13 @@ void runcam_save(void) {
 #endif
 }
 
+void runcam_reset_isp(void) {
+    RUNCAM_Write(camera_device, 0x000694, 0x00000130);
+#ifdef _DEBUG_RUNCAM
+    debugf("\r\nRUNCAM reset isp");
+#endif
+}
+
 uint8_t runcam_set(uint8_t *setting_profile) {
     static uint8_t init_done = 0;
     uint8_t ret = 0;

--- a/src/runcam.c
+++ b/src/runcam.c
@@ -345,7 +345,7 @@ void runcam_video_format(uint8_t val) {
 
     RUNCAM_NANO_90:
         0: 720x540@90 4:3
-        1: 720x540@90 16:9 crop // NANO 90 DEMO CAMERA DOESN"T SUPPORT
+        1: 720x540@90 4:3 crop // NANO 90 DEMO CAMERA DOESN"T SUPPORT
         2: 720x540@60 4:3
         3: 960x720@60 4:3
     */

--- a/src/runcam.c
+++ b/src/runcam.c
@@ -344,10 +344,10 @@ void runcam_video_format(uint8_t val) {
         2: 1280x720@60 16:9 full
 
     RUNCAM_NANO_90:
-        0: 720x540@90
-        1: 720x540@90 crop //NANO 90 DEMO CAMERA DOESN"T SUPPORT
-        2: 720x540@60
-        3: 960x720@60
+        0: 720x540@90 4:3
+        1: 720x540@90 16:9 crop // NANO 90 DEMO CAMERA DOESN"T SUPPORT
+        2: 720x540@60 4:3
+        3: 960x720@60 4:3
     */
     camera_setting_reg_set[11] = val;
 

--- a/src/runcam.h
+++ b/src/runcam.h
@@ -6,5 +6,6 @@ void runcam_type_detect(void);
 void runcam_setting_profile_reset(uint8_t *setting_profile);
 uint8_t runcam_setting_profile_check(uint8_t *setting_profile);
 uint8_t runcam_set(uint8_t *setting_profile);
+void runcam_reset_isp(void);
 void runcam_save(void);
 #endif


### PR DESCRIPTION
- For runcam camera, if video format is changed, users no longer need to repower VTX.
- The nano 90 camera has not yet completed verification.