### PR TITLE
Fix runcam shutter set for runcam nano90

### DIFF
--- a/src/camera.h
+++ b/src/camera.h
@@ -88,4 +88,5 @@ extern uint8_t camera_type;
 extern uint8_t camera_device;
 extern uint8_t camera_attribute[CAMERA_SETTING_NUM][4];
 extern uint8_t camera_setting_reg_set[CAMERA_SETTING_NUM];
+extern uint8_t camera_setting_reg_menu[CAMERA_SETTING_NUM];
 #endif /* __CAMERA_H_ */

--- a/src/i2c.c
+++ b/src/i2c.c
@@ -322,7 +322,7 @@ uint8_t RUNCAM_Write(uint8_t cam_id, uint32_t addr, uint32_t val) {
     if (value) {
         I2C_stop();
 #ifdef _DEBUG_RUNCAM
-        debugf("\r\nRUNCAM_Write error id: %x value: %d", cam_id, value);
+        debugf("\r\nRUNCAM_Write error id: %x value: %d", (uint16_t)cam_id, (uint16_t)value);
 #endif
         return 1;
     }

--- a/src/mcu.c
+++ b/src/mcu.c
@@ -11,6 +11,7 @@
 #include "msp_displayport.h"
 #include "print.h"
 #include "rom.h"
+#include "runcam.h"
 #include "sfr_ext.h"
 #include "smartaudio_protocol.h"
 #include "uart.h"
@@ -166,6 +167,7 @@ void main(void) {
             msp_task();
             Update_EEP_LifeTime();
             uart_baudrate_detect();
+            runcam_shutter_fix(seconds);
         }
 
         RF_Delay_Init();

--- a/src/runcam.c
+++ b/src/runcam.c
@@ -412,10 +412,16 @@ void runcam_shutter(uint8_t val) {
                 dat = 0x460;
             else if (camera_type == CAMERA_TYPE_RUNCAM_NANO_90)
                 dat = 0x447;
-        } else // manual
+            // DO NOT REMOVE, Otherwise, auto mode may fail to be set.
+            RUNCAM_Write(camera_device, 0x00006c, 800);
+            WAIT(50);
+            RUNCAM_Write(camera_device, 0x000044, 0x80009629);
+            WAIT(50);
+        } else { // manual
             dat = (uint32_t)(val)*25;
+        }
 
-        RUNCAM_Read_Write(camera_device, 0x00006c, dat);
+        RUNCAM_Write(camera_device, 0x00006c, dat);
         WAIT(50);
         RUNCAM_Write(camera_device, 0x000044, 0x80009629);
         WAIT(50);

--- a/src/runcam.c
+++ b/src/runcam.c
@@ -428,6 +428,30 @@ void runcam_shutter(uint8_t val) {
     }
 }
 
+void runcam_shutter_fix(uint16_t sec) {
+    static uint8_t fixed = 0;
+    uint32_t dat = 0;
+    uint8_t val = camera_setting_reg_menu[4];
+    /*
+        Setting the shutter for RUNCAM_NANO_90 in the first few seconds of power-on will not take effect, so configure the shutter speed after little seconds.
+    */
+    if (sec >= 1 && !fixed) {
+        if (camera_type == CAMERA_TYPE_RUNCAM_NANO_90) {
+            if (val == 0) {
+                dat = 0x447;
+            } else {
+                dat = (uint32_t)(val)*25;
+            }
+
+            RUNCAM_Write(camera_device, 0x00006c, dat);
+            WAIT(50);
+            RUNCAM_Write(camera_device, 0x000044, 0x80009629);
+            WAIT(50);
+        }
+        fixed = 1;
+    }
+}
+
 uint8_t runcam_setting_update_need(uint8_t *setting_p, uint8_t start, uint8_t stop) {
     uint8_t i;
     for (i = start; i <= stop; i++) {

--- a/src/runcam.h
+++ b/src/runcam.h
@@ -8,4 +8,5 @@ uint8_t runcam_setting_profile_check(uint8_t *setting_profile);
 uint8_t runcam_set(uint8_t *setting_profile);
 void runcam_reset_isp(void);
 void runcam_save(void);
+void runcam_shutter_fix(uint16_t sec);
 #endif


### PR DESCRIPTION
For the runcam nano90 camera, the custom shutter speed cannot take effect when the power is turned on, the reason is unknown.
The current remedy is to configure the shutter speed again about three seconds after the system starts.