### PR TITLE
vtx menu add new item for stick command mode

### DIFF
--- a/src/hardware.c
+++ b/src/hardware.c
@@ -418,6 +418,7 @@ void GetVtxParameter() {
         OFFSET_25MW = 0;
         TEAM_RACE = 0;
         BAUDRATE = 0;
+        SHORTCUT = 0;
         I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_RF_FREQ, RF_FREQ);
         I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_RF_POWER, RF_POWER);
         I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_LPMODE, LP_MODE);
@@ -425,6 +426,7 @@ void GetVtxParameter() {
         I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_25MW, OFFSET_25MW);
         I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_TEAM_RACE, TEAM_RACE);
         I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_BAUDRATE, BAUDRATE);
+        I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_SHORTCUT, SHORTCUT);
 #endif
 #ifdef _DEBUG_MODE
         debugf("\r\nUSE EEPROM for VTX setting:RF_FREQ=%d, RF_POWER=%d, LPMODE=%d PIT_MODE=%d", (uint16_t)RF_FREQ, (uint16_t)RF_POWER, (uint16_t)LP_MODE, (uint16_t)PIT_MODE);

--- a/src/hardware.c
+++ b/src/hardware.c
@@ -44,6 +44,7 @@ uint8_t PIT_MODE = 0;
 uint8_t OFFSET_25MW = 0; // 0~10 -> 0~10    11~20 -> -1~-10
 uint8_t TEAM_RACE = 0;
 uint8_t BAUDRATE = 0;
+uint8_t SHORTCUT = 0;
 
 uint8_t RF_BW = BW_27M;
 uint8_t RF_BW_last = BW_27M;
@@ -285,6 +286,7 @@ void Setting_Save() {
         err |= I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_25MW, OFFSET_25MW);
         err |= I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_BAUDRATE, BAUDRATE);
         err |= I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_TEAM_RACE, TEAM_RACE);
+        err |= I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_SHORTCUT, SHORTCUT);
 #ifdef _DEBUG_MODE
         if (!err)
             debugf("\r\nEEPROM write success");
@@ -300,6 +302,7 @@ void Setting_Save() {
     debugf("    OFFSET_25MW=%d\r\n", (uint16_t)OFFSET_25MW);
     debugf("    BAUDRATE=%d\r\n", (uint16_t)BAUDRATE);
     debugf("    TEAM_RACE=%d\r\n", (uint16_t)TEAM_RACE);
+    debugf("    SHORTCUT=%d\r\n", (uint16_t)SHORTCUT);
 #endif
 }
 
