### PR TITLE
Cam menu option to flip only horizontally or only vertically

### DIFF
--- a/src/camera.c
+++ b/src/camera.c
@@ -455,6 +455,7 @@ void camera_menu_draw_bracket(void) {
 void camera_menu_draw_value(void) {
     const char *wb_mode_str[] = {"   AUTO", " MANUAL"};
     const char *switch_str[] = {"    OFF", "     ON"};
+    const char *hv_flip_str[] = {"    OFF", "     ON", " V ONLY", " H ONLY"};
     const char *resolution_runcam_micro_v2[] = {"      4:3 ", " 16:9CROP ", " 16:9FULL ", "  1080@30 "};
     const char *resolution_runcam_nano_90[] = {"   540P@90", "540@90CROP", "   540P@60", "960X720@60"};
     const char *resolution_runcam_micro_v3[] = {"      4:3 ", " 16:9CROP ", " 16:9FULL ", "  1080@30 "};
@@ -524,6 +525,8 @@ void camera_menu_draw_value(void) {
                 strcpy(&osd_buf[i][osd_menu_offset + 25], str);
                 break;
             case CAM_STATUS_HVFLIP:     // hv flip
+                strcpy(&osd_buf[i][osd_menu_offset + 21], hv_flip_str[camera_setting_reg_menu[i - 1]]);
+                break;
             case CAM_STATUS_NIGHT_MODE: // night mode
             case CAM_STATUS_LED_MODE:   // led mode
                 strcpy(&osd_buf[i][osd_menu_offset + 21], switch_str[camera_setting_reg_menu[i - 1]]);

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -1079,7 +1079,7 @@ void parseMspVtx_V2(uint16_t const cmd_u16) {
             else
 #endif
 #endif
-                if (nxt_pwr == POWER_MAX + 1) {
+            if (nxt_pwr == POWER_MAX + 1) {
                 WriteReg(0, 0x8F, 0x10);
                 dm6300_init_done = 0;
                 cur_pwr = POWER_MAX + 2;

--- a/src/runcam.c
+++ b/src/runcam.c
@@ -23,7 +23,7 @@ const uint8_t runcam_micro_v1_attribute[CAMERA_SETTING_NUM][4] = {
     // wb blue
     {1, 0x00, 0xff, 0xca},
     // hv flip
-    {0, 0x00, 0x01, 0x00},
+    {0, 0x00, 0x03, 0x00},
     // night mode
     {0, 0x00, 0x01, 0x01},
     // led mode
@@ -55,7 +55,7 @@ const uint8_t runcam_micro_v2_attribute[CAMERA_SETTING_NUM][4] = {
     // wb blue
     {1, 0x00, 0xff, 0xca},
     // hv flip
-    {1, 0x00, 0x01, 0x00},
+    {1, 0x00, 0x03, 0x00},
     // night mode
     {1, 0x00, 0x01, 0x01},
     // led mode
@@ -87,7 +87,7 @@ const uint8_t runcam_nano_90_attribute[CAMERA_SETTING_NUM][4] = {
     // wb blue
     {1, 0x00, 0xff, 0xca},
     // hv flip
-    {1, 0x00, 0x01, 0x00},
+    {1, 0x00, 0x03, 0x00},
     // night mode
     {1, 0x00, 0x01, 0x01},
     // led mode
@@ -119,7 +119,7 @@ const uint8_t runcam_micro_v3_attribute[CAMERA_SETTING_NUM][4] = {
     // wb blue
     {1, 0x00, 0xff, 0xca},
     // hv flip
-    {1, 0x00, 0x01, 0x00},
+    {1, 0x00, 0x03, 0x00},
     // night mode
     {1, 0x00, 0x01, 0x01},
     // led mode
@@ -353,10 +353,14 @@ void runcam_hv_flip(uint8_t val) {
 
     camera_setting_reg_set[8] = val;
 
-    if (val == 0)
+    if (val == 0) // no flip
         RUNCAM_Read_Write(camera_device, 0x000040, 0x0022ffa9);
-    else if (val == 1)
+    else if (val == 1) // hv flip
         RUNCAM_Read_Write(camera_device, 0x000040, 0x002effa9);
+    else if (val == 2) // v flip
+        RUNCAM_Read_Write(camera_device, 0x000040, 0x002affa9);
+    else if (val == 3) // h flip
+        RUNCAM_Read_Write(camera_device, 0x000040, 0x0026ffa9);
 #ifdef _DEBUG_RUNCAM
     debugf("\r\nRUNCAM hvFlip:%02x", (uint16_t)val);
 #endif


### PR DESCRIPTION
As described in the title, this PR adds the possibility to flip the image only horizontally or only vertically.
Now the HV FLIP option in cam menu has four possible values:
- OFF
- ON
- V ONLY
- H ONLY

This feature has been added to give more flexibility and it has been suggested by some users on Discord.

Tested on a Race V2 + Runcam Nano V2

https://github.com/hd-zero/hdzero-vtx/assets/32413980/4f56e006-2e96-4a9f-84c3-228970557011

