### PR TITLE
Remove quic font workaround & misc

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -21,6 +21,7 @@ platform = intel_mcs51@2.1.0
 platform_packages = toolchain-sdcc@~1.40100
 upload_protocol = custom
 board = DM5680
+monitor_speed = 115200
 build_unflags =
   --peep-return
 build_flags =

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -255,7 +255,7 @@ uint8_t msp_read_one_frame() {
                     ret = parse_displayport(osd_len);
                 full_frame = 1;
 #ifdef INIT_VTX_TABLE
-                if (fc_lock & FC_VTX_CONFIG_LOCK && !(fc_lock & FC_INIT_VTX_TABLE_LOCK) && fc_lock & FC_VARIANT_LOCK) {
+                if ((fc_lock & FC_VTX_CONFIG_LOCK) && (fc_lock & FC_INIT_VTX_TABLE_LOCK) != 0 && (fc_lock & FC_VARIANT_LOCK)) {
                     fc_lock |= FC_INIT_VTX_TABLE_LOCK;
                     if (msp_cmp_fc_variant("BTFL") || msp_cmp_fc_variant("QUIC")) {
                         InitVtxTable();

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -415,19 +415,10 @@ uint8_t get_tx_data_5680() // prepare data to VRX
         tx_buf[4] = 0x99;
 
     // fcType
-    if (msp_cmp_fc_variant("QUIC")) {
-        // HACK!
-        // TODO: remove once another way of selecting font on the VRX is available
-        tx_buf[5] = 'A';
-        tx_buf[6] = 'R';
-        tx_buf[7] = 'D';
-        tx_buf[8] = 'U';
-    } else {
-        tx_buf[5] = fc_variant[0];
-        tx_buf[6] = fc_variant[1];
-        tx_buf[7] = fc_variant[2];
-        tx_buf[8] = fc_variant[3];
-    }
+    tx_buf[5] = fc_variant[0];
+    tx_buf[6] = fc_variant[1];
+    tx_buf[7] = fc_variant[2];
+    tx_buf[8] = fc_variant[3];
 
     // counter for link quality
     tx_buf[9] = lq_cnt++;

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -26,7 +26,7 @@ uint8_t fc_lock = 0;
 uint8_t disp_mode; // DISPLAY_OSD | DISPLAY_CMS;
 uint8_t osd_ready;
 
-uint8_t fc_variant[4] = {'B', 'T', 'F', 'L'};
+uint8_t fc_variant[4] = {0xff, 0xff, 0xff, 0xff};
 uint8_t fontType = 0x00;
 uint8_t resolution = SD_3016;
 uint8_t resolution_last = HD_5018;


### PR DESCRIPTION
builds on #61

- improve clarity of fc_lock check
- remove quic font workaround
- add monitor speed to pio config, allows 1-click read of debug output in vscode