@@ -309,8 +312,9 @@ void CFG_Back() {
     LP_MODE = (LP_MODE > 2) ? 0 : LP_MODE;
     PIT_MODE = (PIT_MODE > PIT_0MW) ? PIT_OFF : PIT_MODE;
     OFFSET_25MW = (OFFSET_25MW > 20) ? 0 : OFFSET_25MW;
-    TEAM_RACE = (TEAM_RACE > 2) ? 0 : TEAM_RACE;
     BAUDRATE = (BAUDRATE > 1) ? 0 : BAUDRATE;
+    TEAM_RACE = (TEAM_RACE > 2) ? 0 : TEAM_RACE;
+    SHORTCUT = (SHORTCUT > 1) ? 0 : SHORTCUT;
 }
 
 void GetVtxParameter() {
@@ -397,6 +401,7 @@ void GetVtxParameter() {
         PIT_MODE = I2C_Read8(ADDR_EEPROM, EEP_ADDR_PITMODE);
         OFFSET_25MW = I2C_Read8(ADDR_EEPROM, EEP_ADDR_25MW);
         TEAM_RACE = I2C_Read8(ADDR_EEPROM, EEP_ADDR_TEAM_RACE);
+        SHORTCUT = I2C_Read8(ADDR_EEPROM, EEP_ADDR_SHORTCUT);
 #ifdef USE_TRAMP
         // tramp protocol need 115200 bps.
         BAUDRATE = 0;

--- a/src/hardware.h
+++ b/src/hardware.h
@@ -38,6 +38,7 @@ typedef enum {
 #define EEP_ADDR_VTX_CONFIG   0x8A
 #define EEP_ADDR_BAUDRATE     0x8B
 #define EEP_ADDR_LOWBAND_LOCK 0x8C
+#define EEP_ADDR_SHORTCUT     0x8D
 #define EEP_ADDR_DCOC_EN      0xC0
 #define EEP_ADDR_DCOC_IH      0xC1
 #define EEP_ADDR_DCOC_IL      0xC2
@@ -114,6 +115,7 @@ extern uint8_t EE_VALID;
 extern uint8_t RF_BW;
 extern uint8_t RF_BW_last;
 extern uint8_t BAUDRATE;
+extern uint8_t SHORTCUT;
 
 extern uint8_t pwr_offset;
 extern uint8_t heat_protect;

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -1227,7 +1227,7 @@ void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throt
      *
      *                throttle(油门) -                                          pitch(俯仰) -
      */
-    static uint8_t vtx_state = 0;
+    static uint8_t vtx_menu_state = VTX_MENU_CHANNEL;
     uint8_t mid = 0;
     static uint8_t last_mid = 1;
     static uint8_t cms_cnt;
@@ -1291,7 +1291,7 @@ void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throt
                     cms_state = CMS_ENTER_VTX_MENU;
                     // debugf("\r\ncms_state(%x)",cms_state);
                     vtx_menu_init();
-                    vtx_state = 0;
+                    vtx_menu_state = VTX_MENU_CHANNEL;
                 }
             } else if (IS_LO_yaw && IS_LO_throttle && IS_HI_roll && IS_LO_pitch) {
                 if (cur_pwr != POWER_MAX + 2) {
@@ -1382,13 +1382,12 @@ void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throt
     case CMS_VTX_MENU: {
         if (!g_IS_ARMED) {
             if (last_mid) {
-                switch (vtx_state) {
-                // channel
-                case 0:
+                switch (vtx_menu_state) {
+                case VTX_MENU_CHANNEL:
                     if (VirtualBtn == BTN_DOWN)
-                        vtx_state = 1;
+                        vtx_menu_state = VTX_MENU_POWER;
                     else if (VirtualBtn == BTN_UP)
-                        vtx_state = 7;
+                        vtx_menu_state = VTX_MENU_SAVE_EXIT;
                     else if (VirtualBtn == BTN_RIGHT) {
                         if (SA_lock == 0) {
                             vtx_channel++;
@@ -1402,15 +1401,14 @@ void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throt
                                 vtx_channel = FREQ_NUM - 1;
                         }
                     }
-                    update_vtx_menu_param(vtx_state);
+                    update_vtx_menu_param(vtx_menu_state);
                     break;
 
-                // power
-                case 1:
+                case VTX_MENU_POWER:
                     if (VirtualBtn == BTN_DOWN)
-                        vtx_state = 2;
+                        vtx_menu_state = VTX_MENU_LP_MODE;
                     else if (VirtualBtn == BTN_UP)
-                        vtx_state = 0;
+                        vtx_menu_state = VTX_MENU_CHANNEL;
                     else if (VirtualBtn == BTN_RIGHT) {
                         if (SA_lock)
                             ;
@@ -1440,15 +1438,14 @@ void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throt
                                 vtx_power = POWER_MAX;
                         }
                     }
-                    update_vtx_menu_param(vtx_state);
+                    update_vtx_menu_param(vtx_menu_state);
                     break;
 
-                // lp_mode
-                case 2:
+                case VTX_MENU_LP_MODE:
                     if (VirtualBtn == BTN_DOWN)
-                        vtx_state = 3;
+                        vtx_menu_state = VTX_MENU_PIT_MODE;
                     else if (VirtualBtn == BTN_UP)
-                        vtx_state = 1;
+                        vtx_menu_state = VTX_MENU_POWER;
                     else if (VirtualBtn == BTN_LEFT) {
                         if (SA_lock)
                             ;
@@ -1470,15 +1467,14 @@ void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throt
                                 vtx_lp = 0;
                         }
                     }
-                    update_vtx_menu_param(vtx_state);
+                    update_vtx_menu_param(vtx_menu_state);
                     break;
 
-                // pit_mode
-                case 3:
+                case VTX_MENU_PIT_MODE:
                     if (VirtualBtn == BTN_DOWN)
-                        vtx_state = 4;
+                        vtx_menu_state = VTX_MENU_OFFSET_25MW;
                     else if (VirtualBtn == BTN_UP)
-                        vtx_state = 2;
+                        vtx_menu_state = VTX_MENU_LP_MODE;
                     else if (VirtualBtn == BTN_RIGHT) {
                         if (SA_lock)
                             ;
@@ -1502,15 +1498,14 @@ void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throt
                                 vtx_pit--;
                         }
                     }
-                    update_vtx_menu_param(vtx_state);
+                    update_vtx_menu_param(vtx_menu_state);
                     break;
 
-                // offset_25mw
-                case 4:
+                case VTX_MENU_OFFSET_25MW:
                     if (VirtualBtn == BTN_DOWN)
-                        vtx_state = 5;
+                        vtx_menu_state = VTX_MENU_TEAM_RACE;
                     else if (VirtualBtn == BTN_UP)
-                        vtx_state = 3;
+                        vtx_menu_state = VTX_MENU_PIT_MODE;
                     else if (VirtualBtn == BTN_RIGHT) {
                         if (vtx_offset == 10)
                             vtx_offset = vtx_offset;
@@ -1530,15 +1525,14 @@ void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throt
                         else
                             vtx_offset--;
                     }
-                    update_vtx_menu_param(vtx_state);
+                    update_vtx_menu_param(vtx_menu_state);
                     break;
 
-                // 0mw_boot
-                case 5:
+                case VTX_MENU_TEAM_RACE:
                     if (VirtualBtn == BTN_DOWN)
-                        vtx_state = 6;
+                        vtx_menu_state = VTX_MENU_EXIT;
                     else if (VirtualBtn == BTN_UP)
-                        vtx_state = 4;
+                        vtx_menu_state = VTX_MENU_OFFSET_25MW;
                     else if (VirtualBtn == BTN_LEFT) {
                         vtx_team_race--;
                         if (vtx_team_race > 2)
@@ -1548,19 +1542,19 @@ void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throt
                         if (vtx_team_race > 2)
                             vtx_team_race = 0;
                     }
-                    update_vtx_menu_param(vtx_state);
+                    update_vtx_menu_param(vtx_menu_state);
                     break;
 
                 // exit
-                case 6:
+                case VTX_MENU_EXIT:
                     if (VirtualBtn == BTN_DOWN) {
-                        vtx_state = 7;
-                        update_vtx_menu_param(vtx_state);
+                        vtx_menu_state = VTX_MENU_SAVE_EXIT;
+                        update_vtx_menu_param(vtx_menu_state);
                     } else if (VirtualBtn == BTN_UP) {
-                        vtx_state = 5;
-                        update_vtx_menu_param(vtx_state);
+                        vtx_menu_state = VTX_MENU_TEAM_RACE;
+                        update_vtx_menu_param(vtx_menu_state);
                     } else if (VirtualBtn == BTN_RIGHT) {
-                        vtx_state = 0;
+                        vtx_menu_state = VTX_MENU_CHANNEL;
                         cms_state = CMS_OSD;
                         fc_init();
                         msp_tx_cnt = 0;
@@ -1568,15 +1562,15 @@ void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throt
                     break;
 
                 // save&exit
-                case 7:
+                case VTX_MENU_SAVE_EXIT:
                     if (VirtualBtn == BTN_DOWN) {
-                        vtx_state = 0;
-                        update_vtx_menu_param(vtx_state);
+                        vtx_menu_state = VTX_MENU_CHANNEL;
+                        update_vtx_menu_param(vtx_menu_state);
                     } else if (VirtualBtn == BTN_UP) {
-                        vtx_state = 6;
-                        update_vtx_menu_param(vtx_state);
+                        vtx_menu_state = VTX_MENU_EXIT;
+                        update_vtx_menu_param(vtx_menu_state);
                     } else if (VirtualBtn == BTN_RIGHT) {
-                        vtx_state = 0;
+                        vtx_menu_state = VTX_MENU_CHANNEL;
                         cms_state = CMS_OSD;
                         if (SA_lock || tramp_lock) {
                             RF_FREQ = vtx_channel;
@@ -1698,7 +1692,7 @@ void vtx_menu_init() {
     update_vtx_menu_param(0);
 }
 
-void update_vtx_menu_param(uint8_t vtx_state) {
+void update_vtx_menu_param(uint8_t state) {
     uint8_t i;
     uint8_t hourString[4];
     uint8_t minuteString[2];
@@ -1708,9 +1702,9 @@ void update_vtx_menu_param(uint8_t vtx_state) {
     const char *treamRaceString[] = {"  OFF", "MODE1", "MODE2"};
 
     // cursor
-    vtx_state += 2;
+    state += 2;
     for (i = 2; i < 10; i++) {
-        if (i == vtx_state)
+        if (i == state)
             osd_buf[i][osd_menu_offset + 2] = '>';
         else
             osd_buf[i][osd_menu_offset + 2] = ' ';

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -1715,7 +1715,7 @@ void update_vtx_menu_param(uint8_t state) {
     const char *lowPowerString[] = {"  OFF", "   ON", "  1ST"};
     const char *pitString[] = {"  OFF", " P1MW", "  0MW"};
     const char *treamRaceString[] = {"  OFF", "MODE1", "MODE2"};
-    const char *shortcutString[] = {"MODE1", "MODE2"};
+    const char *shortcutString[] = {"OPT_A", "OPT_B"};
 
     // cursor
     state += 2;

--- a/src/msp_displayport.h
+++ b/src/msp_displayport.h
@@ -135,6 +135,7 @@ typedef enum {
     VTX_MENU_PIT_MODE,
     VTX_MENU_OFFSET_25MW,
     VTX_MENU_TEAM_RACE,
+    VTX_MENU_SHORTCUT,
     VTX_MENU_EXIT,
     VTX_MENU_SAVE_EXIT,
 } vtx_menu_state_e;

--- a/src/msp_displayport.h
+++ b/src/msp_displayport.h
@@ -129,6 +129,17 @@ typedef enum {
 } cms_state_e;
 
 typedef enum {
+    VTX_MENU_CHANNEL,
+    VTX_MENU_POWER,
+    VTX_MENU_LP_MODE,
+    VTX_MENU_PIT_MODE,
+    VTX_MENU_OFFSET_25MW,
+    VTX_MENU_TEAM_RACE,
+    VTX_MENU_EXIT,
+    VTX_MENU_SAVE_EXIT,
+} vtx_menu_state_e;
+
+typedef enum {
     DISPLAY_OSD,
     DISPLAY_CMS,
 } disp_mode_e;
@@ -154,7 +165,7 @@ void parseMspVtx_V2(uint16_t const cmd_u16);
 uint8_t parse_displayport(uint8_t len);
 void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throttle);
 void vtx_menu_init();
-void update_vtx_menu_param(uint8_t vtx_state);
+void update_vtx_menu_param(uint8_t state);
 void save_vtx_param();
 void msp_set_vtx_config(uint8_t power, uint8_t save);
 void set_vtx_param();


### PR DESCRIPTION
VTX enter/exit 0mw mode conflicts with some FC stick commands even though most people do not use FC stick commands. We added an option called shortcut to the vtx menu to modify the shortcut of enter/exit 0mw mode to avoid conflicts.
`shortcuts <OPT_A or OPT_B>`
Options：
- OPT_A. As default.
    
![mode1](https://github.com/hd-zero/hdzero-vtx/assets/59721724/0f301335-e295-4afc-b436-830bd667734a)

- OPT_B.

![mode2](https://github.com/hd-zero/hdzero-vtx/assets/59721724/3537528e-40b2-4884-a080-38cdbda89cad)
