### PR TITLE
set uart baudrate only when init

### DIFF
--- a/src/hardware.c
+++ b/src/hardware.c
@@ -1512,12 +1512,15 @@ void uart_baudrate_detect(void) {
     // tramp protocol need 115200 bps.
     return;
 #else
-    if (seconds - msp_lst_rcv_sec >= 20) {
-        msp_lst_rcv_sec = seconds;
-        BAUDRATE++;
-        CFG_Back();
-        uart_set_baudrate(BAUDRATE);
-        Setting_Save();
+    static uint8_t once_done = 0;
+    if (once_done == 0) {
+        if (seconds - msp_lst_rcv_sec >= 10) {
+            msp_lst_rcv_sec = seconds;
+            BAUDRATE++;
+            CFG_Back();
+            Setting_Save();
+            once_done = 1;
+        }
     }
 #endif
 }


### PR DESCRIPTION
- VTX supports 115200 and 230400 baud rates.
- If VTX does not receive the msp packet correctly for more than 10 seconds after powering on, VTX will configure uart to another baud rate the next time it is powered on.