### PR TITLE
Process Initial MSP messages in the correct order.

### DIFF
--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -768,19 +768,22 @@ uint8_t msp_send_header_v2(uint16_t len, uint16_t msg) {
     return crc;
 }
 
-void msp_cmd_tx() // send 3 commands to FC
+void msp_cmd_tx() // Send between 1 and 5 commands to the FC
 {
     uint8_t i;
-    uint8_t const count = (fc_lock & FC_VTX_CONFIG_LOCK) ? 4 : 5;
+
+    // Wait for variant, then config, then continue with status/rx/osd_canvas
+    uint8_t const start = (fc_lock & FC_VTX_CONFIG_LOCK) ? 2 : (fc_lock & FC_VARIANT_LOCK) ? 1 : 0;
+    uint8_t const end = (fc_lock & FC_VTX_CONFIG_LOCK) ? 5 : (fc_lock & FC_VARIANT_LOCK) ? 2 : 1;
     uint8_t const msp_cmd[5] = {
         MSP_FC_VARIANT,
+        MSP_GET_VTX_CONFIG,
         MSP_STATUS,
         MSP_RC,
         MSP_GET_OSD_CANVAS,
-        MSP_GET_VTX_CONFIG,
     };
 
-    for (i = 0; i < count; i++) {
+    for (i = start; i < end; i++) {
         msp_send_command(0, MSP_HEADER_V1);
         msp_tx(0x00);       // len
         msp_tx(msp_cmd[i]); // function

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -768,7 +768,9 @@ uint8_t msp_send_header_v2(uint16_t len, uint16_t msg) {
     return crc;
 }
 
-void msp_cmd_tx() // Send between 1 and 5 commands to the FC
+ // Send commands to the FC.
+ // Ensure VARIANT is processed first, followed by CONFIG, then the others.
+void msp_cmd_tx()
 {
     uint8_t i;
 


### PR DESCRIPTION
On startup, the initial MSP_VARIANT message MUST be processed before the MSP_VTX_CONFIG message.
If this does not happen, the VTX will/may not register properly with the FC and potentially discard further MSP messages.
This change will ensure the initial messages are processed in order.
Process Initial MSP messages in the correct order.