### PR TITLE
fix shortcut

### DIFF
--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -1344,6 +1344,7 @@ void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throt
             vtx_lp = LP_MODE;
             PIT_MODE = PIT_0MW;
             vtx_pit = PIT_0MW;
+            vtx_shortcut = SHORTCUT;
             if (!SA_lock) {
                 save_vtx_param();
             } else {


### PR DESCRIPTION
If the shortcut is OPT_B, when using the shortcut key to enter 0mw, the shortcut will be saved as OPT_A by mistake.