### PR TITLE
check warning band and channel for msp vtx

### DIFF
--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -854,9 +854,15 @@ uint8_t parse_vtx_band_and_channel(uint8_t const band, uint8_t const channel) {
             return INVALID_CHANNEL;
         }
     } else if (band == 5) { // race band
-        return (channel - 1);
-    } else if (band == 6) {
-        return (channel + 9); // low band
+        if (channel >= 1 && channel <= 8)
+            return (channel - 1);
+        else
+            return INVALID_CHANNEL;
+    } else if (band == 6) { // low band
+        if (channel >= 1 && channel <= 8)
+            return (channel + 1);
+        else
+            return INVALID_CHANNEL;
     } else {
         return INVALID_CHANNEL;
     }


### PR DESCRIPTION
This problem will cause channel or band to be confused when using iNav 6.x.x.