### PR TITLE
Fix VTX_MSP frequency control

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -153,4 +153,19 @@
 #define Rom_rx()    RS_rx()
 #define Rom_ready() RS_ready()
 
+#define FREQ_R1 (uint16_t)5658
+#define FREQ_R2 (uint16_t)5696
+#define FREQ_R3 (uint16_t)5732
+#define FREQ_R4 (uint16_t)5769
+#define FREQ_R5 (uint16_t)5806
+#define FREQ_R6 (uint16_t)5843
+#define FREQ_R7 (uint16_t)5880
+#define FREQ_R8 (uint16_t)5917
+#define FREQ_F2 (uint16_t)5760
+#define FREQ_F4 (uint16_t)5800
+
+#define INVALID_CHANNEL 0xff
+
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
+
 #endif /* __COMMON_H_ */

--- a/src/dm6300.c
+++ b/src/dm6300.c
@@ -71,6 +71,8 @@ const uint32_t tab[3][FREQ_MAX_EXT + 1] = {
 const uint32_t freq_tab[FREQ_MAX_EXT + 1] = {113200, 113900, 114700, 115400, 116100, 116780, 117560, 118280, 115200, 116000};
 #endif
 
+const uint16_t frequencies[] = {FREQ_R1, FREQ_R2, FREQ_R3, FREQ_R4, FREQ_R5, FREQ_R6, FREQ_R7, FREQ_R8, FREQ_F2, FREQ_F4};
+
 void DM6300_write_reg_map(const dm6300_reg_value_t *reg_map, uint8_t size) {
     uint8_t i = 0;
     for (i = 0; i < size; i++) {
@@ -140,6 +142,23 @@ void DM6300_SetChannel(uint8_t ch) {
     dm6300_set_channel_regs[24].dat = tab[2][ch];
 
     WRITE_REG_MAP(dm6300_set_channel_regs);
+}
+
+uint8_t DM6300_GetChannelByFreq(uint16_t const freq) {
+    uint8_t iter;
+    for (iter = 0; iter < ARRAY_SIZE(frequencies); iter++) {
+        if (frequencies[iter] == freq) {
+            return iter;
+        }
+    }
+    return INVALID_CHANNEL;
+}
+
+uint16_t DM6300_GetFreqByChannel(uint8_t const ch) {
+    if (ch < ARRAY_SIZE(frequencies)) {
+        return frequencies[ch];
+    }
+    return 0;
 }
 
 void DM6300_SetPower(uint8_t pwr, uint8_t freq, uint8_t offset) {
@@ -354,8 +373,7 @@ CODE_SEG const dm6300_reg_value_t dm6300_init2_regs_bw17[] = {
     {0x3, 0x240, 0x00030041},
     {0x3, 0x248, 0x00000404},
     {0x3, 0x258, 0x00010003},
-    {0x3, 0x254, 0x00057A17}
-};
+    {0x3, 0x254, 0x00057A17}};
 CODE_SEG const dm6300_reg_value_t dm6300_init2_regs_bw27[] = {
     // 02_BBPLL_3456
     {0x6, 0xFF0, 0x00000018},
@@ -499,8 +517,7 @@ CODE_SEG const dm6300_reg_value_t dm6300_init5_regs_bm17[] = {
     {0x3, 0x3B0, 0x00000000},
     {0x3, 0x3D8, 0x0000000A},
     {0x3, 0x380, 0x0B0F8080},
-    {0x3, 0x388, 0x0B0F8280}
-};
+    {0x3, 0x388, 0x0B0F8280}};
 
 CODE_SEG const dm6300_reg_value_t dm6300_init5_regs_bm27[] = {
     // 05_tx_cal_DAC_BBF
@@ -530,7 +547,7 @@ CODE_SEG const dm6300_reg_value_t dm6300_init5_regs_bm27[] = {
 };
 
 void DM6300_init5(uint8_t sel) {
-    if(sel)
+    if (sel)
         WRITE_REG_MAP(dm6300_init5_regs_bm17);
     else
         WRITE_REG_MAP(dm6300_init5_regs_bm27);
@@ -636,8 +653,7 @@ CODE_SEG const dm6300_reg_value_t dm6300_init7_regs_bw17[] = {
     {0x3, 0xCF0, 0xFFDBFFE7},
     {0x3, 0xCF4, 0xFFE9FFDD},
     {0x3, 0xCF8, 0x0001FFF7},
-    {0x3, 0xCFC, 0x00040004}
-};
+    {0x3, 0xCFC, 0x00040004}};
 CODE_SEG const dm6300_reg_value_t dm6300_init7_regs_bw27[] = {
     // 07_fir_128stap
     {0x6, 0xFF0, 0x00000018},

--- a/src/dm6300.h
+++ b/src/dm6300.h
@@ -15,6 +15,8 @@ void DM6300_EFUSE1();
 void DM6300_EFUSE2();
 // void DM6300_CalibRF();
 void DM6300_SetChannel(uint8_t ch);
+uint8_t DM6300_GetChannelByFreq(uint16_t const freq);
+uint16_t DM6300_GetFreqByChannel(uint8_t const ch);
 void DM6300_SetPower(uint8_t pwr, uint8_t freq, uint8_t offset);
 int16_t DM6300_GetTemp();
 void DM6300_AUXADC_Calib();

--- a/src/msp_displayport.h
+++ b/src/msp_displayport.h
@@ -150,7 +150,7 @@ void parse_status();
 void parse_rc();
 void parse_variant();
 void parse_vtx_config();
-void parseMspVtx_V2(uint16_t cmd_u16);
+void parseMspVtx_V2(uint16_t const cmd_u16);
 uint8_t parse_displayport(uint8_t len);
 void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throttle);
 void vtx_menu_init();

--- a/src/smartaudio_protocol.h
+++ b/src/smartaudio_protocol.h
@@ -5,17 +5,6 @@
 
 #if defined USE_SMARTAUDIO_SW || defined USE_SMARTAUDIO_HW
 
-#define FREQ_R1 (uint16_t)5658
-#define FREQ_R2 (uint16_t)5696
-#define FREQ_R3 (uint16_t)5732
-#define FREQ_R4 (uint16_t)5769
-#define FREQ_R5 (uint16_t)5806
-#define FREQ_R6 (uint16_t)5843
-#define FREQ_R7 (uint16_t)5880
-#define FREQ_R8 (uint16_t)5917
-#define FREQ_F2 (uint16_t)5760
-#define FREQ_F4 (uint16_t)5800
-
 #define SA_HEADER0_BYTE 0xAA
 #define SA_HEADER1_BYTE 0x55
 #define SA_VERSION_BYTE 0x09


### PR DESCRIPTION
Firmware is supporting only band and channel setting at the moment even the direct frequency is also possible.
It should be also possible to set and save used channel to FC before even plugin power for VTX (e.g. on races using Configurator without battery plugged in). This is not possible at the moment when VTX_MSP is used. VTX overrides new values using last settings on boot.  

This PR fixes two issues:
1) the direct frequency control.
2) FC can set used band and channel (or freq) on boot and VTX uses those if values are valid.