### PR TITLE
Drop MSP_VTX_CONFIG messages with an invalid VTX id

### DIFF
--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -1055,6 +1055,11 @@ void parse_vtx_params(uint8_t isMSP_V2) {
         return;
     }
 
+    // Check for unknown VTX device  (probably from a device that is not interested in controlling the VTX directly)
+    if (msp_rx_buf[0] = 0xff) {
+        return;
+    }
+
     fc_pwr_rx = msp_rx_buf[3];
     if (fc_pwr_rx == 0) {
         fc_pwr_rx = POWER_MAX+2; // 0mW

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -1055,8 +1055,8 @@ void parse_vtx_params(uint8_t isMSP_V2) {
         return;
     }
 
-    // Check for unknown VTX device  (probably from a device that is not interested in controlling the VTX directly)
-    if (msp_rx_buf[0] = 0xff) {
+    // Ignore unknown/unsupported VTX devices
+    if (msp_rx_buf[0] == VTXDEV_UNKNOWN || msp_rx_buf[0] == VTXDEV_UNSUPPORTED) {
         return;
     }
 

--- a/src/msp_displayport.h
+++ b/src/msp_displayport.h
@@ -113,6 +113,16 @@ typedef enum {
 } vtx_menu_state_e;
 
 typedef enum {
+    VTXDEV_UNSUPPORTED = 0, // reserved for MSP
+    VTXDEV_RTC6705     = 1,
+    // 2 reserved
+    VTXDEV_SMARTAUDIO  = 3,
+    VTXDEV_TRAMP       = 4,
+    VTXDEV_MSP         = 5,
+    VTXDEV_UNKNOWN     = 0xFF,
+} vtxDevType_e;
+
+typedef enum {
     DISPLAY_OSD,
     DISPLAY_CMS,
 } disp_mode_e;


### PR DESCRIPTION
EmuFlight reported an issue with the latest VTX code.
For the VTX to communicate with an FC, an MSP_VTX_CONFIG handshake is done to sync the two devices.
If the FC is not interested in controlling the VTX band/channel/power, it still needs to send a response to the VTX when requested. This is achieved by sending an MSP_VTX_CONFIG message with an invalid VTX ID (6 is MSP).
This change detects this invalid message Id and throws the message away.
