### PR TITLE
Camera control

### DIFF
--- a/src/camera.c
+++ b/src/camera.c
@@ -367,7 +367,7 @@ void camera_setting_reg_menu_update(void) {
 void camera_setting_reg_eep_update(void) {
     uint8_t i;
     for (i = 0; i < CAMERA_SETTING_NUM; i++) {
-        if (i == (CAM_STATUS_VDO_FMT-1) && g_camera_switch) {
+        if (g_camera_switch && i == (CAM_STATUS_VDO_FMT-1)) {
             // Sync all cameras on the camera switch to the same video setting if changed
             uint8_t value = camera_setting_reg_menu[i];
             camera_setting_reg_eep[0][i] = value;
@@ -384,7 +384,7 @@ void camera_setting_reg_eep_update(void) {
 uint8_t camera_set(uint8_t *camera_setting_reg, uint8_t save, uint8_t init) {
     uint8_t ret = 0;
     if (camera_mfr == CAMERA_MFR_RUNCAM) {
-        ret = runcam_set(camera_setting_reg);
+        ret = runcam_set(camera_setting_reg, g_camera_id);
         if (save || (init & ret))
             runcam_save();
     }

--- a/src/camera.c
+++ b/src/camera.c
@@ -388,24 +388,17 @@ uint8_t camera_set(uint8_t *camera_setting_reg, uint8_t save, uint8_t init) {
     return ret;
 }
 
-void camera_detect(void) {
-    camera_type_detect();
-    camera_init();
-}
-
 void camera_init(void) {
+    camera_type_detect();
     camera_setting_read();
     camera_setting_reg_menu_update();
     reset_isp_need = camera_set(camera_setting_reg_menu, 0, 1);
-
     if (reset_isp_need) {
         if (camera_mfr == CAMERA_MFR_RUNCAM) {
             runcam_reset_isp();
         }
     }
-
     camera_mode_detect(1);
-
     camera_button_init();
 }
 

--- a/src/camera.c
+++ b/src/camera.c
@@ -28,7 +28,7 @@ uint8_t reset_isp_need = 0;
 uint8_t camera_is_3v3 = 0;
 
 void camera_type_detect(void) {
-    camera_type = CAMERA_TYPE_UNKNOW;
+    camera_type = CAMERA_TYPE_UNKNOWN;
 
     runcam_type_detect();
     if (camera_type == CAMERA_TYPE_RUNCAM_MICRO_V1 ||
@@ -322,7 +322,7 @@ void camera_setting_read(void) {
     uint8_t camera_type_last;
     uint8_t i;
 
-    if (camera_type == CAMERA_TYPE_UNKNOW ||
+    if (camera_type == CAMERA_TYPE_UNKNOWN ||
         camera_type == CAMERA_TYPE_OUTDATED ||
         camera_type == CAMERA_TYPE_RESERVED)
         return;
@@ -723,7 +723,7 @@ uint8_t camera_status_update(uint8_t op) {
     if (op >= BTN_INVALID)
         return ret;
 
-    if (camera_type == CAMERA_TYPE_UNKNOW ||
+    if (camera_type == CAMERA_TYPE_UNKNOWN ||
         camera_type == CAMERA_TYPE_OUTDATED) {
         camera_button_op(op);
         return ret;

--- a/src/camera.c
+++ b/src/camera.c
@@ -235,7 +235,7 @@ void camera_mode_detect(uint8_t init) {
 
         if (cycles == 0) {
             Set_720P60(0);
-            WriteReg(0, 0x50, 0x01);
+            //WriteReg(0, 0x50, 0x01); // Do not output colorbar
             video_format = VDO_FMT_720P60;
             I2C_Write16(ADDR_TC3587, 0x0058, 0x00e0);
             camera_type = CAMERA_TYPE_RESERVED;

--- a/src/camera.c
+++ b/src/camera.c
@@ -366,8 +366,15 @@ void camera_setting_reg_menu_update(void) {
 
 void camera_setting_reg_eep_update(void) {
     uint8_t i;
-    for (i = 0; i < CAMERA_SETTING_NUM; i++)
+    for (i = 0; i < CAMERA_SETTING_NUM; i++) {
         camera_setting_reg_eep[camera_profile_menu][i] = camera_setting_reg_menu[i];
+        
+        if (i == (CAM_STATUS_VDO_FMT-1) && g_camera_switch) {
+            // Sync both cameras on the camera switch to the same video setting if changed
+            uint8_t index = (camera_profile_menu == 0) ? 1 : 0;
+            camera_setting_reg_eep[index][i] = camera_setting_reg_menu[i];
+        }
+    }
 }
 
 uint8_t camera_set(uint8_t *camera_setting_reg, uint8_t save, uint8_t init) {

--- a/src/camera.c
+++ b/src/camera.c
@@ -388,6 +388,12 @@ uint8_t camera_set(uint8_t *camera_setting_reg, uint8_t save, uint8_t init) {
     return ret;
 }
 
+void camera_switch_profile(void) {
+    camera_setting_read();
+    camera_setting_reg_menu_update();
+    camera_set(camera_setting_reg_menu, 0, 0);
+}
+
 void camera_init(void) {
     camera_type_detect();
     camera_setting_read();

--- a/src/camera.c
+++ b/src/camera.c
@@ -438,7 +438,7 @@ void camera_menu_draw_value(void) {
     osd_buf[0][osd_menu_offset + 28] = '1' + camera_profile_menu;
 
     for (i = CAM_STATUS_BRIGHTNESS; i <= CAM_STATUS_VDO_FMT; i++) {
-        if (camera_attribute[i - 1][CAM_SETTING_ITEM_ENBALE] == 0)
+        if (camera_attribute[i - 1][CAM_SETTING_ITEM_ENABLE] == 0)
             strcpy(&osd_buf[i][osd_menu_offset + 27], "-");
         else {
             switch (i) {
@@ -637,7 +637,7 @@ void camera_setting_reg_menu_toggle(uint8_t op, uint8_t last_op) {
     case CAM_STATUS_BRIGHTNESS:
     case CAM_STATUS_WBRED:
     case CAM_STATUS_WBBLUE:
-        if (!camera_attribute[item][CAM_SETTING_ITEM_ENBALE])
+        if (!camera_attribute[item][CAM_SETTING_ITEM_ENABLE])
             return;
 #if (0)
         // if wb mode if auto, do not modify wbred/wbblue
@@ -682,7 +682,7 @@ void camera_setting_reg_menu_toggle(uint8_t op, uint8_t last_op) {
     case CAM_STATUS_NIGHT_MODE:
     case CAM_STATUS_LED_MODE:
     case CAM_STATUS_VDO_FMT:
-        if (!camera_attribute[item][CAM_SETTING_ITEM_ENBALE])
+        if (!camera_attribute[item][CAM_SETTING_ITEM_ENABLE])
             return;
 
         if (op == BTN_RIGHT) {

--- a/src/camera.c
+++ b/src/camera.c
@@ -367,12 +367,16 @@ void camera_setting_reg_menu_update(void) {
 void camera_setting_reg_eep_update(void) {
     uint8_t i;
     for (i = 0; i < CAMERA_SETTING_NUM; i++) {
-        camera_setting_reg_eep[camera_profile_menu][i] = camera_setting_reg_menu[i];
-        
         if (i == (CAM_STATUS_VDO_FMT-1) && g_camera_switch) {
-            // Sync both cameras on the camera switch to the same video setting if changed
-            uint8_t index = (camera_profile_menu == 0) ? 1 : 0;
-            camera_setting_reg_eep[index][i] = camera_setting_reg_menu[i];
+            // Sync all cameras on the camera switch to the same video setting if changed
+            uint8_t value = camera_setting_reg_menu[i];
+            camera_setting_reg_eep[0][i] = value;
+            camera_setting_reg_eep[1][i] = value;
+            if (g_camera_switch == SWITCH_TYPE_PCA9557) {
+                camera_setting_reg_eep[2][i] = value;
+            }
+        } else {
+            camera_setting_reg_eep[camera_profile_menu][i] = camera_setting_reg_menu[i];
         }
     }
 }

--- a/src/camera.h
+++ b/src/camera.h
@@ -53,7 +53,7 @@ typedef enum {
 } video_format_e;
 
 typedef enum {
-    CAM_SETTING_ITEM_ENBALE,
+    CAM_SETTING_ITEM_ENABLE,
     CAM_SETTING_ITEM_MIN,
     CAM_SETTING_ITEM_MAX,
     CAM_SETTING_ITEM_DEFAULT,
@@ -91,13 +91,14 @@ typedef enum {
     CAM_SELECT_EXIT,
 } camera_select_e;
 
-void camera_init();
+void camera_init(void);
+void camera_select(void);
 uint8_t camera_status_update(uint8_t op);
 void camera_menu_init(void);
 void camera_select_menu_init(void);
 void camera_select_menu_cursor_update(uint8_t index);
-void camera_select_menu_ratio_upate();
-void camera_menu_mode_exit_note();
+void camera_select_menu_ratio_upate(void);
+void camera_menu_mode_exit_note(void);
 
 extern uint8_t camRatio;
 extern uint8_t video_format;

--- a/src/camera.h
+++ b/src/camera.h
@@ -92,6 +92,7 @@ typedef enum {
 } camera_select_e;
 
 void camera_init(void);
+void camera_switch_profile(void);
 uint8_t camera_status_update(uint8_t op);
 void camera_menu_init(void);
 void camera_select_menu_init(void);

--- a/src/camera.h
+++ b/src/camera.h
@@ -10,7 +10,7 @@
 #define RUNCAM_MICRO_V1 0x42
 #define RUNCAM_MICRO_V2 0x44
 #define RUNCAM_NANO_90  0x46
-#define RUNCAM_MICRO_V3 0x4A // Temp change from 0x48 for testing
+#define RUNCAM_MICRO_V3 0x48
 
 #define CAMERA_SETTING_NUM 16
 #define CAMERA_PROFILE_NUM 3

--- a/src/camera.h
+++ b/src/camera.h
@@ -91,13 +91,13 @@ typedef enum {
     CAM_SELECT_EXIT,
 } camera_select_e;
 
+void camera_detect(void);
 void camera_init(void);
-void camera_select(void);
 uint8_t camera_status_update(uint8_t op);
 void camera_menu_init(void);
 void camera_select_menu_init(void);
 void camera_select_menu_cursor_update(uint8_t index);
-void camera_select_menu_ratio_upate(void);
+void camera_select_menu_ratio_update(void);
 void camera_menu_mode_exit_note(void);
 
 extern uint8_t camRatio;

--- a/src/camera.h
+++ b/src/camera.h
@@ -91,7 +91,6 @@ typedef enum {
     CAM_SELECT_EXIT,
 } camera_select_e;
 
-void camera_detect(void);
 void camera_init(void);
 uint8_t camera_status_update(uint8_t op);
 void camera_menu_init(void);

--- a/src/camera.h
+++ b/src/camera.h
@@ -10,7 +10,7 @@
 #define RUNCAM_MICRO_V1 0x42
 #define RUNCAM_MICRO_V2 0x44
 #define RUNCAM_NANO_90  0x46
-#define RUNCAM_MICRO_V3 0x48
+#define RUNCAM_MICRO_V3 0x4A // Temp change from 0x48 for testing
 
 #define CAMERA_SETTING_NUM 16
 #define CAMERA_PROFILE_NUM 3

--- a/src/camera.h
+++ b/src/camera.h
@@ -31,7 +31,7 @@ typedef enum {
 } camera_manufacture_e;
 
 typedef enum {
-    CAMERA_TYPE_UNKNOW,
+    CAMERA_TYPE_UNKNOWN,
     CAMERA_TYPE_RESERVED,        // include foxeer digisight v3
     CAMERA_TYPE_OUTDATED,        // include runcam(orange)
     CAMERA_TYPE_RUNCAM_MICRO_V1, // include hdz nano v1

--- a/src/common.h
+++ b/src/common.h
@@ -193,4 +193,8 @@
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
 
+#if !defined(UNUSED)
+#define UNUSED(x) ((void)(x))    /* To avoid gcc/g++ warnings */
+#endif /* UNUSED */
+
 #endif /* __COMMON_H_ */

--- a/src/hardware.c
+++ b/src/hardware.c
@@ -515,6 +515,7 @@ void Init_HW() {
     reset_config();
 #endif
 
+    pca9570_set(0x02); // camera switch to camera 1
     GetVtxParameter();
     Get_EEP_LifeTime();
     camera_init();

--- a/src/hardware.c
+++ b/src/hardware.c
@@ -517,8 +517,9 @@ void Init_HW() {
     
     GetVtxParameter();
     Get_EEP_LifeTime();
+    
     camera_switch_init();
-    camera_detect();
+    camera_init();
 
 #ifdef _RF_CALIB
     RF_POWER = 0; // max power

--- a/src/hardware.c
+++ b/src/hardware.c
@@ -515,7 +515,7 @@ void Init_HW() {
     reset_config();
 #endif
 
-    pi4io_set(0x03, 0x77); // set camera switch to VTX control
+    init_camera_switch();
     
     GetVtxParameter();
     Get_EEP_LifeTime();

--- a/src/hardware.c
+++ b/src/hardware.c
@@ -515,7 +515,8 @@ void Init_HW() {
     reset_config();
 #endif
 
-    pca9570_set(0x02); // camera switch to camera 1
+    pi4io_set(0x03, 0x77); // set camera switch to VTX control
+    
     GetVtxParameter();
     Get_EEP_LifeTime();
     camera_init();

--- a/src/hardware.c
+++ b/src/hardware.c
@@ -514,12 +514,12 @@ void Init_HW() {
 #ifdef RESET_CONFIG
     reset_config();
 #endif
-
-    init_camera_switch();
     
     GetVtxParameter();
     Get_EEP_LifeTime();
-    camera_init();
+    camera_switch_init();
+    camera_detect();
+
 #ifdef _RF_CALIB
     RF_POWER = 0; // max power
     RF_FREQ = 0;  // ch1

--- a/src/i2c_device.c
+++ b/src/i2c_device.c
@@ -111,3 +111,7 @@ void Init_TC3587(uint8_t fmt) {
     I2C_Write16(ADDR_TC3587, 0x0002, 0x0001);
     I2C_Write16(ADDR_TC3587, 0x0002, 0x0000);
 }
+
+void pca9570_set(uint8_t val) {
+    I2C_Write8(ADDR_PCA9570, 0, val);
+}

--- a/src/i2c_device.c
+++ b/src/i2c_device.c
@@ -157,13 +157,13 @@ void select_camera(uint8_t camera_id) {
         uint8_t command = 0;
         switch (camera_id) {
             case 1:
-                command = (g_camera_switch == SWITCH_TYPE_PI4IO) ? 0x11 : 0x0D;
+                command = (g_camera_switch == SWITCH_TYPE_PI4IO) ? 0x11 : 0x1B;
                 break;
             case 2:
                 command = (g_camera_switch == SWITCH_TYPE_PI4IO) ? 0x64 : 0x16;
                 break;
             case 3:
-                command = (g_camera_switch == SWITCH_TYPE_PI4IO) ? 0x00 : 0x1B;
+                command = (g_camera_switch == SWITCH_TYPE_PI4IO) ? 0x00 : 0x0D;
                 break;
             default:
                 break; // do nothing

--- a/src/i2c_device.c
+++ b/src/i2c_device.c
@@ -150,10 +150,13 @@ void select_camera(uint8_t camera_id, uint8_t sync_config) {
 }
 
 void init_camera_switch() {
-    pi4io_set(0x03, 0x77); // P3 and P7 are inputs
-    pi4io_set(0x07, 0xFF); // Set outputs to follow the output port register.
+    //pi4io_set(0x01, 0xFF); // reset
+    pi4io_set(0x11, 0xFF); // Disable interrupts on inputs
+    pi4io_get(0x013);      // de-assert the interrrupt 
+    pi4io_set(0x03, 0x77); // Set P3 and P7 as inputs
+    pi4io_set(0x07, 0x00); // Set outputs to follow the output port register
+    select_camera(1, 1);   // camera 1 is default, synchronised config
     g_manual_camera_sel = 0;
-    select_camera(1, 1); // camera 1 is default, synchronised config
 }
 
 // Check if manual camera selection is enabled and switch if required

--- a/src/i2c_device.c
+++ b/src/i2c_device.c
@@ -134,7 +134,7 @@ void select_camera(uint8_t camera_id, uint8_t sync_config) {
     switch (camera_id) {
     case 1:
     default:
-        command = 0x40;
+        command = 0x10;
         if (!sync_config) {
             command |= 0x04;
         }
@@ -150,7 +150,8 @@ void select_camera(uint8_t camera_id, uint8_t sync_config) {
 }
 
 void init_camera_switch() {
-    pi4io_set(0x03, 0x77); // P7 and P3 are inputs
+    pi4io_set(0x03, 0x77); // P3 and P7 are inputs
+    pi4io_set(0x07, 0xFF); // Set outputs to follow the output port register.
     g_manual_camera_sel = 0;
     select_camera(1, 1); // camera 1 is default, synchronised config
 }
@@ -159,9 +160,9 @@ void init_camera_switch() {
 // (called from loop)
 void manual_select_camera(void) {
     uint8_t command = pi4io_get(0x0F);
-    g_manual_camera_sel = (command & 0x80);
+    g_manual_camera_sel = (command & 0x08);
     if (g_manual_camera_sel) {
-        uint8_t camera_id = ((command & 0x08) >> 3) + 1;
+        uint8_t camera_id = ((command & 0x80) >> 7) + 1;
         if (camera_id != g_camera_id) {
             g_camera_id = camera_id;
             select_camera(camera_id, 1);

--- a/src/i2c_device.c
+++ b/src/i2c_device.c
@@ -136,13 +136,13 @@ void select_camera(uint8_t camera_id, uint8_t shared_i2c) {
     default:
         command = 0x40;
         if (!shared_i2c) {
-            command |= 0x01;
+            command |= 0x04;
         }
         break;    
     case 2:
         command = 0x60;
         if (!shared_i2c) { // changes only affect this camera
-            command |= 0x04;
+            command |= 0x01;
         }
         break;
     }

--- a/src/i2c_device.c
+++ b/src/i2c_device.c
@@ -129,19 +129,19 @@ void pi4io_set(uint8_t reg, uint8_t val) {
 }
 
 // Select camera 1 or camera 2 and whether the i2c is shared
-void select_camera(uint8_t camera_id, uint8_t shared_i2c) {
+void select_camera(uint8_t camera_id, uint8_t sync_config) {
     uint8_t command;
     switch (camera_id) {
     case 1:
     default:
         command = 0x40;
-        if (!shared_i2c) {
+        if (!sync_config) {
             command |= 0x04;
         }
         break;    
     case 2:
         command = 0x60;
-        if (!shared_i2c) { // changes only affect this camera
+        if (!sync_config) {
             command |= 0x01;
         }
         break;
@@ -152,7 +152,7 @@ void select_camera(uint8_t camera_id, uint8_t shared_i2c) {
 void init_camera_switch() {
     pi4io_set(0x03, 0x77); // P7 and P3 are inputs
     g_manual_camera_sel = 0;
-    select_camera(1, 0); // camera 1 is default
+    select_camera(1, 1); // camera 1 is default, synchronised config
 }
 
 // Check if manual camera selection is enabled and switch if required
@@ -161,10 +161,10 @@ void manual_select_camera(void) {
     uint8_t command = pi4io_get(0x0F);
     g_manual_camera_sel = (command & 0x80);
     if (g_manual_camera_sel) {
-        uint8_t camera_id = ((command & 0x08) >> 4) + 1;
+        uint8_t camera_id = ((command & 0x08) >> 3) + 1;
         if (camera_id != g_camera_id) {
             g_camera_id = camera_id;
-            select_camera(camera_id, 0);
+            select_camera(camera_id, 1);
         }
     }
 }

--- a/src/i2c_device.c
+++ b/src/i2c_device.c
@@ -165,7 +165,8 @@ void select_camera(uint8_t camera_id, uint8_t sync_config) {
             break;
         }
         pi4io_set(0x05, command);
-        //WAIT(200); // wait for camera power up (?)
+        camera_switch_profile();
+        //WAIT(200); // wait for camera power up
     }
 }
 
@@ -181,6 +182,8 @@ void camera_switch_init() {
         pi4io_set(0x03, 0x77); // Set P3 and P7 as inputs
         pi4io_set(0x07, 0x00); // Set outputs to follow the output port register
         g_manual_camera_sel = 0;
+    } else {
+        g_camera_id = 1;
     }
 }
 
@@ -195,7 +198,6 @@ void manual_select_camera(void) {
             if (camera_id != g_camera_id) {
                 g_camera_id = camera_id;
                 select_camera(camera_id, 0);
-                camera_init();
             }
         }
     }

--- a/src/i2c_device.c
+++ b/src/i2c_device.c
@@ -112,6 +112,7 @@ void Init_TC3587(uint8_t fmt) {
     I2C_Write16(ADDR_TC3587, 0x0002, 0x0000);
 }
 
-void pca9570_set(uint8_t val) {
-    I2C_Write8(ADDR_PCA9570, 0, val);
+// Write to camera switch
+void pi4io_set(uint8_t reg, uint8_t val) {
+    I2C_Write8(ADDR_PI4IO, reg, val);
 }

--- a/src/i2c_device.c
+++ b/src/i2c_device.c
@@ -119,18 +119,38 @@ void Init_TC3587(uint8_t fmt) {
 /////////////////////////////////////////////////////////////////
 // Camera Expander Switch
 
-// Read from camera switch
+// Read from 2 camera switch
 uint8_t pi4io_get(uint8_t reg) {
     return I2C_Read8(ADDR_PI4IO, reg);
 }
 
-// Write to camera switch
+// Write to 2 camera switch
 void pi4io_set(uint8_t reg, uint8_t val) {
     I2C_Write8(ADDR_PI4IO, reg, val);
 }
 
-uint8_t is_camera_switch_present(void) {
-    return ((pi4io_get(0x01) & 0xE0) == 0xA0);
+// Read from 3 camera switch
+uint8_t pca9557_get(uint8_t reg) {
+    return I2C_Read8(ADDR_PCA9557, reg);
+}
+
+// Write to 3 camera switch
+void pca9557_set(uint8_t reg, uint8_t val) {
+    I2C_Write8(ADDR_PCA9557, reg, val);
+}
+
+uint8_t get_camera_switch_type(void) {
+    uint8_t camera_switch = 0;
+    if ((pi4io_get(0x01) & 0xE0) == 0xA0) {
+        camera_switch = SWITCH_TYPE_PI4IO;
+    } else {
+        pca9557_set(0x03, 0xEA);
+        if ((pca9557_get(0x03)) == 0xEA) {
+            camera_switch = SWITCH_TYPE_PCA9557;
+        }
+    } 
+
+    return camera_switch;
 }
 
 // 7 0
@@ -143,61 +163,65 @@ uint8_t is_camera_switch_present(void) {
 // 1 0
 // 0 CAM2 I2C (active low)
 
-// Select camera 1 or camera 2 and whether the i2c is shared
-void select_camera(uint8_t camera_id, uint8_t sync_config) {
-    if (is_camera_switch_present())
+void select_camera(uint8_t camera_id) {
+    if (g_camera_switch)
     {
-        uint8_t command;
-
+        uint8_t command = 0;
         switch (camera_id) {
-        case 1:
-        default:
-            command = 0x10;         // CAM 1, GREEN LED, BOTH I2C connected
-            if (!sync_config) {
-                command |= 0x01;    // CAM 2 I2C OFF
-            }
-            break;
-        case 2:
-            command = 0x60 ;        // CAM 2, RED LED, BOTH I2C connected
-            if (!sync_config) {
-                command |= 0x04;    // CAM 1 I2C OFF
-            }
-            break;
+            case 1:
+                command = (g_camera_switch == SWITCH_TYPE_PI4IO) ? 0x11 : 0x1B;
+                break;
+            case 2:
+                command = (g_camera_switch == SWITCH_TYPE_PI4IO) ? 0x64 : 0x16;
+                break;
+            case 3:
+                command = (g_camera_switch == SWITCH_TYPE_PI4IO) ? 0x00 : 0x0D;
+                break;
+            default:
+                break; // do nothing
         }
-        pi4io_set(0x05, command);
-        camera_switch_profile();
-        //WAIT(200); // wait for camera power up
+
+        if (command) {
+            if (g_camera_switch == SWITCH_TYPE_PI4IO) {
+                pi4io_set(0x05, command);
+            }
+            else {
+                pca9557_set(0x01, command);
+            }
+            camera_switch_profile();
+            WAIT(200); // wait for camera power up 
+        }
     }
 }
 
 void camera_switch_init() {
-    g_camera_id = 0;
-    g_camera_switch = is_camera_switch_present();
-
-    if (g_camera_switch) {
+    g_manual_camera_sel = 0;
+    g_camera_id = 1;
+    g_camera_switch = get_camera_switch_type();
+    if (g_camera_switch == SWITCH_TYPE_PI4IO) {
         //pi4io_set(0x01, 0xFF); // reset
         pi4io_set(0x0B, 0xFF); // Disable pullup/pulldown resistors
         pi4io_set(0x11, 0xFF); // Disable interrupts on inputs
         pi4io_get(0x13);       // De-assert the interrrupt 
         pi4io_set(0x03, 0x77); // Set P3 and P7 as inputs
         pi4io_set(0x07, 0x00); // Set outputs to follow the output port register
-        g_manual_camera_sel = 0;
-    } else {
-        g_camera_id = 1;
+        select_camera(g_camera_id);
+    } else if (g_camera_switch == SWITCH_TYPE_PCA9557) {
+        pca9557_set(0x03, 0x00); // all outputs
     }
 }
 
 // Check if manual camera selection is enabled and switch if required
 // (called from loop)
 void manual_select_camera(void) {
-    if (g_camera_switch) {
+    if (g_camera_switch == SWITCH_TYPE_PI4IO) {
         uint8_t command = pi4io_get(0x0F);
         g_manual_camera_sel = (command & 0x08);
         if (g_manual_camera_sel) {
             uint8_t camera_id = ((command & 0x80) >> 7) + 1;
             if (camera_id != g_camera_id) {
                 g_camera_id = camera_id;
-                select_camera(camera_id, 0);
+                select_camera(camera_id);
             }
         }
     }

--- a/src/i2c_device.c
+++ b/src/i2c_device.c
@@ -7,9 +7,9 @@
 #include "i2c.h"
 #include "print.h"
 
-uint8_t g_camera_switch;
-uint8_t g_camera_id;
-uint8_t g_manual_camera_sel;
+uint8_t g_camera_switch = SWITCH_TYPE_NONE;
+uint8_t g_camera_id = 1;
+uint8_t g_manual_camera_sel = 0;
 
 /////////////////////////////////////////////////////////////////
 // MAX7315
@@ -154,50 +154,56 @@ uint8_t get_camera_switch_type(void) {
 void select_camera(uint8_t camera_id) {
     if (g_camera_switch)
     {
-        uint8_t command = 0;
-        switch (camera_id) {
-            case 1:
-                command = (g_camera_switch == SWITCH_TYPE_PI4IO) ? 0x11 : 0x1B;
-                break;
-            case 2:
-                command = (g_camera_switch == SWITCH_TYPE_PI4IO) ? 0x64 : 0x16;
-                break;
-            case 3:
-                command = (g_camera_switch == SWITCH_TYPE_PI4IO) ? 0x00 : 0x0D;
-                break;
-            default:
-                break; // do nothing
-        }
+        // Check cameera id is within range, else default to 1
+        uint8_t camera = (camera_id > 3) ? 1 : camera_id;
+        if (g_camera_id != camera) {
+            g_camera_id = camera;
 
-        if (command) {
-            if (g_camera_switch == SWITCH_TYPE_PI4IO) {
-                pi4io_set(0x05, command);
-            }
-            else {
-                pca9557_set(0x01, command);
-                WAIT(200); // wait for camera power up 
+            uint8_t command = 0;
+            switch (g_camera_id) {
+                case 1:
+                    command = (g_camera_switch == SWITCH_TYPE_PI4IO) ? 0x11 : 0x1B;
+                    break;
+                case 2:
+                    command = (g_camera_switch == SWITCH_TYPE_PI4IO) ? 0x64 : 0x16;
+                    break;
+                case 3:
+                    command = (g_camera_switch == SWITCH_TYPE_PI4IO) ? 0x00 : 0x0D;
+                    break;
+                default:
+                    break; // do nothing
             }
 
-            camera_switch_profile();
+            if (command) {
+                if (g_camera_switch == SWITCH_TYPE_PI4IO) {
+                    pi4io_set(0x05, command);
+                }
+                else {
+                    pca9557_set(0x01, command);
+                    WAIT(200); // wait for camera power up 
+                }
+
+                camera_switch_profile();
+            }
         }
     }
 }
 
 void camera_switch_init() {
-    g_manual_camera_sel = 0;
-    g_camera_id = 1;
     g_camera_switch = get_camera_switch_type();
     if (g_camera_switch == SWITCH_TYPE_PI4IO) {
-        //pi4io_set(0x01, 0xFF); // reset
-        pi4io_set(0x0B, 0xFF); // Disable pullup/pulldown resistors
-        pi4io_set(0x11, 0xFF); // Disable interrupts on inputs
-        pi4io_get(0x13);       // De-assert the interrrupt 
-        pi4io_set(0x03, 0x77); // Set P3 and P7 as inputs
-        pi4io_set(0x07, 0x00); // Set outputs to follow the output port register
+//      pi4io_set(0x01, 0xFF);      // reset
+        pi4io_set(0x0B, 0xFF);      // Disable pullup/pulldown resistors
+        pi4io_set(0x11, 0xFF);      // Disable interrupts on inputs
+        pi4io_get(0x13);            // De-assert the interrrupt 
+        pi4io_set(0x03, 0x77);      // Set P3 and P7 as inputs
+        pi4io_set(0x07, 0x00);      // Set outputs to follow the output port register
+        pi4io_set(0x05, 0x11);      // camera 1 default
     } else if (g_camera_switch == SWITCH_TYPE_PCA9557) {
-        pca9557_set(0x03, 0x00); // all outputs
+        pca9557_set(0x03, 0x00);    // all outputs
+        pca9557_set(0x01, 0x1B);    // camera 1 default
+        WAIT(200);                  // wait for camera power up 
     }
-    select_camera(g_camera_id);
 }
 
 // Check if manual camera selection is enabled and switch if required
@@ -208,10 +214,7 @@ void manual_select_camera(void) {
         g_manual_camera_sel = (command & 0x08);
         if (g_manual_camera_sel) {
             uint8_t camera_id = ((command & 0x80) >> 7) + 1;
-            if (camera_id != g_camera_id) {
-                g_camera_id = camera_id;
-                select_camera(camera_id);
-            }
+            select_camera(camera_id);
         }
     }
 }

--- a/src/i2c_device.h
+++ b/src/i2c_device.h
@@ -11,7 +11,14 @@
 #define ADDR_EEPROM  0x50
 #define ADDR_TEMPADC 0x48
 #define ADDR_RUNCAM  0x21
-#define ADDR_PI4IO   0x43 // camera switch
+#define ADDR_PI4IO   0x43 // 2 camera switch
+#define ADDR_PCA9557 0x18 // 3 camera switch
+
+typedef enum {
+    SWITCH_TYPE_NONE,
+    SWITCH_TYPE_PI4IO,          // 2 camera switch
+    SWITCH_TYPE_PCA9557,        // 3 camera switch
+} switch_type_e;
 
 void set_segment(uint32_t val);
 #ifdef USE_TC3587_LED
@@ -21,9 +28,8 @@ void Init_TC3587(uint8_t fmt);
 
 uint8_t pi4io_get(uint8_t reg);
 void pi4io_set(uint8_t reg, uint8_t val);
-uint8_t is_camera_switch_present(void);
 void camera_switch_init(void);
-void select_camera(uint8_t camera_id, uint8_t sync_config);
+void select_camera(uint8_t camera_id);
 void manual_select_camera(void);
 
 extern uint8_t USE_MAX7315;

--- a/src/i2c_device.h
+++ b/src/i2c_device.h
@@ -11,12 +11,14 @@
 #define ADDR_EEPROM  0x50
 #define ADDR_TEMPADC 0x48
 #define ADDR_RUNCAM  0x21
+#define ADDR_PCA9570 0x24 // camera switch
 
 void set_segment(uint32_t val);
 #ifdef USE_TC3587_LED
 void LED_TC3587_Init();
 #endif
 void Init_TC3587(uint8_t fmt);
+void pca9570_set(uint8_t val);
 
 extern uint8_t USE_MAX7315;
 extern uint8_t USE_PCA9554;

--- a/src/i2c_device.h
+++ b/src/i2c_device.h
@@ -16,9 +16,14 @@
 
 typedef enum {
     SWITCH_TYPE_NONE,
-    SWITCH_TYPE_PI4IO,          // 2 camera switch
-    SWITCH_TYPE_PCA9557,        // 3 camera switch
+    SWITCH_TYPE_PI4IO,
+    SWITCH_TYPE_PCA9557
 } switch_type_e;
+
+typedef enum {
+    PI4IO_CAMS = 2,
+    PCA9557_CAMS = 3
+} switch_cams_e;
 
 void set_segment(uint32_t val);
 #ifdef USE_TC3587_LED

--- a/src/i2c_device.h
+++ b/src/i2c_device.h
@@ -11,14 +11,14 @@
 #define ADDR_EEPROM  0x50
 #define ADDR_TEMPADC 0x48
 #define ADDR_RUNCAM  0x21
-#define ADDR_PCA9570 0x24 // camera switch
+#define ADDR_PI4IO   0x43 // camera switch
 
 void set_segment(uint32_t val);
 #ifdef USE_TC3587_LED
 void LED_TC3587_Init();
 #endif
 void Init_TC3587(uint8_t fmt);
-void pca9570_set(uint8_t val);
+void pi4io_set(uint8_t reg, uint8_t val);
 
 extern uint8_t USE_MAX7315;
 extern uint8_t USE_PCA9554;

--- a/src/i2c_device.h
+++ b/src/i2c_device.h
@@ -21,7 +21,8 @@ void Init_TC3587(uint8_t fmt);
 
 uint8_t pi4io_get(uint8_t reg);
 void pi4io_set(uint8_t reg, uint8_t val);
-void init_camera_switch(void);
+uint8_t is_camera_switch_present(void);
+void camera_switch_init(void);
 void select_camera(uint8_t camera_id, uint8_t sync_config);
 void manual_select_camera(void);
 

--- a/src/i2c_device.h
+++ b/src/i2c_device.h
@@ -22,7 +22,7 @@ void Init_TC3587(uint8_t fmt);
 uint8_t pi4io_get(uint8_t reg);
 void pi4io_set(uint8_t reg, uint8_t val);
 void init_camera_switch(void);
-void select_camera(uint8_t camera_id, uint8_t shared_i2c);
+void select_camera(uint8_t camera_id, uint8_t sync_config);
 void manual_select_camera(void);
 
 extern uint8_t USE_MAX7315;

--- a/src/i2c_device.h
+++ b/src/i2c_device.h
@@ -18,7 +18,12 @@ void set_segment(uint32_t val);
 void LED_TC3587_Init();
 #endif
 void Init_TC3587(uint8_t fmt);
+
+uint8_t pi4io_get(uint8_t reg);
 void pi4io_set(uint8_t reg, uint8_t val);
+void init_camera_switch(void);
+void select_camera(uint8_t camera_id, uint8_t shared_i2c);
+void manual_select_camera(void);
 
 extern uint8_t USE_MAX7315;
 extern uint8_t USE_PCA9554;

--- a/src/lifetime.c
+++ b/src/lifetime.c
@@ -70,25 +70,22 @@ void Update_EEP_LifeTime(void) {
 }
 
 char *parseLifeTime(void) {
-    static char lifetime[6]; // ex, "9999H" or "99M"
+    static char lifetime[7]; // ex, "9999HR" or "59MIN"
     uint32_t hours = sysLifeTime / 360;
     uint32_t num;
     uint8_t pos = 0;
 
-    memset(lifetime, ' ', sizeof(lifetime)-1);
-    lifetime[sizeof(lifetime)-1] = '\0';
-
-    if (hours == 0) { // display minutes
+    if (hours == 0) { // display minutes for the first hour
     
         uint8_t minutes = (sysLifeTime % 360) / 6;
-        num = (minutes % 60) / 10;
+        num = (minutes % 60) / 10; // update every 10 minutes
         if (num > 0) {
             lifetime[pos++] = '0' + num;
         }
         lifetime[pos] = '0' + (minutes % 10);
-        lifetime[pos+1] = 'M';
+        memcpy(lifetime+pos+1, "MIN", 4);
 
-    } else { // display hours
+    } else { // then just display hours
 
         uint32_t num = hours;
         uint8_t digits = 0;
@@ -98,8 +95,8 @@ char *parseLifeTime(void) {
         }
 
         // defensive check
-        if (digits > (sizeof(lifetime) - 2)) {
-            lifetime[0] = 'E';
+        if (digits > (sizeof(lifetime) - 3)) {
+            memcpy(lifetime, "ERROR", 6);
 
         } else {
             uint8_t pos = digits-1;
@@ -107,7 +104,7 @@ char *parseLifeTime(void) {
                 lifetime[pos--] = '0' + (hours % 10);
                 hours /= 10;
             }
-            lifetime[digits] = 'H';
+            memcpy(lifetime+digits, "HR", 3);
         }
     }
 

--- a/src/lifetime.h
+++ b/src/lifetime.h
@@ -9,6 +9,6 @@
 
 void Get_EEP_LifeTime(void);
 void Update_EEP_LifeTime(void);
-void ParseLifeTime(unsigned char *hourString, unsigned char *minuteString);
+char *parseLifeTime(void);
 
 #endif /* __LIFETIME_H_ */

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -1002,7 +1002,7 @@ void msp_set_vtx_config(uint8_t power, uint8_t save) {
 }
 void camera_switch(uint8_t camera_sel) {
     if (g_camera_switch) {
-        if (cms_state == CMS_OSD || cms_state == CMS_ENTER_VTX_MENU) {
+        if (cms_state == CMS_OSD || cms_state == CMS_VTX_MENU) {
             uint8_t camera_id = camera_sel ? 2 : 1;
             if (!g_manual_camera_sel && camera_id != g_camera_id) {
                 g_camera_id = camera_id;

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -574,7 +574,7 @@ uint8_t get_tx_data_5680() // prepare data to VRX
 
     tx_buf[15] = (camRatio == 0) ? 0x55 : 0xaa;
 
-    tx_buf[16] = g_camera_id;
+    tx_buf[16] = VTX_VERSION_MAJOR; // Send g_camera_id in the future to allow the VRX to resync on a camera change
     tx_buf[17] = VTX_VERSION_MINOR;
     tx_buf[18] = VTX_VERSION_PATCH_LEVEL;
 

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -1012,8 +1012,7 @@ void msp_set_vtx_config(uint8_t power, uint8_t save) {
 uint8_t camera_switch(uint8_t camera_id) {
     if (g_camera_switch) {
         if (cms_state == CMS_OSD || cms_state == CMS_VTX_MENU) {
-            if (!g_manual_camera_sel && camera_id != g_camera_id) {
-                g_camera_id = camera_id;
+            if (!g_manual_camera_sel) {
                 select_camera(camera_id);
             }
         }

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -1002,7 +1002,7 @@ void camera_switch(uint8_t camera_sel) {
     uint8_t camera_id = camera_sel ? 2 : 1;
     if (!g_manual_camera_sel && camera_id != g_camera_id) {
         g_camera_id = camera_id;
-        select_camera(g_camera_id, 0);
+        select_camera(g_camera_id, 1);
     }
 }
 void parse_status() {
@@ -1885,8 +1885,6 @@ void vtx_menu_init() {
 
 void update_vtx_menu_param(uint8_t state) {
     uint8_t i;
-    uint8_t hourString[4];
-    uint8_t minuteString[2];
     const char *powerString[] = {"   25", "  200", "  500", "  MAX"};
     const char *lowPowerString[] = {"  OFF", "   ON", "  1ST"};
     const char *pitString[] = {"  OFF", " P1MW", "  0MW"};
@@ -1947,15 +1945,7 @@ void update_vtx_menu_param(uint8_t state) {
     osd_buf[12][osd_menu_offset + 11] = (g_manual_camera_sel) ? 'M' : ' '; 
     strcpy(osd_buf[12] + osd_menu_offset + 13, cameraTypeString[camera_type]);
 
-    ParseLifeTime(hourString, minuteString);
-    osd_buf[15][osd_menu_offset + 16] = hourString[0];
-    osd_buf[15][osd_menu_offset + 17] = hourString[1];
-    osd_buf[15][osd_menu_offset + 18] = hourString[2];
-    osd_buf[15][osd_menu_offset + 19] = hourString[3];
-    osd_buf[15][osd_menu_offset + 20] = 'H';
-    osd_buf[15][osd_menu_offset + 21] = minuteString[0];
-    osd_buf[15][osd_menu_offset + 22] = minuteString[1];
-    osd_buf[15][osd_menu_offset + 23] = 'M';
+    strcpy(osd_buf[15] + osd_menu_offset + 13, parseLifeTime());
 
 #ifdef USE_TEMPERATURE_SENSOR
     osd_buf[16][osd_menu_offset + 16] = (temperature >> 2) / 100 + '0';

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -54,6 +54,7 @@ uint8_t g_boxCamera1_page = 0xff;
 uint8_t g_boxCamera1_mask;
 uint8_t g_camera_id = 0;
 uint8_t g_manual_camera_sel = 0;
+uint8_t g_camera_mode_lock = 0;
 
 uint8_t pit_mode_cfg_done = 0;
 uint8_t lp_mode_cfg_done = 0;
@@ -1731,9 +1732,10 @@ void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throt
             cms_cnt = 0;
             disp_mode = DISPLAY_CMS;
             clear_screen();
-            if (camera_type == CAMERA_TYPE_UNKNOW ||
+            if (camera_type == CAMERA_TYPE_UNKNOWN ||
                 camera_type == CAMERA_TYPE_OUTDATED) {
                 camera_select_menu_init();
+                g_camera_mode_lock = 1;
                 camera_selected = 0;
                 cms_state = CMS_SELECT_CAM;
             } else {
@@ -1815,7 +1817,7 @@ void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throt
     last_mid = mid;
 
 #ifdef USE_TP9950
-    if (cms_state == CMS_CAM && (camera_type == CAMERA_TYPE_UNKNOW || camera_type == CAMERA_TYPE_OUTDATED)) {
+    if (cms_state == CMS_CAM && (camera_type == CAMERA_TYPE_UNKNOWN || camera_type == CAMERA_TYPE_OUTDATED)) {
         if (VirtualBtn_last == VirtualBtn) {
             if (seconds - cam_menu_timeout_sec >= 60) {
                 // exit cam menu
@@ -1854,7 +1856,7 @@ void vtx_menu_init() {
     strcpy(osd_buf[9] + osd_menu_offset + 2, " EXIT  ");
     strcpy(osd_buf[10] + osd_menu_offset + 2, " SAVE&EXIT");
     strcpy(osd_buf[11] + osd_menu_offset + 2, "------INFO------");
-    strcpy(osd_buf[12] + osd_menu_offset + 2, " CAMERA V1");
+    strcpy(osd_buf[12] + osd_menu_offset + 2, " CAMERA");
     strcpy(osd_buf[13] + osd_menu_offset + 2, " VTX");
     strcpy(osd_buf[14] + osd_menu_offset + 2, " VER");
     strcpy(osd_buf[15] + osd_menu_offset + 2, " LIFETIME");
@@ -1867,12 +1869,9 @@ void vtx_menu_init() {
         osd_buf[i][osd_menu_offset + 26] = '>';
     }
 
-    // draw variant
+    // draw variant & version
     strcpy(osd_buf[13] + osd_menu_offset + 13, VTX_NAME);
-
-    // draw version
-     strcpy(osd_buf[14] + osd_menu_offset + 13, VTX_VERSION_STRING);
-
+    strcpy(osd_buf[14] + osd_menu_offset + 13, VTX_VERSION_STRING);
 
     vtx_channel = RF_FREQ;
     vtx_power = RF_POWER;
@@ -1893,6 +1892,7 @@ void update_vtx_menu_param(uint8_t state) {
     const char *pitString[] = {"  OFF", " P1MW", "  0MW"};
     const char *treamRaceString[] = {"  OFF", "MODE1", "MODE2"};
     const char *shortcutString[] = {"OPT_A", "OPT_B"};
+    const char *cameraTypeString[] = {"UNKNOWN", "RESERVED", "OUTDATED", "MICRO_V1", "MICRO_V2", "NANO_90", "MICRO_V3" };
 
     // cursor
     state += 2;
@@ -1943,8 +1943,9 @@ void update_vtx_menu_param(uint8_t state) {
     strcpy(osd_buf[8] + osd_menu_offset + 20, shortcutString[vtx_shortcut]);
 
     // camera selection
-    osd_buf[12][osd_menu_offset + 13] = '0' + g_camera_id;
-    osd_buf[12][osd_menu_offset + 14] = (g_manual_camera_sel) ? 'M' : ' ';   
+    osd_buf[12][osd_menu_offset + 10] = '0' + g_camera_id;
+    osd_buf[12][osd_menu_offset + 11] = (g_manual_camera_sel) ? 'M' : ' '; 
+    strcpy(osd_buf[12] + osd_menu_offset + 13, cameraTypeString[camera_type]);
 
     ParseLifeTime(hourString, minuteString);
     osd_buf[15][osd_menu_offset + 16] = hourString[0];

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -1007,7 +1007,6 @@ void camera_switch(uint8_t camera_sel) {
             if (!g_manual_camera_sel && camera_id != g_camera_id) {
                 g_camera_id = camera_id;
                 select_camera(g_camera_id, 0);
-                camera_init();
             }
         }
     }

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -1979,7 +1979,7 @@ void update_vtx_menu_param(uint8_t state) {
     const char *treamRaceString[] = {"  OFF", "MODE1", "MODE2"};
     const char *shortcutString[] = {"OPT_A", "OPT_B"};
     const char *cameraTypeString[] = {"UNKNOWN", "RESERVED", "OUTDATED", "MICRO_V1", "MICRO_V2", "NANO_90", "MICRO_V3" };
-    const char *cameraSwitchString[] = {"NONE", "2-CAMERA", "3-CAMERA"};
+    const char *cameraSwitchString[] = {"NONE", "DUAL", "TREBLE"};
 
     // cursor
     state += 2;

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -497,7 +497,7 @@ uint8_t get_tx_data_5680() // prepare data to VRX
     tx_buf[1] = DP_HEADER1;
     tx_buf[2] = 0xff;
     // len
-    tx_buf[3] = 15;
+    tx_buf[3] = 16;
 
     // video format
     if (video_format == VDO_FMT_720P50)
@@ -576,7 +576,9 @@ uint8_t get_tx_data_5680() // prepare data to VRX
     tx_buf[17] = VTX_VERSION_MINOR;
     tx_buf[18] = VTX_VERSION_PATCH_LEVEL;
 
-    return 20;
+    tx_buf[19] = g_camera_id;
+
+    return 21;
 }
 
 uint8_t get_tx_data_osd(uint8_t index) // prepare osd+data to VTX

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -996,7 +996,7 @@ void msp_set_vtx_config(uint8_t power, uint8_t save) {
 void camera_switch(uint8_t camera_sel) {
     if (camera_sel != g_camera_sel) {
         g_camera_sel = camera_sel;
-        pca9570_set(0x02 | ((g_camera_sel) ? 0x01 : 0x00));
+        pi4io_set(0x05, (g_camera_sel) ? 0x60 : 0x10);
     }
 }
 
@@ -1850,8 +1850,8 @@ void vtx_menu_init() {
     strcpy(osd_buf[9] + osd_menu_offset + 2, " EXIT  ");
     strcpy(osd_buf[10] + osd_menu_offset + 2, " SAVE&EXIT");
     strcpy(osd_buf[11] + osd_menu_offset + 2, "------INFO------");
-    strcpy(osd_buf[12] + osd_menu_offset + 2, " CAMERA");
-   strcpy(osd_buf[13] + osd_menu_offset + 2, " VTX");
+    strcpy(osd_buf[12] + osd_menu_offset + 2, " CAMERA x  1.0");
+    strcpy(osd_buf[13] + osd_menu_offset + 2, " VTX");
     strcpy(osd_buf[14] + osd_menu_offset + 2, " VER");
     strcpy(osd_buf[15] + osd_menu_offset + 2, " LIFETIME");
 #ifdef USE_TEMPERATURE_SENSOR
@@ -1938,8 +1938,8 @@ void update_vtx_menu_param(uint8_t state) {
 
     strcpy(osd_buf[8] + osd_menu_offset + 20, shortcutString[vtx_shortcut]);
 
-        // dual camera selection
-    strcpy(osd_buf[12] + osd_menu_offset + 13, (g_camera_sel) ? "2" : "1");
+    // camera selection
+    strcpy(osd_buf[12] + osd_menu_offset + 10, (g_camera_sel) ? "2" : "1");   
 
     ParseLifeTime(hourString, minuteString);
     osd_buf[15][osd_menu_offset + 16] = hourString[0];

--- a/src/msp_displayport.c
+++ b/src/msp_displayport.c
@@ -1008,11 +1008,6 @@ void camera_switch(uint8_t camera_sel) {
                 g_camera_id = camera_id;
                 select_camera(g_camera_id, 0);
                 camera_init();
-                //camera_setting_reg_menu_update();
-                //if (camera_set(camera_setting_reg_menu, 0, 0)) {
-                //    runcam_reset_isp();
-                //    camera_mode_detect(0);    
-                //}
             }
         }
     }

--- a/src/msp_displayport.h
+++ b/src/msp_displayport.h
@@ -34,6 +34,11 @@ typedef enum {
 } vtxPtiType_e;
 
 typedef enum {
+BOXCAMERA1_BTFL = 32,
+BOXCAMERA1_INAV = 39
+} boxCameraId_e;
+
+typedef enum {
     MSP_HEADER_START,
     MSP_HEADER_M,
     MSP_PACKAGE_REPLAY1,
@@ -67,6 +72,7 @@ typedef enum {
     CUR_RC,
     CUR_STATUS,
     CUR_FC_VARIANT,
+    CUR_BOXIDS,
     CUR_VTX_CONFIG,
     CUR_GET_OSD_CANVAS,
     CUR_OTHERS
@@ -138,6 +144,7 @@ void msp_send_vtx_hw_faults();
 void parse_status();
 void parse_rc();
 void parse_variant();
+void parse_boxids(uint8_t len);
 void parse_vtx_params(uint8_t isMSP_V2);
 void parse_vtx_config();
 void parseMspVtx_V2();

--- a/src/msp_displayport.h
+++ b/src/msp_displayport.h
@@ -34,9 +34,11 @@ typedef enum {
 } vtxPtiType_e;
 
 typedef enum {
-BOXCAMERA1_BTFL = 32,
-BOXCAMERA1_INAV = 39
-} boxCameraId_e;
+    BOXARM_BTFL = 0, // for completeness
+    BOXARM_INAV = 0,
+    BOXCAMERA1_BTFL = 32, // 0x20
+    BOXCAMERA1_INAV = 39  // 0x27
+} box_permanent_ids;
 
 typedef enum {
     MSP_HEADER_START,
@@ -158,6 +160,7 @@ void parse_boxids(uint8_t len);
 void parse_vtx_params(uint8_t isMSP_V2);
 void parse_vtx_config();
 void parseMspVtx_V2();
+void parseiNavMspStatus();
 uint8_t parse_displayport(uint8_t len);
 void update_cms_menu(uint16_t roll, uint16_t pitch, uint16_t yaw, uint16_t throttle);
 void vtx_menu_init();

--- a/src/msp_displayport.h
+++ b/src/msp_displayport.h
@@ -34,10 +34,16 @@ typedef enum {
 } vtxPtiType_e;
 
 typedef enum {
-    BOXARM_BTFL = 0, // for completeness
-    BOXARM_INAV = 0,
+    BOXARM_BTFL = 0, // for completeness    
     BOXCAMERA1_BTFL = 32, // 0x20
-    BOXCAMERA1_INAV = 39  // 0x27
+    BOXCAMERA2_BTFL = 33, // 0x21
+    BOXCAMERA3_BTFL = 34, // 0x22
+
+    BOXARM_INAV = 0,
+    BOXCAMERA1_INAV = 39, // 0x27
+    BOXCAMERA2_INAV = 40, // 0x28
+    BOXCAMERA3_INAV = 41, // 0x29
+
 } box_permanent_ids;
 
 typedef enum {

--- a/src/msp_displayport.h
+++ b/src/msp_displayport.h
@@ -37,12 +37,10 @@ typedef enum {
     BOXARM_BTFL = 0, // for completeness    
     BOXCAMERA1_BTFL = 32, // 0x20
     BOXCAMERA2_BTFL = 33, // 0x21
-    BOXCAMERA3_BTFL = 34, // 0x22
 
     BOXARM_INAV = 0,
     BOXCAMERA1_INAV = 39, // 0x27
     BOXCAMERA2_INAV = 40, // 0x28
-    BOXCAMERA3_INAV = 41, // 0x29
 
 } box_permanent_ids;
 

--- a/src/msp_protocol.h
+++ b/src/msp_protocol.h
@@ -32,6 +32,7 @@
 #define FC_VTX_CONFIG_LOCK     0x08
 #define FC_STATUS_LOCK         0x10
 #define FC_BOXIDS_LOCK         0x20
+#define FC_STARTUP_LOCK        0x40
 #define FC_INIT_VTX_TABLE_LOCK 0x80
 
 #define OSD_CANVAS_SD_HMAX  30

--- a/src/msp_protocol.h
+++ b/src/msp_protocol.h
@@ -18,6 +18,7 @@
 #define MSP_SET_VTX_CONFIG 0x59 // 89  // in message
 #define MSP_STATUS         0x65 // 101 //out message
 #define MSP_RC             0x69 // 105 //out message
+#define MSP_BOXIDS         0x77 // 119 //out message
 #define MSP_DISPLAYPORT    0xB6 // 182 // in message
 #define MSP_SET_OSD_CANVAS 0xBC // 188 // in message
 #define MSP_GET_OSD_CANVAS 0xBD // 188 //out message
@@ -30,6 +31,7 @@
 #define FC_RC_LOCK             0x04
 #define FC_VTX_CONFIG_LOCK     0x08
 #define FC_STATUS_LOCK         0x10
+#define FC_BOXIDS_LOCK         0x20
 #define FC_INIT_VTX_TABLE_LOCK 0x80
 
 #define OSD_CANVAS_SD_HMAX  30

--- a/src/msp_protocol.h
+++ b/src/msp_protocol.h
@@ -28,12 +28,10 @@
 
 #define FC_OSD_LOCK            0x01
 #define FC_VARIANT_LOCK        0x02
-#define FC_RC_LOCK             0x04
-#define FC_VTX_CONFIG_LOCK     0x08
-#define FC_STATUS_LOCK         0x10
-#define FC_BOXIDS_LOCK         0x20
-#define FC_STARTUP_LOCK        0x40
-#define FC_INIT_VTX_TABLE_LOCK 0x80
+#define FC_VTX_CONFIG_LOCK     0x04
+#define FC_STATUS_LOCK         0x08
+#define FC_STARTUP_LOCK        0x10
+#define FC_INIT_VTX_TABLE_LOCK 0x20
 
 #define OSD_CANVAS_SD_HMAX  30
 #define OSD_CANVAS_SD_VMAX  16

--- a/src/msp_protocol.h
+++ b/src/msp_protocol.h
@@ -29,9 +29,8 @@
 #define FC_OSD_LOCK            0x01
 #define FC_VARIANT_LOCK        0x02
 #define FC_VTX_CONFIG_LOCK     0x04
-#define FC_STATUS_LOCK         0x08
-#define FC_STARTUP_LOCK        0x10
-#define FC_INIT_VTX_TABLE_LOCK 0x20
+#define FC_STARTUP_LOCK        0x08
+#define FC_INIT_VTX_TABLE_LOCK 0x10
 
 #define OSD_CANVAS_SD_HMAX  30
 #define OSD_CANVAS_SD_VMAX  16
@@ -71,5 +70,8 @@
 #define MSP_VTX_GET_FW_VERSION  0x0386 // Query VTX for firmware version
 #define MSP_VTX_GET_TEMPERATURE 0x0387 // Query VTX for temperature in celcius
 #define MSP_VTX_GET_HW_FAULTS   0x0388 // Query VTX for hardware errors
+
+// outgoing packets
+#define MSP2_INAV_STATUS        0x2000 // iNav specific STATUS that overcomes MSP_V1 shrtcomings.
 
 #endif /* __MSP_PROTO_H_ */

--- a/src/runcam.c
+++ b/src/runcam.c
@@ -511,37 +511,51 @@ void runcam_reset_isp(void) {
     RUNCAM_Write(camera_device, 0x000694, 0x00000130);
 }
 
-uint8_t runcam_set(uint8_t *setting_profile) {
-    static uint8_t init_done = 0;
+uint8_t runcam_set(uint8_t *setting_profile, uint8_t camera_id) {
+    static uint8_t initialised[3] = {0,0,0}; // up to 3 cameras
     uint8_t ret = 0;
-    if (!init_done || runcam_setting_update_need(setting_profile, 0, 0) || runcam_setting_update_need(setting_profile, 10, 10))
+    uint8_t cam_idx = (camera_id > 3) ? 0 : camera_id-1;
+    uint8_t init_done = initialised[cam_idx];
+
+    if (!init_done || runcam_setting_update_need(setting_profile, 0, 0) || runcam_setting_update_need(setting_profile, 10, 10)) {
         runcam_brightness(setting_profile[0], setting_profile[10]); // include led_mode
+    }
 
-    if (!init_done || runcam_setting_update_need(setting_profile, 1, 1))
+    if (!init_done || runcam_setting_update_need(setting_profile, 1, 1)) {
         runcam_sharpness(setting_profile[1]);
+    }
 
-    if (!init_done || runcam_setting_update_need(setting_profile, 2, 2))
+    if (!init_done || runcam_setting_update_need(setting_profile, 2, 2)) {
         runcam_contrast(setting_profile[2]);
+    }
 
-    if (!init_done || runcam_setting_update_need(setting_profile, 3, 3))
+    if (!init_done || runcam_setting_update_need(setting_profile, 3, 3)) {
         runcam_saturation(setting_profile[3]);
+    }
 
-    if (!init_done || runcam_setting_update_need(setting_profile, 4, 4))
+    if (!init_done || runcam_setting_update_need(setting_profile, 4, 4)) {
         runcam_shutter(setting_profile[4]);
+    }
 
-    if (!init_done || runcam_setting_update_need(setting_profile, 5, 7))
+    if (!init_done || runcam_setting_update_need(setting_profile, 5, 7)) {
         runcam_wb(setting_profile[5], setting_profile[6], setting_profile[7]);
+    }
 
-    if (!init_done || runcam_setting_update_need(setting_profile, 8, 8))
+    if (!init_done || runcam_setting_update_need(setting_profile, 8, 8)) {
         runcam_hv_flip(setting_profile[8]);
+    }
 
-    if (!init_done || runcam_setting_update_need(setting_profile, 9, 9))
+    if (!init_done || runcam_setting_update_need(setting_profile, 9, 9)) {
         runcam_night_mode(setting_profile[9]);
+    }
 
     if (!init_done || runcam_setting_update_need(setting_profile, 11, 11)) {
         ret = runcam_video_format(setting_profile[11]);
     }
-    if (!init_done)
-        init_done = 1;
+
+    if (!init_done) {
+        initialised[cam_idx] = 1;
+    }
+
     return ret;
 }

--- a/src/runcam.c
+++ b/src/runcam.c
@@ -188,7 +188,7 @@ void runcam_setting_profile_reset(uint8_t *setting_profile) {
 uint8_t runcam_setting_profile_check(uint8_t *setting_profile) {
     uint8_t i;
     for (i = 0; i < CAMERA_SETTING_NUM; i++) {
-        if (camera_attribute[i][CAM_SETTING_ITEM_ENBALE]) {
+        if (camera_attribute[i][CAM_SETTING_ITEM_ENABLE]) {
             if (setting_profile[i] < camera_attribute[i][CAM_SETTING_ITEM_MIN])
                 return 1;
             if (setting_profile[i] > camera_attribute[i][CAM_SETTING_ITEM_MAX])

--- a/src/runcam.h
+++ b/src/runcam.h
@@ -5,7 +5,7 @@
 void runcam_type_detect(void);
 void runcam_setting_profile_reset(uint8_t *setting_profile);
 uint8_t runcam_setting_profile_check(uint8_t *setting_profile);
-uint8_t runcam_set(uint8_t *setting_profile, uint8_t camera_id);
+uint8_t runcam_set(uint8_t *setting_profile, uint8_t init);
 void runcam_reset_isp(void);
 void runcam_save(void);
 void runcam_shutter_fix(uint16_t sec);

--- a/src/runcam.h
+++ b/src/runcam.h
@@ -5,7 +5,7 @@
 void runcam_type_detect(void);
 void runcam_setting_profile_reset(uint8_t *setting_profile);
 uint8_t runcam_setting_profile_check(uint8_t *setting_profile);
-uint8_t runcam_set(uint8_t *setting_profile);
+uint8_t runcam_set(uint8_t *setting_profile, uint8_t camera_id);
 void runcam_reset_isp(void);
 void runcam_save(void);
 void runcam_shutter_fix(uint16_t sec);

--- a/src/version.h
+++ b/src/version.h
@@ -4,7 +4,7 @@
 #define VTX_VERSION_MAJOR       1 // increment when a major release is made (big new feature, etc)
 #define VTX_VERSION_MINOR       7 // increment when a minor release is made (small new feature, change etc)
 #define VTX_VERSION_PATCH_LEVEL 0 // increment when a bug is fixed
-#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL)
+#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL) " CAM 3.1"
 
 #define _STR(x) #x
 #define STR(x)  _STR(x)

--- a/src/version.h
+++ b/src/version.h
@@ -4,7 +4,7 @@
 #define VTX_VERSION_MAJOR       1 // increment when a major release is made (big new feature, etc)
 #define VTX_VERSION_MINOR       7 // increment when a minor release is made (small new feature, change etc)
 #define VTX_VERSION_PATCH_LEVEL 0 // increment when a bug is fixed
-#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL) "  CAM 2.1"
+#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL)
 
 #define _STR(x) #x
 #define STR(x)  _STR(x)

--- a/src/version.h
+++ b/src/version.h
@@ -4,7 +4,7 @@
 #define VTX_VERSION_MAJOR       1 // increment when a major release is made (big new feature, etc)
 #define VTX_VERSION_MINOR       7 // increment when a minor release is made (small new feature, change etc)
 #define VTX_VERSION_PATCH_LEVEL 0 // increment when a bug is fixed
-#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL) "  CAM 1.8"
+#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL) "  CAM 2.0"
 
 #define _STR(x) #x
 #define STR(x)  _STR(x)

--- a/src/version.h
+++ b/src/version.h
@@ -4,7 +4,7 @@
 #define VTX_VERSION_MAJOR       1 // increment when a major release is made (big new feature, etc)
 #define VTX_VERSION_MINOR       7 // increment when a minor release is made (small new feature, change etc)
 #define VTX_VERSION_PATCH_LEVEL 0 // increment when a bug is fixed
-#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL) "  CAM 1.6"
+#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL) "  CAM 1.8"
 
 #define _STR(x) #x
 #define STR(x)  _STR(x)

--- a/src/version.h
+++ b/src/version.h
@@ -4,7 +4,7 @@
 #define VTX_VERSION_MAJOR       1 // increment when a major release is made (big new feature, etc)
 #define VTX_VERSION_MINOR       7 // increment when a minor release is made (small new feature, change etc)
 #define VTX_VERSION_PATCH_LEVEL 0 // increment when a bug is fixed
-#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL) "  CAM 1.5"
+#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL) "  CAM 1.6"
 
 #define _STR(x) #x
 #define STR(x)  _STR(x)

--- a/src/version.h
+++ b/src/version.h
@@ -4,7 +4,7 @@
 #define VTX_VERSION_MAJOR       1 // increment when a major release is made (big new feature, etc)
 #define VTX_VERSION_MINOR       7 // increment when a minor release is made (small new feature, change etc)
 #define VTX_VERSION_PATCH_LEVEL 0 // increment when a bug is fixed
-#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL) "  CAM 1.1"
+#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL) "  CAM 1.3"
 
 #define _STR(x) #x
 #define STR(x)  _STR(x)

--- a/src/version.h
+++ b/src/version.h
@@ -4,7 +4,7 @@
 #define VTX_VERSION_MAJOR       1 // increment when a major release is made (big new feature, etc)
 #define VTX_VERSION_MINOR       7 // increment when a minor release is made (small new feature, change etc)
 #define VTX_VERSION_PATCH_LEVEL 0 // increment when a bug is fixed
-#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL) " CAM 3.1"
+#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL)
 
 #define _STR(x) #x
 #define STR(x)  _STR(x)

--- a/src/version.h
+++ b/src/version.h
@@ -4,7 +4,7 @@
 #define VTX_VERSION_MAJOR       1 // increment when a major release is made (big new feature, etc)
 #define VTX_VERSION_MINOR       7 // increment when a minor release is made (small new feature, change etc)
 #define VTX_VERSION_PATCH_LEVEL 0 // increment when a bug is fixed
-#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL) "  CAM 2.0"
+#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL) "  CAM 2.0 ALPHA"
 
 #define _STR(x) #x
 #define STR(x)  _STR(x)

--- a/src/version.h
+++ b/src/version.h
@@ -4,7 +4,7 @@
 #define VTX_VERSION_MAJOR       1 // increment when a major release is made (big new feature, etc)
 #define VTX_VERSION_MINOR       7 // increment when a minor release is made (small new feature, change etc)
 #define VTX_VERSION_PATCH_LEVEL 0 // increment when a bug is fixed
-#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL)
+#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL) "  CAM 1.1"
 
 #define _STR(x) #x
 #define STR(x)  _STR(x)

--- a/src/version.h
+++ b/src/version.h
@@ -4,7 +4,7 @@
 #define VTX_VERSION_MAJOR       1 // increment when a major release is made (big new feature, etc)
 #define VTX_VERSION_MINOR       7 // increment when a minor release is made (small new feature, change etc)
 #define VTX_VERSION_PATCH_LEVEL 0 // increment when a bug is fixed
-#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL) "  CAM 2.0"
+#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL) "  CAM 2.1"
 
 #define _STR(x) #x
 #define STR(x)  _STR(x)

--- a/src/version.h
+++ b/src/version.h
@@ -4,7 +4,7 @@
 #define VTX_VERSION_MAJOR       1 // increment when a major release is made (big new feature, etc)
 #define VTX_VERSION_MINOR       7 // increment when a minor release is made (small new feature, change etc)
 #define VTX_VERSION_PATCH_LEVEL 0 // increment when a bug is fixed
-#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL) "  CAM 1.3"
+#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL) "  CAM 1.5"
 
 #define _STR(x) #x
 #define STR(x)  _STR(x)

--- a/src/version.h
+++ b/src/version.h
@@ -4,7 +4,7 @@
 #define VTX_VERSION_MAJOR       1 // increment when a major release is made (big new feature, etc)
 #define VTX_VERSION_MINOR       7 // increment when a minor release is made (small new feature, change etc)
 #define VTX_VERSION_PATCH_LEVEL 0 // increment when a bug is fixed
-#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL) "  CAM 2.0 ALPHA"
+#define VTX_VERSION_STRING      STR(VTX_VERSION_MAJOR) "." STR(VTX_VERSION_MINOR) "." STR(VTX_VERSION_PATCH_LEVEL) "  CAM 2.0"
 
 #define _STR(x) #x
 #define STR(x)  _STR(x)


### PR DESCRIPTION
**Add control for 2 and 3 camera switches.**
Use CAMERA CONTROL 1 to select a camera on a 2 camera switch.
Use CAMERA CONTROL 2 to select camera 3 on a 3 camera switch.
Disable camera control when in camera menu and switch detected.
Assign each camera profile to each camera on the switch (ex, profile 1 for camera 1) when switch detected.
Synchronize video mode across all profiles when switch detected.
Display switch type detected on the VTX menu.
Display camera type detected on the VTX menu.

**Additional.**
Ensure Nano90 HV Flip is actioned when changed in the camera menu (will only change on save/exit at this time).
Use BOXID to determine location of ARM flag in status messages.
Correct spelling and/or clarify some function names and variables.
Add an UNUSED(param) definition to avoid gcc/g++ warnings when a parameter is not used in a function.
Update lifetime display in VTX menu to show minutes for the first hour and then only hours.