### PR TITLE
Initialize uart first, then enable interrupt

### DIFF
--- a/src/hardware.c
+++ b/src/hardware.c
@@ -349,7 +349,6 @@ void Setting_Save() {
         err |= I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_LPMODE, LP_MODE);
         err |= I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_PITMODE, PIT_MODE);
         err |= I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_25MW, OFFSET_25MW);
-        err |= I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_BAUDRATE, BAUDRATE);
         err |= I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_TEAM_RACE, TEAM_RACE);
         err |= I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_SHORTCUT, SHORTCUT);
 #ifdef _DEBUG_MODE
@@ -365,7 +364,6 @@ void Setting_Save() {
     debugf("    LP_MODE=%d\r\n", (uint16_t)LP_MODE);
     debugf("    PIT_MODE=%d\r\n", (uint16_t)PIT_MODE);
     debugf("    OFFSET_25MW=%d\r\n", (uint16_t)OFFSET_25MW);
-    debugf("    BAUDRATE=%d\r\n", (uint16_t)BAUDRATE);
     debugf("    TEAM_RACE=%d\r\n", (uint16_t)TEAM_RACE);
     debugf("    SHORTCUT=%d\r\n", (uint16_t)SHORTCUT);
 #endif
@@ -377,7 +375,6 @@ void CFG_Back() {
     LP_MODE = (LP_MODE > 2) ? 0 : LP_MODE;
     PIT_MODE = (PIT_MODE > PIT_0MW) ? PIT_OFF : PIT_MODE;
     OFFSET_25MW = (OFFSET_25MW > 20) ? 0 : OFFSET_25MW;
-    BAUDRATE = (BAUDRATE > 1) ? 0 : BAUDRATE;
     TEAM_RACE = (TEAM_RACE > 2) ? 0 : TEAM_RACE;
     SHORTCUT = (SHORTCUT > 1) ? 0 : SHORTCUT;
 }
@@ -470,12 +467,6 @@ void GetVtxParameter() {
         OFFSET_25MW = I2C_Read8(ADDR_EEPROM, EEP_ADDR_25MW);
         TEAM_RACE = I2C_Read8(ADDR_EEPROM, EEP_ADDR_TEAM_RACE);
         SHORTCUT = I2C_Read8(ADDR_EEPROM, EEP_ADDR_SHORTCUT);
-#ifdef USE_TRAMP
-        // tramp protocol need 115200 bps.
-        BAUDRATE = 0;
-#else
-        BAUDRATE = I2C_Read8(ADDR_EEPROM, EEP_ADDR_BAUDRATE);
-#endif
         CFG_Back();
 
 #ifdef _DEBUG_MODE
@@ -567,8 +558,6 @@ void Init_HW() {
     GetVtxParameter();
     Get_EEP_LifeTime();
     camera_init();
-
-    uart_set_baudrate(BAUDRATE);
 //--------- dm6300 --------------------
 // move to RF_Delay_Init()
 #endif
@@ -1583,10 +1572,14 @@ void uart_baudrate_detect(void) {
     if (!msp_tx_en) {
         if (seconds - msp_lst_rcv_sec > 2) {
             msp_lst_rcv_sec = seconds;
+
             BAUDRATE++;
-            CFG_Back();
+            if (BAUDRATE > 1)
+                BAUDRATE = 0;
+
             uart_set_baudrate(BAUDRATE);
-            Setting_Save();
+
+            I2C_Write8_Wait(10, ADDR_EEPROM, EEP_ADDR_BAUDRATE, BAUDRATE);
         }
     }
 #endif

--- a/src/isr.c
+++ b/src/isr.c
@@ -40,7 +40,7 @@ void CPU_init(void) {
     TH0 = 139;
     TL0 = 0;
 
-    TH1 = 0xEC; // [7:0] in timer mode 0x10:   ----------------->> 148.5MHz: 0x87; 100MHz: 0xAF; 54MHz: 0xD4; 27MHz: 0xEA
+    TH1 = 0x0E; // [7:0] in timer mode 0x10:   ----------------->> 148.5MHz: 0x87; 100MHz: 0xAF; 54MHz: 0xD4; 27MHz: 0xEA
                 //	               f(clk)
                 //  BaudRate = --------------  (M=16 or 32, decided by PCON double rate flag)
                 //             N*(256-TH1)*M   (N=4 or 12, decided by CKCON [4])

--- a/src/isr.c
+++ b/src/isr.c
@@ -40,7 +40,7 @@ void CPU_init(void) {
     TH0 = 139;
     TL0 = 0;
 
-    TH1 = 0x0E; // [7:0] in timer mode 0x10:   ----------------->> 148.5MHz: 0x87; 100MHz: 0xAF; 54MHz: 0xD4; 27MHz: 0xEA
+    TH1 = 0xEC; // [7:0] in timer mode 0x10:   ----------------->> 148.5MHz: 0x87; 100MHz: 0xAF; 54MHz: 0xD4; 27MHz: 0xEA
                 //	               f(clk)
                 //  BaudRate = --------------  (M=16 or 32, decided by PCON double rate flag)
                 //             N*(256-TH1)*M   (N=4 or 12, decided by CKCON [4])
@@ -53,6 +53,7 @@ void CPU_init(void) {
     TCON = 0x50; // [6]   enable timer1
                  // [4]   enable timer0
 
+#if (0)        // IE should be set after uart_init()
     IE = 0xD2; // [7]   enable global interupts  1
                // [6]   enable uart1  interupt   1
                // [5]   enable timer2 interupt   0
@@ -61,5 +62,6 @@ void CPU_init(void) {
                // [2]   enable INT1   interupt   0
                // [1]   enable timer0 interupt   0
                // [0]   enable INT0   interupt   0
+#endif
     IP = 0x10; // UART0=higher priority, Timer 0 = low
 }

--- a/src/mcu.c
+++ b/src/mcu.c
@@ -130,6 +130,7 @@ void main(void) {
         I2C_EN = 1;
 
     // init
+    uart_init();
     check_eeprom();
     version_info();
     Init_HW(); // init

--- a/src/mcu.c
+++ b/src/mcu.c
@@ -129,8 +129,18 @@ void main(void) {
     if (I2C_EN == 0)
         I2C_EN = 1;
 
-    // init
     uart_init();
+
+    // IE should be set after uart_init()
+    IE = 0xD2; // [7]   enable global interupts  1
+               // [6]   enable uart1  interupt   1
+               // [5]   enable timer2 interupt   0
+               // [4]   enable uart0  interupt   1
+               // [3]   enable timer1 interupt   0
+               // [2]   enable INT1   interupt   0
+               // [1]   enable timer0 interupt   0
+               // [0]   enable INT0   interupt   0
+
     check_eeprom();
     version_info();
     Init_HW(); // init

--- a/src/uart.c
+++ b/src/uart.c
@@ -47,6 +47,19 @@ void uart_set_baudrate(uint8_t baudIndex) {
 #endif
 }
 
+void uart_init() {
+#ifdef USE_TRAMP
+    // tramp protocol need 115200 bps.
+    BAUDRATE = 0;
+#else
+    BAUDRATE = I2C_Read8(ADDR_EEPROM, EEP_ADDR_BAUDRATE);
+#endif
+    if (BAUDRATE > 1)
+        BAUDRATE = 0;
+
+    uart_set_baudrate(BAUDRATE);
+}
+
 uint8_t RS_ready(void) {
     if (RS_in == RS_out)
         return 0;

--- a/src/uart.h
+++ b/src/uart.h
@@ -34,6 +34,7 @@ uint8_t RS_rx1_len(void);
 */
 
 void uart_set_baudrate(uint8_t baudIndex);
+void uart_init();
 
 void RS_tx1(uint8_t c);
 uint8_t RS_rx1(void);


### PR DESCRIPTION
This PR is used to solve the OSD freeze problem after VTX is powered on.

- Cause:
  - The initial baud rate of VTX is 230400 and that of FC is 115200.
  - After power-on, `CPU_init()` will initialize the uart to 115200 and immediately enable interrupt.
  - VTX executes `Init_HW()`. During this period, the serial port receives some msp packages (115200) from FC.
  - VTX sets the baud rate to 230400(eeprom saved) at the end of Init_HW().
  - VTX enters the `while(1)` loop and parses the complete msp package, mistakenly thinking that the baud rate of FC is 230400.
  - After that, VTX can no longer receive the correct msp package due to the baud rate mismatch.

- Solution:
  - Do not enable interrupts during `CPU_init()`.
  - Initialize the uart bardate(eepram saved) earlier to avoid losing data. Then enable interrupt.