### PR TITLE
Fault framework

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
     "editor.formatOnSave": true,
+    "files.associations": {
+        "fault.h": "c"
+    },
 }

--- a/src/camera.c
+++ b/src/camera.c
@@ -1,6 +1,7 @@
 #include "camera.h"
 #include "common.h"
 #include "dm6300.h"
+#include "fault/fault.h"
 #include "global.h"
 #include "hardware.h"
 #include "i2c.h"
@@ -26,7 +27,7 @@ uint8_t camMenuStatus = CAM_STATUS_IDLE;
 uint8_t reset_isp_need = 0;
 
 void camera_type_detect(void) {
-    camera_type = CAMERA_TYPE_UNKNOW;
+    camera_type = CAMERA_TYPE_UNKNOWN;
 
     runcam_type_detect();
     if (camera_type == CAMERA_TYPE_RUNCAM_MICRO_V1 ||
@@ -320,6 +321,7 @@ void camera_setting_profile_check(uint8_t profile) {
     if (need_reset) {
         camera_setting_profile_reset(profile);
         camera_setting_profile_write(profile);
+        add_fault(FLT_ET_CAMERA, FLT_DT_TABLE, FLT_TBL_CAMERA_CFG_RESET);
 #ifdef _DEBUG_CAMERA
         debugf("\r\ncamera setting need to be reset");
 #endif
@@ -345,7 +347,7 @@ void camera_setting_read(void) {
     uint8_t camera_type_last;
     uint8_t i;
 
-    if (camera_type == CAMERA_TYPE_UNKNOW ||
+    if (camera_type == CAMERA_TYPE_UNKNOWN ||
         camera_type == CAMERA_TYPE_OUTDATED ||
         camera_type == CAMERA_TYPE_RESERVED)
         return;
@@ -415,7 +417,6 @@ void camera_init(void) {
     }
 
     camera_mode_detect(1);
-
     camera_button_init();
 }
 
@@ -574,7 +575,7 @@ void camera_menu_init(void) {
 
     memset(osd_buf, 0x20, sizeof(osd_buf));
     disp_mode = DISPLAY_CMS;
-    if (camera_type == CAMERA_TYPE_UNKNOW ||
+    if (camera_type == CAMERA_TYPE_UNKNOWN ||
         camera_type == CAMERA_TYPE_OUTDATED)
         camera_button_enter;
     else {
@@ -754,7 +755,7 @@ uint8_t camera_status_update(uint8_t op) {
     if (op >= BTN_INVALID)
         return ret;
 
-    if (camera_type == CAMERA_TYPE_UNKNOW ||
+    if (camera_type == CAMERA_TYPE_UNKNOWN ||
         camera_type == CAMERA_TYPE_OUTDATED) {
         camera_button_op(op);
         return ret;

--- a/src/camera.h
+++ b/src/camera.h
@@ -29,7 +29,7 @@ typedef enum {
 } camera_manufacture_e;
 
 typedef enum {
-    CAMERA_TYPE_UNKNOW,
+    CAMERA_TYPE_UNKNOWN,
     CAMERA_TYPE_RESERVED,        // include foxeer digisight v3
     CAMERA_TYPE_OUTDATED,        // include runcam(orange)
     CAMERA_TYPE_RUNCAM_MICRO_V1, // include hdz nano v1

--- a/src/dm6300.c
+++ b/src/dm6300.c
@@ -1,6 +1,7 @@
 #include "dm6300.h"
 
 #include "common.h"
+#include "fault/fault.h"
 #include "global.h"
 #include "hardware.h"
 #include "i2c.h"

--- a/src/fault/fault.c
+++ b/src/fault/fault.c
@@ -3,7 +3,7 @@
 /**
  *  Global storage of faults entries.
  */
-static fault_msg_t g_fault_msgs[MAX_FAULTS];
+static fault_msg_t g_fault_msgs[MAX_FAULTS] = {{0, 0}};
 
 /**
  *  Keep track of used fault msgs.

--- a/src/fault/fault.c
+++ b/src/fault/fault.c
@@ -1,0 +1,53 @@
+#include "fault.h"
+
+/**
+ *  Global storage of faults entries.
+ */
+static fault_msg_t g_fault_msgs[MAX_FAULTS];
+
+/**
+ *  Keep track of used fault msgs.
+ */
+static uint8_t g_fault_head = 0;
+static uint8_t g_fault_tail = 0;
+
+void enc_fault_msg(const fault_msg_t *msg, uint8_t *buffer) {
+    buffer[0] = msg->mask;
+    buffer[1] = msg->data;
+}
+
+void dec_fault_msg(const uint8_t *buffer, fault_msg_t *msg) {
+    msg->mask = buffer[0];
+    msg->data = buffer[1];
+}
+
+void extract_fault_msg(const fault_msg_t *msg, fault_id_t *id, fault_et_e *et, fault_dt_e *dt, uint8_t *data) {
+    *id = (msg->mask & 0xF0) >> 4;
+    *et = (msg->mask & 0x0E) >> 1;
+    *dt = (msg->mask & 0x01);
+    *data = msg->data;
+}
+
+void add_fault(fault_et_e et, fault_dt_e dt, uint8_t data) {
+    // Once the buffer is full we drop any new reports
+    if (g_fault_head < MAX_FAULTS) {
+        g_fault_msgs[g_fault_head].mask =
+            ((g_fault_head << 4) & 0xF0) |
+            ((et << 1) & 0x0E) |
+            (dt & 0x01);
+
+        g_fault_msgs[g_fault_head].data = data;
+        g_fault_head++;
+    }
+}
+
+fault_msg_t *get_next_fault() {
+    fault_msg_t *tmp = &g_fault_msgs[g_fault_tail++];
+
+    // Wrap back to beginning
+    if (g_fault_tail >= g_fault_head) {
+        g_fault_tail = 0;
+    }
+
+    return tmp;
+}

--- a/src/fault/fault.h
+++ b/src/fault/fault.h
@@ -1,0 +1,78 @@
+#ifndef __FAULT_H_
+#define __FAULT_H_
+
+#include "fault_table.h"
+#include "stdint.h"
+
+/**
+ *  Constants & Types
+ */
+#define MAX_FAULTS 16 // Max reportable faults.
+typedef uint8_t fault_id_t;
+
+/**
+ * Fault Message:
+ *
+ *  0xFF 0xEE
+ *  ---- ----
+ *  |    DATA
+ *  |
+ *  1111 111 1
+ *     |   | |
+ *     |   | fault_dt_e
+ *     |   fault_et_e
+ *     fault_id_t
+ */
+typedef struct {
+    uint8_t mask;
+    uint8_t data;
+} fault_msg_t;
+
+/**
+ *  Data Type published, flt_msg_t bit 1
+ */
+typedef enum {
+    FLT_DT_TABLE = 0,
+    FLT_DT_VALUE,
+} fault_dt_e;
+
+/**
+ *  Event Type published, flt_msg_t bits 2-4
+ */
+typedef enum {
+    FLT_ET_NONE = 0,
+    FLT_ET_CAMERA,
+    FLT_ET_EEPROM,
+    FLT_ET_DM6300,
+    FLT_ET_UART,
+    FLT_ET_VTX,
+    FLT_ET_I2C,
+    FLT_ET_SPI,
+} fault_et_e;
+
+/**
+ *  Serialize to byte array
+ */
+void enc_fault_msg(const fault_msg_t *msg, uint8_t *buffer);
+
+/**
+ *  Deserialize to structure
+ */
+void dec_fault_msg(const uint8_t *buffer, fault_msg_t *msg);
+
+/**
+ *  Extract fault attributes
+ */
+void extract_fault_msg(const fault_msg_t *msg, fault_id_t *id, fault_et_e *et, fault_dt_e *dt, uint8_t *data);
+
+/**
+ *  Inserts a fault record into database.
+ */
+void add_fault(fault_et_e et, fault_dt_e dt, uint8_t data);
+
+/**
+ *  Returns a fault record from database.
+ */
+fault_msg_t *get_next_fault();
+
+#endif /* __FAULT_H_ */

--- a/src/fault/fault_table.c
+++ b/src/fault/fault_table.c
@@ -1,0 +1,36 @@
+/**
+ *  This file is to be managed by the VTX codebase
+ *  and referenced/processed by the VRX codebase.
+ *
+ *  FLT_TBL_ strings are NOT to be referenced within VTX codebase!
+ */
+#include "fault_table.h"
+
+const char *FLT_TBL_CAMERA[FLT_TBL_CAMERA_TOTAL] = {
+    "CAMERA not detected:\nReplace camera or MIPI cable.\nCheck MIPI socket for obstructions.\nCheck DM5680 chip pins are clean.",
+    "CAMERA configuration reset is required",
+};
+
+const char *FLT_TBL_EEPROM[FLT_TBL_EEPROM_TOTAL] = {
+    "EEPROM is not initialized, using default RF Power Table.",
+};
+
+const char *FLT_TBL_DM6300[FLT_TBL_DM6300_TOTAL] = {
+    "DM6300 not detected: Chip could be damaged or not responding back to DM5680.",
+};
+
+const char *FLT_TBL_UART[FLT_TBL_UART_TOTAL] = {
+    "UART Receive line not detecting data stream.",
+};
+
+const char *FLT_TBL_VTX[FLT_TBL_VTX_TOTAL] = {
+    "VTX overheat protection activated.",
+};
+
+const char *FLT_TBL_I2C[FLT_TBL_I2C_TOTAL] = {
+    "I2C RUNCAM write error.",
+};
+
+const char *FLT_TBL_SPI[FLT_TBL_SPI_TOTAL] = {
+    "SPI write error.",
+};

--- a/src/fault/fault_table.h
+++ b/src/fault/fault_table.h
@@ -1,0 +1,61 @@
+#ifndef __FAULT_TABLE_H_
+#define __FAULT_TABLE_H_
+
+/**
+ *  This file is to be managed by the VTX codebase
+ *  and referenced/processed by the VRX codebase.
+ *
+ *  FLT_TBL_ strings are NOT to be referenced within VTX codebase!
+ */
+
+typedef enum {
+    FLT_TBL_CAMERA_NOT_DETECTED = 0,
+    FLT_TBL_CAMERA_CFG_RESET,
+
+    FLT_TBL_CAMERA_TOTAL,
+} fault_table_camera_e;
+extern const char *FLT_TBL_CAMERA[FLT_TBL_CAMERA_TOTAL];
+
+typedef enum {
+    FLT_TBL_EEPROM_NOT_INITIALIZED = 0,
+
+    FLT_TBL_EEPROM_TOTAL,
+} fault_table_eeprom_e;
+extern const char *FLT_TBL_EEPROM[FLT_TBL_EEPROM_TOTAL];
+
+typedef enum {
+    FLT_TBL_DM6300_NOT_DETECTED = 0,
+
+    FLT_TBL_DM6300_TOTAL,
+} fault_table_dm6300_e;
+extern const char *FLT_TBL_DM6300[FLT_TBL_DM6300_TOTAL];
+
+typedef enum {
+    FLT_TBL_UART_RX_DATA_TIMEOUT = 0,
+
+    FLT_TBL_UART_TOTAL,
+} fault_table_uart_e;
+extern const char *FLT_TBL_UART[FLT_TBL_UART_TOTAL];
+
+typedef enum {
+    FLT_TBL_VTX_HEAT_PROTECTION_ACTIVE = 0,
+
+    FLT_TBL_VTX_TOTAL,
+} fault_table_vtx_e;
+extern const char *FLT_TBL_VTX[FLT_TBL_VTX_TOTAL];
+
+typedef enum {
+    FLT_TBL_I2C_RUNCAM_WRITE_ERROR = 0,
+
+    FLT_TBL_I2C_TOTAL,
+} fault_table_i2c_e;
+extern const char *FLT_TBL_I2C[FLT_TBL_I2C_TOTAL];
+
+typedef enum {
+    FLT_TBL_SPI_WRITE_ERROR = 0,
+
+    FLT_TBL_SPI_TOTAL,
+} fault_table_spi_e;
+extern const char *FLT_TBL_SPI[FLT_TBL_SPI_TOTAL];
+
+#endif /* __FAULT_TABLE_H_ */

--- a/src/hardware.c
+++ b/src/hardware.c
@@ -1525,24 +1525,23 @@ void LED_Flip() {
     }
 }
 void LED_Task() {
+    static uint8_t logged[3] = {0};
+
     if (dm6300_lost) {
-        static uint8_t logged = 0;
-        if (!logged) {
-            logged = 1;
+        if (!logged[0]) {
+            logged[0] = 1;
             add_fault(FLT_ET_DM6300, FLT_DT_TABLE, FLT_TBL_DM6300_NOT_DETECTED);
         }
         Set_Blue_LED(diag_led_flags_dm6300lost[led_timer_cnt]);
     } else if (cameraLost) {
-        static uint8_t logged = 0;
-        if (!logged) {
-            logged = 1;
+        if (!logged[1]) {
+            logged[1] = 1;
             add_fault(FLT_ET_CAMERA, FLT_DT_TABLE, FLT_TBL_CAMERA_NOT_DETECTED);
         }
         Set_Blue_LED(diag_led_flags_cameralost[led_timer_cnt]);
     } else if (heat_protect) {
-        static uint8_t logged = 0;
-        if (!logged) {
-            logged = 1;
+        if (!logged[2]) {
+            logged[2] = 1;
             add_fault(FLT_ET_VTX, FLT_DT_TABLE, FLT_TBL_VTX_HEAT_PROTECTION_ACTIVE);
         }
         Set_Blue_LED(diag_led_flags_heatprotect[led_timer_cnt]);

--- a/src/hardware.c
+++ b/src/hardware.c
@@ -2,6 +2,7 @@
 #include "camera.h"
 #include "common.h"
 #include "dm6300.h"
+#include "fault/fault.h"
 #include "global.h"
 #include "i2c.h"
 #include "i2c_device.h"
@@ -448,6 +449,7 @@ void GetVtxParameter() {
                 }
             }
         } else {
+            add_fault(FLT_ET_EEPROM, FLT_DT_TABLE, FLT_TBL_EEPROM_NOT_INITIALIZED);
 #ifdef _DEBUG_MODE
             debugf("\r\nEEPROM is NOT initialized. Use default rf_pwr_tab.");
 #endif
@@ -1524,14 +1526,26 @@ void LED_Flip() {
 }
 void LED_Task() {
     if (dm6300_lost) {
+        static uint8_t logged = 0;
+        if (!logged) {
+            logged = 1;
+            add_fault(FLT_ET_DM6300, FLT_DT_TABLE, FLT_TBL_DM6300_NOT_DETECTED);
+        }
         Set_Blue_LED(diag_led_flags_dm6300lost[led_timer_cnt]);
-
     } else if (cameraLost) {
+        static uint8_t logged = 0;
+        if (!logged) {
+            logged = 1;
+            add_fault(FLT_ET_CAMERA, FLT_DT_TABLE, FLT_TBL_CAMERA_NOT_DETECTED);
+        }
         Set_Blue_LED(diag_led_flags_cameralost[led_timer_cnt]);
-
     } else if (heat_protect) {
+        static uint8_t logged = 0;
+        if (!logged) {
+            logged = 1;
+            add_fault(FLT_ET_VTX, FLT_DT_TABLE, FLT_TBL_VTX_HEAT_PROTECTION_ACTIVE);
+        }
         Set_Blue_LED(diag_led_flags_heatprotect[led_timer_cnt]);
-
     } else if (cur_pwr == POWER_MAX + 2) {
         Set_Blue_LED(diag_led_flags_0mW[led_timer_cnt]);
 

--- a/src/i2c.c
+++ b/src/i2c.c
@@ -2,6 +2,7 @@
 
 #include "camera.h"
 #include "common.h"
+#include "fault/fault.h"
 #include "global.h"
 #include "print.h"
 
@@ -321,6 +322,13 @@ uint8_t RUNCAM_Write(uint8_t cam_id, uint32_t addr, uint32_t val) {
 
     value = I2C_write_byte(cam_id); // slave
     if (value) {
+        static uint8_t logged = 0;
+        if (!logged) {
+            logged = 1;
+            add_fault(FLT_ET_I2C, FLT_DT_TABLE, FLT_TBL_I2C_RUNCAM_WRITE_ERROR);
+            add_fault(FLT_ET_I2C, FLT_DT_VALUE, cam_id);
+            add_fault(FLT_ET_I2C, FLT_DT_VALUE, value);
+        }
         I2C_stop();
 #ifdef _DEBUG_RUNCAM
         debugf("\r\nRUNCAM_Write error id: %x value: %d", (uint16_t)cam_id, (uint16_t)value);

--- a/src/i2c.c
+++ b/src/i2c.c
@@ -316,13 +316,13 @@ uint16_t I2C_Read16_a8(uint8_t slave_addr, uint8_t reg_addr) {
 /////////////////////////////////////////////////////////////////
 // runcam I2C
 uint8_t RUNCAM_Write(uint8_t cam_id, uint32_t addr, uint32_t val) {
-    uint8_t value;
+    uint8_t value = 0;
+    static uint8_t logged = 0;
 
     I2C_start(); // start
 
     value = I2C_write_byte(cam_id); // slave
     if (value) {
-        static uint8_t logged = 0;
         if (!logged) {
             logged = 1;
             add_fault(FLT_ET_I2C, FLT_DT_TABLE, FLT_TBL_I2C_RUNCAM_WRITE_ERROR);

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -2,6 +2,7 @@
 #include "camera.h"
 #include "common.h"
 #include "dm6300.h"
+#include "fault/fault.h"
 #include "global.h"
 #include "hardware.h"
 #include "isr.h"
@@ -406,7 +407,7 @@ uint8_t msp_read_one_frame() {
             state = MSP_HEADER_START;
             break;
         } // switch(state)
-    }     // i
+    } // i
     return ret;
 }
 
@@ -525,9 +526,7 @@ uint8_t get_tx_data_5680() // prepare data to VRX
 
     tx_buf[11] = fontType; // fontType
 
-    tx_buf[12] = 0x00; // deprecated
-
-    tx_buf[13] = VTX_ID;
+    enc_fault_msg(get_next_fault(), &tx_buf[12]); // tx_buf[13] is populated
 
     tx_buf[14] = fc_lock & 0x03;
 
@@ -537,7 +536,7 @@ uint8_t get_tx_data_5680() // prepare data to VRX
     tx_buf[17] = VTX_VERSION_MINOR;
     tx_buf[18] = VTX_VERSION_PATCH_LEVEL;
 
-    return 20;
+    return 20; // Reserve 2 for CRC
 }
 
 uint8_t get_tx_data_osd(uint8_t index) // prepare osd+data to VTX
@@ -1615,7 +1614,7 @@ void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throt
                     fc_init();
                     break;
                 } // switch
-            }     // if(last_mid)
+            } // if(last_mid)
             // last_mid = mid;
         } else {
             cms_state = CMS_OSD;

--- a/src/uart.c
+++ b/src/uart.c
@@ -1,5 +1,6 @@
 #include "uart.h"
 #include "common.h"
+#include "fault/fault.h"
 #include "global.h"
 #include "hardware.h"
 #include "print.h"

--- a/src/version.h
+++ b/src/version.h
@@ -2,7 +2,7 @@
 #define __VERSION_H_
 
 #define VTX_VERSION_MAJOR       1 // increment when a major release is made (big new feature, etc)
-#define VTX_VERSION_MINOR       6 // increment when a minor release is made (small new feature, change etc)
+#define VTX_VERSION_MINOR       7 // increment when a minor release is made (small new feature, change etc)
 #define VTX_VERSION_PATCH_LEVEL 0 // increment when a bug is fixed
 #define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL)
 

--- a/targets/common.ini
+++ b/targets/common.ini
@@ -1,6 +1,6 @@
 [common]
 include_dir = src
-src_filter = +<*> -<.git/> -<.svn/> -<example/> -<examples/> -<test/> -<tests/>
+src_filter = +<*> -<.git/> -<.svn/> -<example/> -<examples/> -<test/> -<tests/> -<fault/fault_table.c>
 extra_scripts = 
   pre:script/pre_script.py
   post:script/post_script.py


### PR DESCRIPTION
Allows us to relay issues detected within VTX to goggles for logging via the MSP protocol.

Do keep in mind I had to update the version number to 1.7 in order to prevent issues on the goggle side.  Goggle only supports fault logging when version is greater than 1.6 otherwise we will report invalid faults.