### PR TITLE
Allow MSP-VTX to work with INAV

### DIFF
--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -314,7 +314,7 @@ uint8_t msp_read_one_frame() {
                         InitVtxTable();
 #endif
                         msp_set_osd_canvas();
-                    } else {
+                    } else if (msp_cmp_fc_variant("INAV")) {
                         init_table_unsupported = 1;
                     }
                 }

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -94,6 +94,7 @@ uint8_t boot_0mw_done = 0;
 
 #ifdef USE_MSP
 void msp_set_osd_canvas(void);
+void msp_set_inav_osd_canvas(void);
 void parse_set_osd_canvas(void);
 
 uint8_t msp_cmp_fc_variant(const char *variant) {
@@ -316,6 +317,7 @@ uint8_t msp_read_one_frame() {
                         msp_set_osd_canvas();
                     } else if (msp_cmp_fc_variant("INAV")) {
                         init_table_unsupported = 1;
+                        msp_set_inav_osd_canvas();
                     }
                 }
             }
@@ -881,7 +883,7 @@ void parse_vtx_config() {
 
     fc_lock |= FC_VTX_CONFIG_LOCK;
 
-    if (!msp_cmp_fc_variant("BTFL") && !msp_cmp_fc_variant("EMUF") && !msp_cmp_fc_variant("QUIC")) {
+    if (!msp_cmp_fc_variant("BTFL") && !msp_cmp_fc_variant("EMUF") && !msp_cmp_fc_variant("QUIC") && !msp_cmp_fc_variant("INAV")) {
         return;
     }
     if (!msp_rx_buf[0]) {
@@ -922,11 +924,19 @@ void msp_set_osd_canvas(void) {
     }
 }
 
+void msp_set_inav_osd_canvas(void) {
+    if (msp_cmp_fc_variant("INAV")) {
+        resolution = HD_5018;
+        osd_menu_offset = 8;
+    }
+}
+
 void parse_set_osd_canvas(void) {
     resolution = HD_5018;
     // debugf("\r\nparse_set_osd_canvas");
     osd_menu_offset = 8;
 }
+
 void parseMspVtx_V2(uint16_t const cmd_u16) {
     uint8_t nxt_ch = INVALID_CHANNEL;
     uint8_t nxt_pwr = 0;

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -66,6 +66,7 @@ uint8_t msp_rbuf[64];
 
 uint8_t mspVtxLock = 0;
 uint8_t init_table_done = 0;
+uint8_t init_table_unsupported = 0;
 
 uint8_t crc8tab[256] = {
     0x00, 0xD5, 0x7F, 0xAA, 0xFE, 0x2B, 0x81, 0x54, 0x29, 0xFC, 0x56, 0x83, 0xD7, 0x02, 0xA8, 0x7D,
@@ -313,6 +314,8 @@ uint8_t msp_read_one_frame() {
                         InitVtxTable();
 #endif
                         msp_set_osd_canvas();
+                    } else {
+                        init_table_unsupported = 1;
                     }
                 }
             }
@@ -723,10 +726,10 @@ void msp_set_vtx_config(uint8_t power, uint8_t save) {
     uint8_t band;
     uint16_t const freq = DM6300_GetFreqByChannel(channel);
 
-    if (channel < 8) {  // race band
+    if (channel < 8) { // race band
         band = 5;
         channel = channel + 1;
-    } else {  // fatshark band
+    } else { // fatshark band
         band = 4;
         if (channel == 8)
             channel = 2;
@@ -834,9 +837,9 @@ void parse_rc() {
 }
 
 uint8_t parse_vtx_band_and_channel(uint8_t const band, uint8_t const channel) {
-    if (band == 5) {            // race band
+    if (band == 5) { // race band
         return (channel - 1);
-    } else if (band == 4) {     // fatshark band
+    } else if (band == 4) { // fatshark band
         if (channel == 2) {
             return 8;
         }
@@ -862,9 +865,8 @@ uint8_t msp_vtx_set_channel(uint8_t const channel) {
 
 void parse_vtx_config() {
     uint8_t nxt_ch;
-    //uint8_t const power = msp_rx_buf[3];
-    //uint8_t const pitmode = msp_rx_buf[4];
-
+    // uint8_t const power = msp_rx_buf[3];
+    // uint8_t const pitmode = msp_rx_buf[4];
 
     /*
     nxt_pwr:
@@ -873,9 +875,9 @@ void parse_vtx_config() {
         .....
         POWER_MAX+1: 0mw
     */
-    //uint8_t nxt_pwr = 0;
-    //uint8_t pit_update = 0;
-    //uint8_t needSaveEEP = 0;
+    // uint8_t nxt_pwr = 0;
+    // uint8_t pit_update = 0;
+    // uint8_t needSaveEEP = 0;
 
     fc_lock |= FC_VTX_CONFIG_LOCK;
 
@@ -901,7 +903,6 @@ void parse_vtx_config() {
     msp_vtx_set_channel(nxt_ch);
     // PIT_MODE ?
     // RF_POWER ?
-
 }
 
 void msp_set_osd_canvas(void) {
@@ -957,7 +958,7 @@ void parseMspVtx_V2(uint16_t const cmd_u16) {
     debugf("\r\n    fc_channel_rx: %x", (uint16_t)msp_rx_buf[2]);
     debugf("\r\n    fc_pwr_rx:     %x", (uint16_t)fc_pwr_rx);
     debugf("\r\n    fc_pit_rx :    %x", (uint16_t)fc_pit_rx);
-    debugf("\r\n    fc_frequency : %x", fc_frequency);
+    debugf("\r\n    fc_frequency : %x", ((uint16_t)msp_rx_buf[6] << 8) + msp_rx_buf[5]);
     debugf("\r\n    fc_vtx_status: %x", (uint16_t)msp_rx_buf[7]);
     debugf("\r\n    fc_lp_rx:      %x", (uint16_t)fc_lp_rx);
     debugf("\r\n    fc_bands:      %x", (uint16_t)msp_rx_buf[12]);
@@ -965,8 +966,12 @@ void parseMspVtx_V2(uint16_t const cmd_u16) {
     debugf("\r\n    fc_powerLevels %x", (uint16_t)msp_rx_buf[14]);
 #endif
 
-    if (SA_lock || (init_table_done == 0))
+    if (SA_lock || (init_table_done == 0 && !init_table_unsupported)) {
+#ifdef _DEBUG_MODE
+        debugf("\r\nparseMspVtx_V2 skipped. (SA_lock: %i, init_table_done: %i, init_table_unsupported: %i)\r\n", SA_lock, init_table_done, init_table_unsupported);
+#endif
         return;
+    }
 
     // update LP_MODE
     if (fc_lp_rx != last_lp) {
@@ -1887,7 +1892,7 @@ void set_vtx_param() {
 }
 
 #ifdef INIT_VTX_TABLE
-#define FACTORY_BAND 0  // BF requires band to be CUSTOM with VTX_MSP
+#define FACTORY_BAND 0 // BF requires band to be CUSTOM with VTX_MSP
 
 CODE_SEG const uint8_t bf_vtx_band_table[6][31] = {
     /*BOSCAM_A*/


### PR DESCRIPTION
The current firmware prevents MSP-VTX messages from being parsed if init_tables_done = 0, but init_tables_done = 1 can only be set if InitVtxTable is called.

InitVtxTable is only called for BTFL or QUIC.

INAV does not have the concept of VTX tables, this PR allows INAV's MSP_SET_CONFIG messages to be processed.

The check for INAV when setting init_table_unsupported can potentially be dropped to prevent similar pull requests from being needed in the future.

If you would like to help test this pull request, you will need to flash a version of INAV 7.0.0 that includes https://github.com/iNavFlight/inav/pull/9166 and a VTX firmware that includes this pull request.

For instructions on how to download INAV firmware including that pull request, please refer to [INAV's documentation](https://github.com/iNavFlight/inav/blob/master/docs/development/How%20to%20test%20a%20pull%20request.md).

Your INAV 6.x diff all should work with 7.0.0.

If you are already using MSP OSD with HD-Zero the only change you should make is disable Smart Audio configuration in INAV (and/or disconnect the SA cable) , you will only need MSP OSD.

This is what your port setting for MSP OSD should look like in the INAV Configurator:

<img width="777" alt="image" src="https://github.com/hd-zero/hdzero-vtx/assets/23555060/92f10185-bcd8-450a-8f9e-520405060792">

Once you have both firmwares flashed and configured, you should be able to change channels and power levels using ELRS backpack, or the OSD Menus in INAV using only the MSP DisplayPort UART.
