### PR TITLE
Optimize power on init RF delay

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -102,6 +102,7 @@
 #define WAIT_SA_LOCK   4
 #define WAIT_SA_CONFIG 9
 #else
+#define WAIT_SA_LOCK   0
 #define WAIT_SA_CONFIG 0
 #endif
 

--- a/src/common.h
+++ b/src/common.h
@@ -88,19 +88,25 @@
 #define IS_RX 0
 
 // time
-#define TIMER0_1S      9588
-#define TIMER0_1SD2    (TIMER0_1S >> 1)
-#define TIMER0_1SD16   (TIMER0_1S >> 4)
-#define I2C_BIT_DLY    40
-#define MS_DLY         (237)
-#define MS_DLY_SDCC    (2746)
-#define PRESS_L        3
-#define PRESS_LL       8
-#define PWR_LMT_SEC    10
+#define TIMER0_1S    9588
+#define TIMER0_1SD2  (TIMER0_1S >> 1)
+#define TIMER0_1SD16 (TIMER0_1S >> 4)
+#define I2C_BIT_DLY  40
+#define MS_DLY       (237)
+#define MS_DLY_SDCC  (2746)
+#define PRESS_L      3
+#define PRESS_LL     8
+#define PWR_LMT_SEC  10
+
+#ifdef USE_SMARTAUDIO
 #define WAIT_SA_CONFIG 9
-#define CFG_TO_SEC     10
-#define CAM_DET_DLY    1000
-#define DISPF_TIME     3 // 3/8s
+#else
+#define WAIT_SA_CONFIG 0
+#endif
+
+#define CFG_TO_SEC  10
+#define CAM_DET_DLY 1000
+#define DISPF_TIME  3 // 3/8s
 
 // gpio
 #define SCL     P0_0

--- a/src/common.h
+++ b/src/common.h
@@ -99,6 +99,7 @@
 #define PWR_LMT_SEC  10
 
 #ifdef USE_SMARTAUDIO
+#define WAIT_SA_LOCK   4
 #define WAIT_SA_CONFIG 9
 #else
 #define WAIT_SA_CONFIG 0

--- a/src/hardware.c
+++ b/src/hardware.c
@@ -944,9 +944,9 @@ void Flicker_LED(uint8_t n) {
     uint8_t i;
     for (i = 0; i < n; i++) {
         LED_BLUE_OFF;
-        WAIT(120);
+        WAIT(50);
         LED_BLUE_ON;
-        WAIT(120);
+        WAIT(50);
     }
     led_status = ON;
 }

--- a/src/mcu.c
+++ b/src/mcu.c
@@ -184,9 +184,14 @@ void RF_Delay_Init() {
     }
 
     // init_rf
-    if (seconds < WAIT_SA_CONFIG)
-        return;
-    else if (rf_delay_init_done)
+    if (seconds < WAIT_SA_CONFIG) { // wait for SA config vtx
+        if (seconds < WAIT_SA_LOCK)
+            return;
+        else if (SA_lock)
+            return;
+        else
+            seconds = WAIT_SA_CONFIG;
+    } else if (rf_delay_init_done)
         return;
     else if (dm6300_init_done)
         return;

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -1081,7 +1081,7 @@ uint8_t parse_displayport(uint8_t len) {
                 _outchar(' ');
 #endif
                 if (!(fc_lock & FC_OSD_LOCK)) {
-                    Flicker_LED(8);
+                    Flicker_LED(3);
                     fc_lock |= FC_OSD_LOCK;
                 }
                 return 1;


### PR DESCRIPTION
- For VTX with SA port:
     - Enable msp vtx, initialize RF delay about 3-4 seconds.
     - Disable msp vtx and SA, initialization RF delay is expected to be 5 seconds (if vtx works as expected).
     - When SA is enabled, the initial RF delay is still 10 seconds.
- For VTX without SA port (whoop vtx):
     - Enable msp vtx, initialize RF delay about 3-4 seconds.
     - Disable msp vtx, the initial RF delay is expected to be 5 seconds (if vtx works as expected).